### PR TITLE
Add TikTok support

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -2,6 +2,7 @@
 global.instagram = require('eleventy-plugin-embed-instagram');
 global.soundcloud = require('eleventy-plugin-embed-soundcloud');
 global.spotify = require('eleventy-plugin-embed-spotify');
+global.tiktok = require('eleventy-plugin-embed-tiktok');
 global.twitch = require('eleventy-plugin-embed-twitch');
 global.vimeo = require('eleventy-plugin-vimeo-embed');
 global.youtube = require('eleventy-plugin-youtube-embed');
@@ -13,6 +14,7 @@ module.exports = function(eleventyConfig, options) {
     'instagram',
     'soundcloud',
     'spotify',
+    'tiktok',
     'twitch',
     'vimeo',
     'youtube'
@@ -22,6 +24,7 @@ module.exports = function(eleventyConfig, options) {
   const defaultEmbeds = [
     'instagram',
     'spotify',
+    'tiktok',
     'twitch',
     'vimeo',
     'youtube'

--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@
 
 This [Eleventy](https://11ty.dev) plugin will automatically embed common media formats in your pages, requiring only a URL in your markdown files.
 
-It currently supports **Instagram**, **SoundCloud**, **Spotify**, **Twitch**, **Vimeo**, and **YouTube**, with more planned.
+It currently supports **Instagram**, **SoundCloud**, **Spotify**, **TikTok**, **Twitch**, **Vimeo**, and **YouTube**, with more planned.
 
-- ⚡️ [Installation](#installation)
-- 🛠 [Usage](#usage)
-- 🌈 [Supported services](#supported-services)
-- ⚙️ [Settings](#settings)
-- ⚠️ [Notes and caveats](#notes-and-caveats)
+- ⚡️ [Installation](#%EF%B8%8F-installation)
+- 🛠 [Usage](#-usage)
+- 🌈 [Supported services](#-supported-services)
+- ⚙️ [Settings](#%EF%B8%8F-settings)
+- ⚠️ [Notes and caveats](#%EF%B8%8F-notes-and-caveats)
 
 ## ⚡️ Installation
 
@@ -58,6 +58,7 @@ Currently, the plugin supports the following embed services (listed alphabetical
 **On by default:**
 - Instagram
 - Spotify
+- TikTok
 - Twitch
 - Vimeo
 - YouTube
@@ -112,6 +113,7 @@ For more about each [supported service](#supported-services), consult this table
 | Instagram | [npm](https://www.npmjs.com/package/eleventy-plugin-embed-instagram) | [GitHub](https://github.com/gfscott/eleventy-plugin-embed-instagram) |
 | SoundCloud | [npm](https://www.npmjs.com/package/eleventy-plugin-embed-soundcloud) | [GitHub](https://github.com/gfscott/eleventy-plugin-embed-soundcloud) |
 | Spotify | [npm](https://www.npmjs.com/package/eleventy-plugin-embed-spotify) | [GitHub](https://github.com/gfscott/eleventy-plugin-embed-spotify) |
+| TikTok | [npm](https://www.npmjs.com/package/eleventy-plugin-embed-tiktok) | [GitHub](https://github.com/gfscott/eleventy-plugin-embed-tiktok) |
 | Twitch | [npm](https://www.npmjs.com/package/eleventy-plugin-embed-twitch) | [GitHub](https://github.com/gfscott/eleventy-plugin-embed-twitch) |
 | Vimeo | [npm](https://www.npmjs.com/package/eleventy-plugin-vimeo-embed) | [GitHub](https://github.com/gfscott/eleventy-plugin-vimeo-embed) |
 | YouTube | [npm](https://www.npmjs.com/package/eleventy-plugin-youtube-embed) | [GitHub](https://github.com/gfscott/eleventy-plugin-youtube-embed) |

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,11 @@
       "resolved": "https://registry.npmjs.org/eleventy-plugin-embed-spotify/-/eleventy-plugin-embed-spotify-1.1.0.tgz",
       "integrity": "sha512-VRKfy/zJefpHlNr1Euqir9GxJMYiVvnJMlkfaBrK7+PgS3V4+XCEMRmDL5HE4A7fK8ngtLqGmg/GAhQAU2yDHA=="
     },
+    "eleventy-plugin-embed-tiktok": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/eleventy-plugin-embed-tiktok/-/eleventy-plugin-embed-tiktok-1.0.0.tgz",
+      "integrity": "sha512-C6DHBw87We56+lvW+S+uOtVknMx1PwunwQl2tzZ48rrCbsyODKKXOWQeGg3YrYA1YNIlYhGg1nrb8P1kio/fsA=="
+    },
     "eleventy-plugin-embed-twitch": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/eleventy-plugin-embed-twitch/-/eleventy-plugin-embed-twitch-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,12 @@
     "eleventy-plugin",
     "embeds",
     "embedding",
+    "instagram",
     "media",
+    "soundcloud",
+    "spotify",
+    "tiktok",
+    "twitch",
     "youtube",
     "vimeo"
   ],
@@ -21,6 +26,7 @@
     "eleventy-plugin-embed-instagram": "^1.1.2",
     "eleventy-plugin-embed-soundcloud": "^1.0.1",
     "eleventy-plugin-embed-spotify": "^1.1.0",
+    "eleventy-plugin-embed-tiktok": "^1.0.0",
     "eleventy-plugin-embed-twitch": "^1.0.0",
     "eleventy-plugin-vimeo-embed": "^1.1.1",
     "eleventy-plugin-youtube-embed": "^1.3.1"


### PR DESCRIPTION
Adds support for the [eleventy-plugin-embed-tiktok](https://www.npmjs.com/package/eleventy-plugin-embed-tiktok) package.

Also updates package.json tags to include previous services that had been omitted.