### PR TITLE
Bump YouTube to 1.6.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "eleventy-plugin-embed-twitch": "^1.2.0",
         "eleventy-plugin-embed-twitter": "^1.3.0",
         "eleventy-plugin-vimeo-embed": "^1.3.0",
-        "eleventy-plugin-youtube-embed": "^1.6.1"
+        "eleventy-plugin-youtube-embed": "^1.6.2"
       },
       "devDependencies": {
         "ava": "^3.15.0",
@@ -1620,9 +1620,9 @@
       "integrity": "sha512-0b+A9lp9pprD+Q9qZ8nkctWA0GPiZIBLNeuQe+39gg52BTSscZaenl2V88RZmyTWBaDv/HBgS8QxMG/+WHwJMQ=="
     },
     "node_modules/eleventy-plugin-youtube-embed": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/eleventy-plugin-youtube-embed/-/eleventy-plugin-youtube-embed-1.6.1.tgz",
-      "integrity": "sha512-SrOrIuu2aWX118ivLy+q2bUieHq2ufJ8JzuI2f1hwxaQQu2yk/35NVcSDBGFWYTe5Pr4CCEBQeey60n4uwI6ww==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/eleventy-plugin-youtube-embed/-/eleventy-plugin-youtube-embed-1.6.2.tgz",
+      "integrity": "sha512-6VCA6SvP1xOX4gy6JpMMoPCXpcDe/Fmv5Puj4ceej4/ZFxdz5Q4n+3rXO5Yz6KCjLl6HdAZ/qSidXfj9aLkdqA==",
       "dependencies": {
         "deepmerge": "^4.2.2",
         "lite-youtube-embed": "^0.2.0"
@@ -5737,9 +5737,9 @@
       "integrity": "sha512-0b+A9lp9pprD+Q9qZ8nkctWA0GPiZIBLNeuQe+39gg52BTSscZaenl2V88RZmyTWBaDv/HBgS8QxMG/+WHwJMQ=="
     },
     "eleventy-plugin-youtube-embed": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/eleventy-plugin-youtube-embed/-/eleventy-plugin-youtube-embed-1.6.1.tgz",
-      "integrity": "sha512-SrOrIuu2aWX118ivLy+q2bUieHq2ufJ8JzuI2f1hwxaQQu2yk/35NVcSDBGFWYTe5Pr4CCEBQeey60n4uwI6ww==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/eleventy-plugin-youtube-embed/-/eleventy-plugin-youtube-embed-1.6.2.tgz",
+      "integrity": "sha512-6VCA6SvP1xOX4gy6JpMMoPCXpcDe/Fmv5Puj4ceej4/ZFxdz5Q4n+3rXO5Yz6KCjLl6HdAZ/qSidXfj9aLkdqA==",
       "requires": {
         "deepmerge": "^4.2.2",
         "lite-youtube-embed": "^0.2.0"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "eleventy-plugin-embed-twitch": "^1.2.0",
     "eleventy-plugin-embed-twitter": "^1.3.0",
     "eleventy-plugin-vimeo-embed": "^1.3.0",
-    "eleventy-plugin-youtube-embed": "^1.6.1"
+    "eleventy-plugin-youtube-embed": "^1.6.2"
   },
   "author": {
     "name": "Graham F. Scott",


### PR DESCRIPTION
Bump YouTube plugin to [1.6.2](https://github.com/gfscott/eleventy-plugin-youtube-embed/releases/tag/v1.6.2) to fix bug with `lite` version.