### PR TITLE
Youtube dependency patch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,9 +15,9 @@
       "integrity": "sha512-0FuU7vQTlTS1eSPvJEdEpvz8R8Wp8fNCBU/rGB08p8+DBWFe69CBUNvGPcDyT9Hf2dCs6WH8TBYAskeJefOydQ=="
     },
     "eleventy-plugin-youtube-embed": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/eleventy-plugin-youtube-embed/-/eleventy-plugin-youtube-embed-1.2.0.tgz",
-      "integrity": "sha512-ZB0/NYS+oNgTcWcHCNBGaMRuXD+k5s8zfkVj6RF9bw9cIoRR5CZuJtdwk/hKgJvQxBUvSmvRzfpimo6ZjnTNSw=="
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/eleventy-plugin-youtube-embed/-/eleventy-plugin-youtube-embed-1.2.1.tgz",
+      "integrity": "sha512-XsTM08MCNkr8dzb47RBD2KA0yIUxbkq/txz6YTVlqQYKJEIc/5Of/lZZVHfOS5yCiJLpN8bxseua7+AL9ohDxA=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "eleventy-plugin-embed-instagram": "^1.0.2",
     "eleventy-plugin-vimeo-embed": "^1.0.0",
-    "eleventy-plugin-youtube-embed": "^1.2.0"
+    "eleventy-plugin-youtube-embed": "^1.2.1"
   },
   "author": {
     "name": "Graham F. Scott",


### PR DESCRIPTION
Bump [eleventy-plugin-youtube-embed](https://github.com/gfscott/eleventy-plugin-youtube-embed) to [1.2.1](https://github.com/gfscott/eleventy-plugin-youtube-embed/releases/tag/v1.2.1).