### PR TITLE
Monorepo migration: Spotify

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Service | Package | Repository | Migrated?
 ------- | ------- | ---------- | ---------
 Instagram   | [npm](https://www.npmjs.com/package/eleventy-plugin-embed-instagram)  | [GitHub](https://github.com/gfscott/eleventy-plugin-embed-instagram)  | No
 SoundCloud  | [npm](https://www.npmjs.com/package/eleventy-plugin-embed-soundcloud) | [GitHub](https://github.com/gfscott/eleventy-plugin-embed-soundcloud) | No
-Spotify     | [npm](https://www.npmjs.com/package/eleventy-plugin-embed-spotify)    | [GitHub](https://github.com/gfscott/eleventy-plugin-embed-spotify)    | No
+Spotify     | [npm](https://www.npmjs.com/package/eleventy-plugin-embed-spotify)    | [GitHub](https://github.com/gfscott/eleventy-plugin-embed-everything/packages/spotify)    | Yes
 TikTok      | [npm](https://www.npmjs.com/package/eleventy-plugin-embed-tiktok)     | [GitHub](https://github.com/gfscott/eleventy-plugin-embed-tiktok)     | No 
 Twitch      | [npm](https://www.npmjs.com/package/eleventy-plugin-embed-twitch)     | [GitHub](https://github.com/gfscott/eleventy-plugin-embed-twitch)     | No
 Twitter     | [npm](https://www.npmjs.com/package/eleventy-plugin-embed-twitter)    | [GitHub](https://github.com/gfscott/eleventy-plugin-embed-twitter)    | No

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "embed-everything",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "Monorepo for Embed Everything: an Eleventy plugin that allows you to quickly add common web embeds to markdown posts, using only their URLs",
   "private": true,
   "scripts": {

--- a/packages/everything/package.json
+++ b/packages/everything/package.json
@@ -32,7 +32,7 @@
     "deepmerge": "^4.2.2",
     "eleventy-plugin-embed-instagram": "^1.2.5",
     "eleventy-plugin-embed-soundcloud": "^1.2.5",
-    "eleventy-plugin-embed-spotify": "^1.2.5",
+    "eleventy-plugin-embed-spotify": "workspace:^",
     "eleventy-plugin-embed-tiktok": "^1.1.5",
     "eleventy-plugin-embed-twitch": "^1.2.5",
     "eleventy-plugin-embed-twitter": "^1.3.5",

--- a/packages/spotify/.eleventy.js
+++ b/packages/spotify/.eleventy.js
@@ -1,0 +1,26 @@
+const spotPattern = require("./lib/spotPattern.js");
+const extractMatches = require("./lib/extractMatches.js");
+const buildEmbedCodeString = require("./lib/buildEmbed.js");
+const pluginDefaults = require("./lib/pluginDefaults.js");
+
+module.exports = function(eleventyConfig, options) {
+	const pluginConfig = Object.assign(pluginDefaults, options);
+	eleventyConfig.addTransform(
+		"embedSpotify",
+		async (content, outputPath) => {
+			if (outputPath && outputPath.endsWith(".html")) {
+				let matches = spotPattern(content);
+				if (!matches) {
+					return content;
+				}
+				matches.forEach(function(stringToReplace) {
+					let mediaId = extractMatches(stringToReplace);
+					let embedCode = buildEmbedCodeString(mediaId, pluginConfig);
+					content = content.replace(stringToReplace, embedCode);
+				});
+				return content;
+			}
+			return content;
+		},
+	);
+};

--- a/packages/spotify/README.md
+++ b/packages/spotify/README.md
@@ -1,0 +1,138 @@
+# eleventy-plugin-embed-spotify
+
+[![NPM Version](https://img.shields.io/npm/v/eleventy-plugin-embed-spotify?style=for-the-badge)](https://www.npmjs.com/package/eleventy-plugin-embed-spotify)
+[![Build test status](https://img.shields.io/github/actions/workflow/status/gfscott/eleventy-plugin-embed-spotify/test-and-codecov.yml?branch=main&style=for-the-badge)](https://github.com/gfscott/eleventy-plugin-embed-spotify/actions?query=workflow%3A%22Node.js+CI+and+Codecov%22)
+[![Code coverage](https://img.shields.io/codecov/c/gh/gfscott/eleventy-plugin-embed-spotify/main?style=for-the-badge)](https://codecov.io/gh/gfscott/eleventy-plugin-embed-spotify)\
+[![MIT License](https://img.shields.io/github/license/gfscott/eleventy-plugin-embed-spotify?style=for-the-badge)](https://github.com/gfscott/eleventy-plugin-embed-spotify/blob/master/LICENSE)
+[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v2.0-ff69b4.svg?style=for-the-badge)](code_of_conduct.md)
+
+This [Eleventy](https://www.11ty.dev/) plugin automatically embeds responsive Spotify tracks from URLs in Markdown files.
+
+- ⚡️ [Installation](#install-in-eleventy)
+- 🛠 [Usage](#usage)
+- ⚙️ [Settings](#settings)
+- ⚠️ [Notes and caveats](#notes-and-caveats)
+
+---
+<span id="install-in-eleventy"></span>
+## ⚡️ Installation
+
+In your Eleventy project, [install the plugin](https://www.11ty.dev/docs/plugins/#adding-a-plugin) through npm:
+
+```sh
+$ npm i eleventy-plugin-embed-spotify
+```
+
+Then add it to your [Eleventy config](https://www.11ty.dev/docs/config/) file:
+
+```javascript
+const embedSpotify = require("eleventy-plugin-embed-spotify");
+
+module.exports = function(eleventyConfig) {
+  eleventyConfig.addPlugin(embedSpotify);
+};
+```
+
+<span id="usage"></span>
+## 🛠 Usage
+
+To embed a Spotify widget into any Markdown page, paste its URL into a new line. The URL should be the only thing on that line.
+
+### Markdown file example:
+
+```markdown
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam vehicula, elit vel condimentum porta, purus.
+
+https://open.spotify.com/track/7nJZ9LplJ3ZAyhQyJCJk0K
+
+Maecenas non velit nibh. Aenean eu justo et odio commodo ornare. In scelerisque sapien at.
+```
+
+### Result:
+
+![Janelle Monae’s “Dirty Computer”](https://user-images.githubusercontent.com/547470/78504267-f70eb980-7739-11ea-8206-9862782b1f80.png)
+
+<span id="settings"></span>
+## ⚙️ Settings
+
+You can configure the plugin to change its behavior by passing an options object to the `addPlugin` function:
+
+```javascript
+eleventyConfig.addPlugin(embedSpotify, {
+  // edit options here
+});
+```
+
+### Plugin default options
+
+Edit any of the [default values](lib/pluginDefaults.js) in this options object to override the plugin behavior. These are the default settings, which will apply to all embed instances. Currently there’s no way to configure individual embeds.
+
+```javascript
+{
+  // Spotify’s iframe embed requires the `allow` attribute to include `encrypted-media`
+  // in order to enable full-track playback.
+  // Substitute your preferred string to allow other iframe behaviors
+  allowAttrs: 'encrypted-media',
+  // The Spotify player iframe is always wrapped in a div with this class.
+  // Substitute your preferred string to rename the wrapper class
+  embedClass: 'eleventy-plugin-embed-spotify',
+  // Default iframe height, in pixels
+  height: '380',
+  // default iframe width, in pixels
+  width: '300'
+  // width: '100%' // Use 100% width value to make the player responsive!
+};
+```
+
+### Supported URL patterns
+
+The plugin supports common Spotify URL variants as well. These should also work in your Markdown files.:
+
+```markdown
+<!-- Works with individual tracks, albums, artists, podcast episodes, and playlists: -->
+
+https://open.spotify.com/track/7nJZ9LplJ3ZAyhQyJCJk0K
+https://open.spotify.com/album/2PjlaxlMunGOUvcRzlTbtE
+https://open.spotify.com/artist/6ueGR6SWhUJfvEhqkvMsVs
+https://open.spotify.com/episode/7G5O2wWmch1ciYDPZS4a4O
+
+<!-- Playlists work with or without usernames: -->
+
+https://open.spotify.com/user/janellemonae/playlist/5yEkeuBVoXWuGuzpcmzUZ5
+https://open.spotify.com/playlist/5yEkeuBVoXWuGuzpcmzUZ5
+
+<!-- No protocol: -->
+
+open.spotify.com/track/7nJZ9LplJ3ZAyhQyJCJk0K
+spotify.com/track/7nJZ9LplJ3ZAyhQyJCJk0K
+
+<!-- With or without HTTPS: -->
+
+https://open.spotify.com/track/7nJZ9LplJ3ZAyhQyJCJk0K
+http://open.spotify.com/track/7nJZ9LplJ3ZAyhQyJCJk0K
+
+<!-- With or without 'www' or 'open' subdomains: -->
+
+https://open.spotify.com/track/7nJZ9LplJ3ZAyhQyJCJk0K
+https://www.spotify.com/track/7nJZ9LplJ3ZAyhQyJCJk0K
+https://spotify.com/track/7nJZ9LplJ3ZAyhQyJCJk0K
+
+<!-- URLs with extra parameters: -->
+
+https://open.spotify.com/track/7nJZ9LplJ3ZAyhQyJCJk0K?si=3qc9p-sGR3es3e8kkP9VFA
+```
+
+If you run across a URL pattern that you think should work, but doesn’t, please [file an issue](https://github.com/gfscott/eleventy-plugin-embed-spotify/issues/new)!
+
+<span id="notes-and-caveats"></span>
+## ⚠️ Notes and caveats
+
+- This plugin is deliberately designed _only_ to embed tracks when the URL is on its own line, and not inline with other text.
+- To do this, it uses [a regular expression](lib/spotPattern.js) to recognize relevant Spotify URLs. Currently these are the limitations on what it can recognize in a Markdown parser’s HTML output:
+  - The URL *must* be wrapped in a paragraph tag: `<p>`
+  - It *may* also be wrapped in an anchor tag, (*inside* the paragraph): `<a>`
+  - The URL string *may* have whitespace around it
+- I’ve tried to accommodate common variants, but there are conceivably valid Spotify URLs that wouldn’t get recognized. Please [file an issue](https://github.com/gfscott/eleventy-plugin-embed-spotify/issues/new) if you run into an edge case!
+- This plugin uses [transforms](https://www.11ty.dev/docs/config/#transforms), so it alters Eleventy’s HTML output as it’s generated. It doesn’t alter the source Markdown.
+- The embedded player is not responsive by default. Spotify’s default player is 300 pixels wide by 380 pixels tall.
+- **New in 1.1.0:** The embedded podcast player _is_ responsive, in keeping with Spotify’s defaults. Currently, all podcast episode players will be 232 pixels tall, with 100% width.

--- a/packages/spotify/lib/buildEmbed.js
+++ b/packages/spotify/lib/buildEmbed.js
@@ -1,0 +1,14 @@
+module.exports = function(media, options) {
+	let out = `<div id="spotify-${media.type}-${media.id}" class="${options.embedClass} ${options.embedClass}-${media.type}">`;
+	out += `<iframe title="${media.type} on Spotify" src="https://open.spotify.com/embed${media.type ===
+	"episode"
+		? "-podcast"
+		: ""}/${media.type}/${media.id}" `;
+	out += `width="${media.type === "episode" ? "100%" : options.width}" height="${media.type ===
+	"episode"
+		? "232"
+		: options.height}" `;
+	out += `frameborder="0" allowtransparency="true" allow="${options.allowAttrs}"></iframe>`;
+	out += "</div>";
+	return out;
+};

--- a/packages/spotify/lib/extractMatches.js
+++ b/packages/spotify/lib/extractMatches.js
@@ -1,0 +1,11 @@
+const pattern = /<p>(?=(\s*))\1(?:<a [^>]*?>)??(?=(\s*))\2(?:https?:)??(?:\/\/)??(?:open\.|www\.)??spotify\.com\/(?:user)??\/??(?:[0-9a-zA-Z]+)??\/??(playlist|track|album|artist|episode)\/([0-9a-zA-Z]{22})(?:[^\s<>]*)(?=(\s*))\5(?:<\/a>)??(?=(\s*))\6<\/p>/;
+
+module.exports = function(str) {
+	let match = str.match(pattern);
+	let type = match[3];
+	let id = match[4];
+	return {
+		type,
+		id,
+	};
+};

--- a/packages/spotify/lib/pluginDefaults.js
+++ b/packages/spotify/lib/pluginDefaults.js
@@ -1,0 +1,10 @@
+// Follows defaults used on Spotify’s Play Button generator
+// https://developer.spotify.com/documentation/widgets/generate/play-button/
+// Spotify requires `allow="encrypted-media"` to enable full-track playback in embeds
+// https://web.archive.org/web/20200405163940/https://developer.spotify.com/community/news/2018/07/19/new-updates-to-spotify-play-button/
+module.exports = {
+	allowAttrs: "encrypted-media",
+	embedClass: "eleventy-plugin-embed-spotify",
+	height: "380",
+	width: "300",
+};

--- a/packages/spotify/lib/spotPattern.js
+++ b/packages/spotify/lib/spotPattern.js
@@ -1,0 +1,5 @@
+const pattern = /<p>(?=(\s*))\1(?:<a [^>]*?>)??(?=(\s*))\2(?:https?:)??(?:\/\/)??(?:open\.|www\.)??spotify\.com\/(?:user)??\/??(?:[0-9a-zA-Z]+)??\/??(?:playlist|track|album|artist|episode)\/[0-9a-zA-Z]{22}(?:[^\s<>]*)(?=(\s*))\3(?:<\/a>)??(?=(\s*))\4<\/p>/g;
+
+module.exports = function(str) {
+	return str.match(pattern);
+};

--- a/packages/spotify/package.json
+++ b/packages/spotify/package.json
@@ -10,10 +10,13 @@
   ],
   "main": ".eleventy.js",
   "scripts": {
-    "test": "nyc --reporter=lcov ava",
-    "coverage": "coverage",
-    "lint": "npx rome check"
+    "test": "npx ava",
+    "coverage": "nyc --reporter=lcov ava"
   },
+  "files": [
+    ".eleventy.js",
+    "lib/**"
+  ],
   "ava": {
     "files": [
       "!test/inc",
@@ -29,13 +32,7 @@
   "homepage": "https://gfscott.com/embed-everything/",
   "repository": {
     "type": "git",
-    "url": "https://github.com/gfscott/eleventy-plugin-embed-spotify.git"
+    "url": "https://github.com/gfscott/eleventy-plugin-embed-everything.git"
   },
-  "bugs": "https://github.com/gfscott/eleventy-plugin-embed-spotify/issues",
-  "devDependencies": {
-    "ava": "^5.1.0",
-    "codecov": "^3.8.3",
-    "nyc": "^15.1.0",
-    "rome": "^10.0.4-beta"
-  }
+  "bugs": "https://github.com/gfscott/eleventy-plugin-embed-everything/issues"
 }

--- a/packages/spotify/package.json
+++ b/packages/spotify/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "eleventy-plugin-embed-spotify",
+  "version": "1.2.5",
+  "description": "An Eleventy plugin to automatically embed Spotify tracks, using just their URLs.",
+  "keywords": [
+    "11ty",
+    "eleventy",
+    "eleventy-plugin",
+    "spotify"
+  ],
+  "main": ".eleventy.js",
+  "scripts": {
+    "test": "nyc --reporter=lcov ava",
+    "coverage": "coverage",
+    "lint": "npx rome check"
+  },
+  "ava": {
+    "files": [
+      "!test/inc",
+      "!test/html"
+    ]
+  },
+  "author": {
+    "name": "Graham F. Scott",
+    "email": "gfscott@gmail.com",
+    "url": "https://gfscott.com"
+  },
+  "license": "MIT",
+  "homepage": "https://gfscott.com/embed-everything/",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gfscott/eleventy-plugin-embed-spotify.git"
+  },
+  "bugs": "https://github.com/gfscott/eleventy-plugin-embed-spotify/issues",
+  "devDependencies": {
+    "ava": "^5.1.0",
+    "codecov": "^3.8.3",
+    "nyc": "^15.1.0",
+    "rome": "^10.0.4-beta"
+  }
+}

--- a/packages/spotify/test/inc/invalidStrings.js
+++ b/packages/spotify/test/inc/invalidStrings.js
@@ -1,0 +1,22 @@
+module.exports = [
+	{
+		type: "With prepended text",
+		str: "foo https://open.spotify.com/playlist/7zv2xFPTH1MBynYafuvtCj",
+	},
+	{
+		type: "With prepended text, with link",
+		str: 'foo <a href="">https://open.spotify.com/playlist/7zv2xFPTH1MBynYafuvtCj</a>',
+	},
+	{
+		type: "With appended text",
+		str: "https://open.spotify.com/playlist/7zv2xFPTH1MBynYafuvtCj bar",
+	},
+	{
+		type: "With appended text, with link",
+		str: '<a href="">https://open.spotify.com/playlist/7zv2xFPTH1MBynYafuvtCj</a> bar',
+	},
+	{
+		type: "With incomplete playlist ID",
+		str: "https://open.spotify.com/playlist/7zv2xFPTH1M",
+	},
+];

--- a/packages/spotify/test/inc/validStrings.js
+++ b/packages/spotify/test/inc/validStrings.js
@@ -1,0 +1,38 @@
+module.exports = [
+	{
+		id: "75qojmHz1id8sL2LDR5qVz",
+		slug: "album",
+		type: "Album",
+		str: "spotify.com/album/75qojmHz1id8sL2LDR5qVz",
+	},
+	{
+		id: "066X20Nz7iquqkkCW6Jxy6",
+		slug: "artist",
+		type: "Artist",
+		str: "spotify.com/artist/066X20Nz7iquqkkCW6Jxy6",
+	},
+	{
+		id: "7zv2xFPTH1MBynYafuvtCj",
+		slug: "playlist",
+		type: "Playlist",
+		str: "spotify.com/playlist/7zv2xFPTH1MBynYafuvtCj",
+	},
+	{
+		id: "7zv2xFPTH1MBynYafuvtCj",
+		slug: "userPlaylist",
+		type: "Playlist with user ID",
+		str: "spotify.com/user/gfscott/playlist/7zv2xFPTH1MBynYafuvtCj",
+	},
+	{
+		id: "3gsCAGsWr6pUm1Vy7CPPob",
+		slug: "track",
+		type: "Track",
+		str: "spotify.com/track/3gsCAGsWr6pUm1Vy7CPPob",
+	},
+	{
+		id: "7G5O2wWmch1ciYDPZS4a4O",
+		slug: "episode",
+		type: "Podcast episode",
+		str: "spotify.com/episode/7G5O2wWmch1ciYDPZS4a4O",
+	},
+];

--- a/packages/spotify/test/test-buildEmbed.js
+++ b/packages/spotify/test/test-buildEmbed.js
@@ -1,0 +1,74 @@
+/**
+ * Test buildEmbed.js
+ * -------------------
+ * This file tests that the buildEmbed module returns the expected
+ * HTML, given the extracted data.
+ */
+
+const test = require("ava");
+const extractMatch = require("../lib/extractMatches.js");
+const pluginDefaults = require("../lib/pluginDefaults.js");
+const buildEmbed = require("../lib/buildEmbed.js");
+
+test(
+	"URL string returns expected HTML string for albums, default options",
+	(t) => {
+		let str = "<p>https://open.spotify.com/album/75qojmHz1id8sL2LDR5qVz</p>";
+		let expected = '<div id="spotify-album-75qojmHz1id8sL2LDR5qVz" class="eleventy-plugin-embed-spotify eleventy-plugin-embed-spotify-album"><iframe title="album on Spotify" src="https://open.spotify.com/embed/album/75qojmHz1id8sL2LDR5qVz" width="300" height="380" frameborder="0" allowtransparency="true" allow="encrypted-media"></iframe></div>';
+		let out = buildEmbed(extractMatch(str), pluginDefaults);
+		t.is(out, expected);
+	},
+);
+
+test(
+	"URL string returns expected HTML string for artists, default options",
+	(t) => {
+		let str = "<p>https://open.spotify.com/artist/066X20Nz7iquqkkCW6Jxy6</p>";
+		let expected = '<div id="spotify-artist-066X20Nz7iquqkkCW6Jxy6" class="eleventy-plugin-embed-spotify eleventy-plugin-embed-spotify-artist"><iframe title="artist on Spotify" src="https://open.spotify.com/embed/artist/066X20Nz7iquqkkCW6Jxy6" width="300" height="380" frameborder="0" allowtransparency="true" allow="encrypted-media"></iframe></div>';
+		let out = buildEmbed(extractMatch(str), pluginDefaults);
+		t.is(out, expected);
+	},
+);
+
+test(
+	"URL string returns expected HTML string for playlists, default options",
+	(t) => {
+		let str = "<p>https://open.spotify.com/playlist/7zv2xFPTH1MBynYafuvtCj</p>";
+		let expected = '<div id="spotify-playlist-7zv2xFPTH1MBynYafuvtCj" class="eleventy-plugin-embed-spotify eleventy-plugin-embed-spotify-playlist"><iframe title="playlist on Spotify" src="https://open.spotify.com/embed/playlist/7zv2xFPTH1MBynYafuvtCj" width="300" height="380" frameborder="0" allowtransparency="true" allow="encrypted-media"></iframe></div>';
+		let out = buildEmbed(extractMatch(str), pluginDefaults);
+		t.is(out, expected);
+	},
+);
+
+test(
+	"URL string returns expected HTML string for user-specific playlists, default options",
+	(t) => {
+		let str = "<p>https://open.spotify.com/user/gfscott/playlist/7zv2xFPTH1MBynYafuvtCj</p>";
+		let expected = '<div id="spotify-playlist-7zv2xFPTH1MBynYafuvtCj" class="eleventy-plugin-embed-spotify eleventy-plugin-embed-spotify-playlist"><iframe title="playlist on Spotify" src="https://open.spotify.com/embed/playlist/7zv2xFPTH1MBynYafuvtCj" width="300" height="380" frameborder="0" allowtransparency="true" allow="encrypted-media"></iframe></div>';
+		let out = buildEmbed(extractMatch(str), pluginDefaults);
+		t.is(out, expected);
+	},
+);
+
+test(
+	"URL string returns expected HTML string for tracks, default options",
+	(t) => {
+		let str = "<p>https://open.spotify.com/track/3gsCAGsWr6pUm1Vy7CPPob</p>";
+		let expected = '<div id="spotify-track-3gsCAGsWr6pUm1Vy7CPPob" class="eleventy-plugin-embed-spotify eleventy-plugin-embed-spotify-track"><iframe title="track on Spotify" src="https://open.spotify.com/embed/track/3gsCAGsWr6pUm1Vy7CPPob" width="300" height="380" frameborder="0" allowtransparency="true" allow="encrypted-media"></iframe></div>';
+		let out = buildEmbed(extractMatch(str), pluginDefaults);
+		t.is(out, expected);
+	},
+);
+
+// Note that expected output is different for podcast episodes!
+// Podcast players have different dimensions from standard Spotify embeds,
+// and their embed iframe URL uses a different directory.
+test(
+	"URL string returns expected HTML string for podcast episodes, default options",
+	(t) => {
+		let str = "<p>https://open.spotify.com/episode/7G5O2wWmch1ciYDPZS4a4O</p>";
+		let expected = '<div id="spotify-episode-7G5O2wWmch1ciYDPZS4a4O" class="eleventy-plugin-embed-spotify eleventy-plugin-embed-spotify-episode"><iframe title="episode on Spotify" src="https://open.spotify.com/embed-podcast/episode/7G5O2wWmch1ciYDPZS4a4O" width="100%" height="232" frameborder="0" allowtransparency="true" allow="encrypted-media"></iframe></div>';
+		let out = buildEmbed(extractMatch(str), pluginDefaults);
+		t.is(out, expected);
+	},
+);

--- a/packages/spotify/test/test-extractMatches.js
+++ b/packages/spotify/test/test-extractMatches.js
@@ -1,0 +1,79 @@
+/**
+ * Test extractMatches.js
+ * -------------------
+ * This file tests that the extractMatches module returns the expected
+ * data.
+ */
+
+const test = require("ava");
+const validStrings = require("./inc/validStrings.js");
+const extractMatch = require("../lib/extractMatches.js");
+
+validStrings.forEach((obj) => {
+	test(
+		`URL string returns expected media type for ${obj.type}`,
+		(t) => {
+			let str = `<p>https://open.${obj.str}</p>`;
+			let extract = extractMatch(str).type;
+			let expected = obj.slug;
+			// User playlists may have the username in the URL, but it's
+			// not neccessary for embedding, so the extractor only returns
+			// the 'playlist' type.
+			if (obj.slug === "userPlaylist") {
+				t.is(extract, "playlist");
+			} else {
+				t.is(extract, expected);
+			}
+		},
+	);
+
+	test(
+		`URL string returns expected media ID for ${obj.type}`,
+		(t) => {
+			let str = `<p>https://open.${obj.str}</p>`;
+			let extract = extractMatch(str).id;
+			let expected = obj.id;
+			t.is(extract, expected);
+		},
+	);
+
+	test(
+		`URL string returns expected media object for ${obj.type}`,
+		(t) => {
+			let str = `<p>https://open.${obj.str}</p>`;
+			let extract = extractMatch(str);
+			let expected = {
+				type: obj.slug,
+				id: obj.id,
+			};
+			// see user playlist notes above
+			if (obj.slug === "userPlaylist") {
+				t.deepEqual(extract, {type: "playlist", id: "7zv2xFPTH1MBynYafuvtCj"});
+			} else {
+				t.deepEqual(extractMatch(str), expected);
+			}
+		},
+	);
+});
+
+/**
+ * In the "validStrings.js" file, the "playlist" and "userPlaylist" types
+ * should have identical IDs and produce the same `type` when processed by
+ * extractMatch.js. This test ensures that the ids and slugs of those two
+ * types remain in sync. It will error out if those strings are messed with!
+ */
+test(
+	"Playlist and User Playlist types in validStrings.js have identical IDs",
+	(t) => {
+		let filteredArray = validStrings.filter((obj) =>
+			obj.slug === "playlist" || obj.slug === "userPlaylist"
+		);
+
+		// filteredArray should always be exactly 2 entries
+		t.is(filteredArray.length, 2);
+
+		// Both filteredArray objects have the same IDs, and it's the expected one
+		t.is(filteredArray[0].id, filteredArray[1].id);
+		t.is(filteredArray[0].id, "7zv2xFPTH1MBynYafuvtCj");
+	},
+);

--- a/packages/spotify/test/test-spotPattern.js
+++ b/packages/spotify/test/test-spotPattern.js
@@ -1,0 +1,145 @@
+/**
+ * Test spotPattern.js
+ * -------------------
+ * This file tests that valid strings are correctly identified
+ * by the spotPattern module.
+ */
+
+const test = require("ava");
+const validStrings = require("./inc/validStrings.js");
+const invalidStrings = require("./inc/invalidStrings.js");
+const patternPresent = require("../lib/spotPattern.js");
+
+validStrings.forEach(function(obj) {
+	test(
+		`VALID: ${obj.type} ideal full HTTPS URL`,
+		(t) => {
+			let str = `<p>https://open.${obj.str}</p>`;
+			t.truthy(patternPresent(str));
+		},
+	);
+	test(
+		`VALID: ${obj.type} HTTP URL`,
+		(t) => {
+			let str = `<p>http://open.${obj.str}</p>`;
+			t.truthy(patternPresent(str));
+		},
+	);
+	test(
+		`VALID: ${obj.type} no protocol, with slashes`,
+		(t) => {
+			let str = `<p>//open.${obj.str}</p>`;
+			t.truthy(patternPresent(str));
+		},
+	);
+	test(
+		`VALID: ${obj.type} no protocol, no slashes `,
+		(t) => {
+			let str = `<p>open.${obj.str}</p>`;
+			t.truthy(patternPresent(str));
+		},
+	);
+	test(
+		`VALID: ${obj.type} open > www, ideal full HTTPS URL`,
+		(t) => {
+			let str = `<p>https://www.${obj.str}</p>`;
+			t.truthy(patternPresent(str));
+		},
+	);
+	test(
+		`VALID: ${obj.type} open > www, HTTP URL`,
+		(t) => {
+			let str = `<p>http://www.${obj.str}</p>`;
+			t.truthy(patternPresent(str));
+		},
+	);
+	test(
+		`VALID: ${obj.type} open > www, no protocol, with slashes`,
+		(t) => {
+			let str = `<p>//www.${obj.str}</p>`;
+			t.truthy(patternPresent(str));
+		},
+	);
+	test(
+		`VALID: ${obj.type} open > www, no protocol, no slashes `,
+		(t) => {
+			let str = `<p>www.${obj.str}</p>`;
+			t.truthy(patternPresent(str));
+		},
+	);
+	test(
+		`VALID: ${obj.type} ideal full HTTPS URL, with arbitrary params`,
+		(t) => {
+			let str = `<p>https://open.${obj.str}?foo=bar</p>`;
+			t.truthy(patternPresent(str));
+		},
+	);
+	test(
+		`VALID: ${obj.type} HTTP URL, with arbitrary params`,
+		(t) => {
+			let str = `<p>http://open.${obj.str}?foo=bar</p>`;
+			t.truthy(patternPresent(str));
+		},
+	);
+	test(
+		`VALID: ${obj.type} no protocol, with slashes, with arbitrary params`,
+		(t) => {
+			let str = `<p>//open.${obj.str}?foo=bar</p>`;
+			t.truthy(patternPresent(str));
+		},
+	);
+	test(
+		`VALID: ${obj.type} no protocol, no slashes , with arbitrary params`,
+		(t) => {
+			let str = `<p>open.${obj.str}?foo=bar</p>`;
+			t.truthy(patternPresent(str));
+		},
+	);
+	test(
+		`VALID: ${obj.type} open > www, ideal full HTTPS URL, with arbitrary params`,
+		(t) => {
+			let str = `<p>https://www.${obj.str}?foo=bar</p>`;
+			t.truthy(patternPresent(str));
+		},
+	);
+	test(
+		`VALID: ${obj.type} open > www, HTTP URL, with arbitrary params`,
+		(t) => {
+			let str = `<p>http://www.${obj.str}?foo=bar</p>`;
+			t.truthy(patternPresent(str));
+		},
+	);
+	test(
+		`VALID: ${obj.type} open > www, no protocol, with slashes, with arbitrary params`,
+		(t) => {
+			let str = `<p>//www.${obj.str}?foo=bar</p>`;
+			t.truthy(patternPresent(str));
+		},
+	);
+	test(
+		`VALID: ${obj.type} open > www, no protocol, no slashes , with arbitrary params`,
+		(t) => {
+			let str = `<p>www.${obj.str}?foo=bar</p>`;
+			t.truthy(patternPresent(str));
+		},
+	);
+});
+
+invalidStrings.forEach(function(obj) {
+	test(
+		`INVALID: ${obj.type} ideal case`,
+		(t) => {
+			let idealCase = `<p>${obj.str}</p>`;
+			t.falsy(patternPresent(idealCase));
+		},
+	);
+	test(
+		`INVALID: ${obj.type} with whitespace`,
+		(t) => {
+			let withWhitespace = `<p>
+        ${obj.str}
+        </p>`;
+			t.falsy(patternPresent(withWhitespace));
+		},
+	);
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,7 +20,7 @@ importers:
       deepmerge: ^4.2.2
       eleventy-plugin-embed-instagram: ^1.2.5
       eleventy-plugin-embed-soundcloud: ^1.2.5
-      eleventy-plugin-embed-spotify: ^1.2.5
+      eleventy-plugin-embed-spotify: workspace:^
       eleventy-plugin-embed-tiktok: ^1.1.5
       eleventy-plugin-embed-twitch: ^1.2.5
       eleventy-plugin-embed-twitter: ^1.3.5
@@ -30,12 +30,15 @@ importers:
       deepmerge: 4.2.2
       eleventy-plugin-embed-instagram: 1.2.5
       eleventy-plugin-embed-soundcloud: 1.2.5
-      eleventy-plugin-embed-spotify: 1.2.5
+      eleventy-plugin-embed-spotify: link:../spotify
       eleventy-plugin-embed-tiktok: 1.1.5
       eleventy-plugin-embed-twitch: 1.2.5
       eleventy-plugin-embed-twitter: 1.3.5
       eleventy-plugin-vimeo-embed: 1.3.5
       eleventy-plugin-youtube-embed: 1.8.0
+
+  packages/spotify:
+    specifiers: {}
 
 packages:
 
@@ -1146,10 +1149,6 @@ packages:
     transitivePeerDependencies:
       - encoding
       - supports-color
-    dev: false
-
-  /eleventy-plugin-embed-spotify/1.2.5:
-    resolution: {integrity: sha512-9FVfsjtfAObdSmiOxn+cUW7hcWkuHY/v+iXBKMk5wtJrpLpDcE8MCwz+/YW+Tpi57W5s3s0fJQlB++CkhKgmuw==}
     dev: false
 
   /eleventy-plugin-embed-tiktok/1.1.5:


### PR DESCRIPTION
This PR migrates the `eleventy-plugin-embed-spotify` package into the monorepo. I'll do each package migration as a separate PR.

I'm using git's `--allow-unrelated-histories` feature to import the complete commit history, using the method outlined in [this blog post](https://blog.jdriven.com/2021/04/how-to-merge-multiple-git-repositories/) by @hetzijzo (🙏🏻). I think it's important to maintain the full history of the codebase and, in particular, to preserve a record of the contributions made by volunteers.