### PR TITLE
Change test exit code to zero

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "An Eleventy plugin that allows you to quickly add common web embeds to markdown posts, using only their URLs",
   "main": ".eleventy.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"No tests specified\" && exit 0"
   },
   "keywords": [
     "11ty",


### PR DESCRIPTION
Currently the `npm-publish` Github action won't run properly because the test command exits `1` instead of `0`.

Since there's no testing in this repo (yet!) and testing is handled in the dependencies instead, I think we can safely let the CI pass the nonexistent tests so that we can use automatic npm publishing.