### PR TITLE
Add Instagram

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,19 +1,22 @@
 // Needs to be in global context to be accessed by module
 global.youtube = require('eleventy-plugin-youtube-embed');
 global.vimeo = require('eleventy-plugin-vimeo-embed');
+global.instagram = require('eleventy-plugin-embed-instagram');
 
 module.exports = function(eleventyConfig, options) {
 
   // every valid embed offered
   const validEmbeds = [
-    'youtube',
-    'vimeo'
+    'instagram',
+    'vimeo',
+    'youtube'
   ];
 
   // embeds offered by default
   const defaultEmbeds = [
-    'youtube',
-    'vimeo'
+    'instagram',
+    'vimeo',
+    'youtube'
   ];
 
   // active embeds on this instance

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 This [Eleventy](https://11ty.dev) plugin will automatically embed common media formats in your pages, requiring only a URL in your markdown files.
 
-It currently supports **YouTube** and **Vimeo**, with more planned.
+It currently supports **Instagram**, **YouTube**, and **Vimeo**, with more planned.
 
 - ⚡️ [Installation](#installation)
 - 🛠 [Usage](#usage)
@@ -53,6 +53,7 @@ Maecenas non velit nibh. Aenean eu justo et odio commodo ornare. In scelerisque 
 
 Currently, the plugin supports the following embed services (listed alphabetically):
 
+- Instagram
 - Vimeo
 - YouTube
 
@@ -65,9 +66,9 @@ _More are planned!_
 The plugin supports a number of frequently used services by default, but you can configure it for only the specific ones you want by passing an options object to the `addPlugin` function:
 
 ```javascript
-// configure the plugin to ~only~ embed Vimeo videos
+// configure the plugin to ~only~ embed Vimeo videos and Instagram photos/videos
 eleventyConfig.addPlugin(embedEverything, {
-  use: ['vimeo']
+  use: ['vimeo', 'instagram']
 });
 ```
 
@@ -100,5 +101,6 @@ For more about each [supported service](#supported-services), consult this table
 
 | Service | Package | Repository |
 | ------- | ------- | ---------- |
+| Instagram | [npm](https://www.npmjs.com/package/eleventy-plugin-embed-instagram) | [GitHub](https://github.com/gfscott/eleventy-plugin-embed-instagram) |
 | Vimeo | [npm](https://www.npmjs.com/package/eleventy-plugin-vimeo-embed) | [GitHub](https://github.com/gfscott/eleventy-plugin-vimeo-embed) |
 | YouTube | [npm](https://www.npmjs.com/package/eleventy-plugin-youtube-embed) | [GitHub](https://github.com/gfscott/eleventy-plugin-youtube-embed) |

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,8 +4,10 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "eleventy-plugin-instagram-embed": {
-      "version": "file:../eleventy-plugin-instagram-embed"
+    "eleventy-plugin-embed-instagram": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/eleventy-plugin-embed-instagram/-/eleventy-plugin-embed-instagram-1.0.2.tgz",
+      "integrity": "sha512-vVy0Jk6/JT37UfSiEA1UuhFmUNaHahlEANauP6OusoDbMI2MD+3WRBraQG5Ff62B4iIK5jD5Dftb319P4HqX5w=="
     },
     "eleventy-plugin-vimeo-embed": {
       "version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eleventy-plugin-embed-everything",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   ],
   "license": "MIT",
   "dependencies": {
+    "eleventy-plugin-embed-instagram": "^1.0.2",
     "eleventy-plugin-vimeo-embed": "^1.0.0",
     "eleventy-plugin-youtube-embed": "^1.2.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eleventy-plugin-embed-everything",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "An Eleventy plugin that allows you to quickly add common web embeds to markdown posts, using only their URLs",
   "main": ".eleventy.js",
   "scripts": {


### PR DESCRIPTION
This adds the new [eleventy-plugin-embed-instagram](https://www.npmjs.com/package/eleventy-plugin-embed-instagram) package as a valid embed type. Instagram joins the plugin as a **default** embed.