### PR TITLE
Monorepo migration: Soundcloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ As of early 2023, all the plugins in this collection reside in their own repos, 
 Service | Package | Repository | Migrated?
 ------- | ------- | ---------- | ---------
 Instagram   | [npm](https://www.npmjs.com/package/eleventy-plugin-embed-instagram)  | [GitHub](https://github.com/gfscott/eleventy-plugin-embed-instagram)  | No
-SoundCloud  | [npm](https://www.npmjs.com/package/eleventy-plugin-embed-soundcloud) | [GitHub](https://github.com/gfscott/eleventy-plugin-embed-soundcloud) | No
+SoundCloud  | [npm](https://www.npmjs.com/package/eleventy-plugin-embed-soundcloud) | [GitHub](https://github.com/gfscott/eleventy-plugin-embed-everything/packages/soundcloud) | Yes
 Spotify     | [npm](https://www.npmjs.com/package/eleventy-plugin-embed-spotify)    | [GitHub](https://github.com/gfscott/eleventy-plugin-embed-everything/packages/spotify)    | Yes
 TikTok      | [npm](https://www.npmjs.com/package/eleventy-plugin-embed-tiktok)     | [GitHub](https://github.com/gfscott/eleventy-plugin-embed-tiktok)     | No 
 Twitch      | [npm](https://www.npmjs.com/package/eleventy-plugin-embed-twitch)     | [GitHub](https://github.com/gfscott/eleventy-plugin-embed-twitch)     | No

--- a/packages/everything/package.json
+++ b/packages/everything/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "deepmerge": "^4.2.2",
     "eleventy-plugin-embed-instagram": "^1.2.5",
-    "eleventy-plugin-embed-soundcloud": "^1.2.5",
+    "eleventy-plugin-embed-soundcloud": "workspace:^",
     "eleventy-plugin-embed-spotify": "workspace:^",
     "eleventy-plugin-embed-tiktok": "^1.1.5",
     "eleventy-plugin-embed-twitch": "^1.2.5",

--- a/packages/soundcloud/.eleventy.js
+++ b/packages/soundcloud/.eleventy.js
@@ -1,0 +1,44 @@
+const patternPresent = require('./lib/spotPattern.js');
+const getEmbed = require('./lib/getEmbed.js');
+const pluginDefaults = require('./lib/pluginDefaults.js');
+
+// module.exports = function(eleventyConfig, options) {
+//   const pluginConfig = Object.assign({}, pluginDefaults, options);
+//   eleventyConfig.addTransform("embedSoundCloud", async (content, outputPath) => {
+//     if (!outputPath.endsWith(".html")) {
+//       return content;
+//     }
+//     let matches = patternPresent(content);
+//     if (!matches) {
+//       return content;
+//     }
+//     // modern for loop instead of array.forEach, to enable await
+//     // https://stackoverflow.com/a/37576787
+//     for ( const match of matches ) {
+//       let embedCode = await getEmbed(match, pluginConfig);
+//       content = content.replace(match, embedCode);
+//     }
+//     return content;
+//   });
+// };
+
+module.exports = function (eleventyConfig, options) {
+  const pluginConfig = Object.assign(pluginDefaults, options);
+  eleventyConfig.addTransform("embedSoundCloud", async (content, outputPath) => {
+    if (outputPath && outputPath.endsWith(".html")) {
+      let matches = patternPresent(content);
+      if (!matches) {
+        return content;
+      }
+      // modern for loop instead of array.forEach, to enable await
+      // https://stackoverflow.com/a/37576787
+      for ( const match of matches ) {
+        let embedCode = await getEmbed(match, pluginConfig);
+        content = content.replace(match, embedCode);
+      }
+      return content;
+    }
+
+    return content;
+  });
+};

--- a/packages/soundcloud/README.md
+++ b/packages/soundcloud/README.md
@@ -1,0 +1,125 @@
+# eleventy-plugin-embed-soundcloud
+
+[![NPM Version](https://img.shields.io/npm/v/eleventy-plugin-embed-soundcloud?style=for-the-badge)](https://www.npmjs.com/package/eleventy-plugin-embed-soundcloud)
+[![Build test status](https://img.shields.io/github/actions/workflow/status/gfscott/eleventy-plugin-embed-soundcloud/test-and-codecov.yml?branch=main&style=for-the-badge)](https://github.com/gfscott/eleventy-plugin-embed-soundcloud/actions?query=workflow%3A%22Node.js+CI+and+Codecov%22)\
+[![MIT License](https://img.shields.io/github/license/gfscott/eleventy-plugin-embed-soundcloud?style=for-the-badge)](https://github.com/gfscott/eleventy-plugin-embed-soundcloud/blob/master/LICENSE)
+[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v2.0-ff69b4.svg?style=for-the-badge)](CODE_OF_CONDUCT.md)
+
+This [Eleventy](https://www.11ty.dev/) plugin automatically embeds responsive SoundCloud players from URLs in Markdown files.
+
+- ⚡️ [Installation](#install-in-eleventy)
+- 🛠 [Usage](#usage)
+- ⚙️ [Settings](#settings)
+- ⚠️ [Notes and caveats](#notes-and-caveats)
+
+---
+
+## ⚡️ Installation
+
+In your Eleventy project, [install the plugin](https://www.11ty.dev/docs/plugins/#adding-a-plugin) through npm:
+
+```sh
+$ npm i eleventy-plugin-embed-soundcloud
+```
+
+Then add it to your [Eleventy config](https://www.11ty.dev/docs/config/) file:
+
+```javascript
+const embedSoundCloud = require("eleventy-plugin-embed-soundcloud");
+
+module.exports = function(eleventyConfig) {
+  eleventyConfig.addPlugin(embedSoundCloud);
+};
+```
+
+## 🛠 Usage
+
+To embed a SoundCloud player into any Markdown page, paste its URL into a new line. The URL should be the only thing on that line.
+
+### Markdown file example:
+
+```markdown
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam vehicula, elit vel condimentum porta, purus.
+
+https://soundcloud.com/megan-thee-stallion/sets/suga
+
+Maecenas non velit nibh. Aenean eu justo et odio commodo ornare. In scelerisque sapien at.
+```
+
+### Result:
+
+![Screnshot of Megan Thee Stallion album “Suga” on SoundCloud](https://user-images.githubusercontent.com/547470/79051218-ff189e80-7bfc-11ea-9cf2-4fc802d8a2f2.png)
+
+
+## ⚙️ Settings
+
+You can configure the plugin to change its behavior by passing an options object to the `addPlugin` function:
+
+```javascript
+eleventyConfig.addPlugin(embedSoundCloud, {
+  // edit options here
+});
+```
+
+### Plugin default options
+
+Edit any of the [default values](lib/pluginDefaults.js) to change the plugin’s behavior. These are the default settings, which will apply to all embed instances. Currently there’s no way to configure individual embeds.
+
+```javascript
+{
+  auto_play: false, // @Boolean: be cool, don’t do this!
+  color: '#ff7700', // @String: hex code to control the color scheme
+  embedClass: 'eleventy-plugin-embed-soundcloud', // @String: class name of wrapper div
+  height: 400, // @Int/@String: height of the embedded iframe.
+  // ☝️ Use Integer for pixels; Use String for percent value
+  sharing: true, // @Boolean: show sharing button
+  show_artwork: true, // @Boolean: show the track/playlist cover art
+  show_comments: true, // @Boolean: show listener comments
+  show_playcount: true, // @Boolean: show total number of plays
+  show_reposts: false, // @Boolean: show total number of reposts
+  show_user: true, // @Boolean: show the uploading user’s name above the track/set name
+  small: false, // @Boolean: Convenience setting: Use smaller waveform embed style
+  // ☝️ small: true overrides `visual` to `false` and `height` to `166`.
+  single_active: true, // @Boolean: only one player active on a page at a time. 
+  // ☝️ single_active behavior seems buggy right now, your mileage may vary
+  visual: true, // @Boolean: Default SoundCloud player style shows a huge cover image.
+  width: '100%' // @Int/@String: width of the embedded iframe
+  // ☝️ Use Integer for pixels; Use String for percent value
+}
+```
+
+### Supported URL patterns
+
+The plugin supports common SoundCloud URL types:
+
+```markdown
+<!-- User profile  URL embeds a playlist of the most recent uploaded tracks -->
+https://soundcloud.com/megan-thee-stallion
+
+<!-- Albums and Playlists are both “sets” on SoundCloud -->
+https://soundcloud.com/megan-thee-stallion/sets/suga
+
+<!-- Individual tracks -->
+https://soundcloud.com/megan-thee-stallion/rich
+
+<!-- URL variants also work  -->
+https://www.soundcloud.com/...
+http://www.soundcloud.com/...
+http://soundcloud.com/...
+//soundcloud.com/...
+soundcloud.com/...
+```
+
+If you run across a URL pattern that you think should work, but doesn’t, please [file an issue](https://github.com/gfscott/eleventy-plugin-embed-soundcloud/issues/new)!
+
+## ⚠️ Notes and caveats
+
+- 📞 Unlike most plugins in the [Embed Everything](https://www.npmjs.com/package/eleventy-plugin-embed-everything) family, this one must make a network request to retrieve the relevant embed URLs. This is because SoundCloud widget `iframe src` URLs have no relationship to SoundCloud website URLs. I agree this is irritating, but it’s how the service works. Be aware that using this plugin **will** cause network requests during Eleventy’s build process. If the plugin experiences any network failure (such as if you're not connected to the internet), then it simply won’t complete the embed and the URL will be rendered as plain text.
+- SoundCloud has a bunch of embed settings that are available only to its “Pro Unlimited” accounts, such as a [mini-player style](https://help.soundcloud.com/hc/en-us/articles/115003449027-The-Mini-embedded-player). It’s pretty unlikely that this plugin will ever support SoundCloud’s paid embedding features.
+- This plugin is deliberately designed _only_ to embed players when the URL is on its own line, and not inline with other text.
+- To do this, it uses [a regular expression](lib/spotPattern.js) to recognize SoundCloud URLs. Currently these are the limitations on what it can recognize in a Markdown parser’s HTML output:
+  - The URL *must* be wrapped in a paragraph tag: `<p>`
+  - It *may* also be wrapped in an anchor tag, (*inside* the paragraph): `<a>`
+  - The URL string *may* have whitespace around it
+- I’ve tried to accommodate common URL variants, but there are conceivably valid SoundCloud URLs that wouldn’t get recognized. Please [file an issue](https://github.com/gfscott/eleventy-plugin-embed-soundcloud/issues/new) if you run into an edge case!
+- This plugin uses [transforms](https://www.11ty.dev/docs/config/#transforms), so it alters Eleventy’s HTML output as it’s generated. It doesn’t alter the source Markdown.

--- a/packages/soundcloud/lib/configEmbed.js
+++ b/packages/soundcloud/lib/configEmbed.js
@@ -1,0 +1,34 @@
+module.exports = function(str, options) {
+
+  // convenience setting to use the smaller player, overrides visual and height
+  if ( options.small ) {
+    options.visual = false
+    options.height = 166
+  }
+  
+  // get the iframe src as provided by SoundCloud
+  let [, src] = str.match(/src="(.+?)"/);
+  
+  // parse the "url" param to get the track URL
+  let embedUrl = new URL(src).searchParams.get('url');
+  
+  // compile the player params
+  let params = '';
+  for ( let option in options ){
+    // stuff not set with URL params
+    const exclude = ['height', 'width', 'small', 'embedClass'];
+    if ( exclude.indexOf(option) < 0 ) {
+      params += `${option}=${encodeURIComponent(options[option])}&`;
+    } else {
+      params += '';
+    }
+  }
+
+  // build the embed HTML
+  let out = `<div class="${options.embedClass}">`;
+      out += `<iframe title="${options.iframeTitle}" width="${options.width}" height="${options.height}" scrolling="no" frameborder="no" allow="autoplay" `;
+      out += `src="https://w.soundcloud.com/player/?url=${encodeURIComponent(embedUrl)}&${params}"></iframe>`;
+      out += `</div>`;
+
+  return out;
+}

--- a/packages/soundcloud/lib/getEmbed.js
+++ b/packages/soundcloud/lib/getEmbed.js
@@ -1,0 +1,22 @@
+const Cache = require("@11ty/eleventy-fetch");
+const sc = 'https://soundcloud.com';
+const configEmbed = require('./configEmbed.js');
+const pattern = /<p>\s*(?:<a.*>)?\s*(?:https?)?(?::\/\/)?(?:soundcloud\.com)(\/\S+?)(?:\?\S+)?\s*(?:<\/a>)?\s*<\/p>/;
+
+module.exports = async function(str, options) {
+  let [ , id ] = str.match(pattern);
+  let url = `${sc}/oembed?url=${encodeURIComponent(sc + id)}&format=json`;
+  try {
+    let json = await Cache(url, {
+      duration: options.cacheDuration,
+      type: 'json'
+    });
+    // grab the track title for iframe a11y
+    options.iframeTitle = json.title || 'Embedded SoundCloud track';
+    let out = await configEmbed(json.html, options);
+    return out;
+  } catch (err) {
+    console.error("Error communicating with SoundCloud’s servers: ", err);
+    return str;
+  }
+}

--- a/packages/soundcloud/lib/pluginDefaults.js
+++ b/packages/soundcloud/lib/pluginDefaults.js
@@ -1,0 +1,21 @@
+// Mostly follows SoundCloud embed defaults
+// https://developers.soundcloud.com/docs/api/html5-widget
+
+module.exports = {
+  auto_play: false,
+  cacheDuration: '5m',
+  color: '#ff7700',
+  embedClass: 'eleventy-plugin-embed-soundcloud',
+  height: 400,
+  sharing: true,
+  show_artwork: true,
+  show_comments: true,
+  show_playcount: true,
+  show_reposts: false,
+  show_teaser: false,
+  show_user: true,
+  small: false,
+  single_active: true,
+  visual: true,
+  width: '100%'
+};

--- a/packages/soundcloud/lib/spotPattern.js
+++ b/packages/soundcloud/lib/spotPattern.js
@@ -1,0 +1,5 @@
+const pattern = /<p>\s*(?:<a.*>)?\s*(?:https?)?(?::)?(?:\/\/)?(?:w{3}\.)?(?:soundcloud\.com)(?:\/\S+)\s*(?:<\/a>)?\s*<\/p>/g;
+
+module.exports = function(str) {
+  return str.match(pattern);
+}

--- a/packages/soundcloud/package.json
+++ b/packages/soundcloud/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "eleventy-plugin-embed-soundcloud",
+  "version": "1.2.5",
+  "description": "An Eleventy plugin to automatically embed SoundCloud players, using just their URLs.",
+  "keywords": [
+    "11ty",
+    "eleventy",
+    "eleventy-plugin",
+    "soundcloud"
+  ],
+  "main": ".eleventy.js",
+  "scripts": {
+    "test": "npx ava"
+  },
+  "ava": {
+    "files": [
+      "!test/inc"
+    ]
+  },
+  "author": {
+    "name": "Graham F. Scott",
+    "email": "gfscott@gmail.com",
+    "url": "https://gfscott.com"
+  },
+  "license": "MIT",
+  "homepage": "https://gfscott.com/embed-everything/",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gfscott/eleventy-plugin-embed-soundcloud.git"
+  },
+  "bugs": "https://github.com/gfscott/eleventy-plugin-embed-soundcloud/issues",
+  "devDependencies": {
+    "ava": "^5.1.0"
+  },
+  "dependencies": {
+    "@11ty/eleventy-fetch": "^3.0.0"
+  }
+}

--- a/packages/soundcloud/package.json
+++ b/packages/soundcloud/package.json
@@ -10,8 +10,13 @@
   ],
   "main": ".eleventy.js",
   "scripts": {
-    "test": "npx ava"
+    "test": "npx ava",
+    "coverage": "nyc --reporter=lcov ava"
   },
+  "files": [
+    ".eleventy.js",
+    "lib/**"
+  ],
   "ava": {
     "files": [
       "!test/inc"
@@ -26,12 +31,9 @@
   "homepage": "https://gfscott.com/embed-everything/",
   "repository": {
     "type": "git",
-    "url": "https://github.com/gfscott/eleventy-plugin-embed-soundcloud.git"
+    "url": "https://github.com/gfscott/eleventy-plugin-embed-everything.git"
   },
-  "bugs": "https://github.com/gfscott/eleventy-plugin-embed-soundcloud/issues",
-  "devDependencies": {
-    "ava": "^5.1.0"
-  },
+  "bugs": "https://github.com/gfscott/eleventy-plugin-embed-everything/issues",
   "dependencies": {
     "@11ty/eleventy-fetch": "^3.0.0"
   }

--- a/packages/soundcloud/test/getEmbed.test.js
+++ b/packages/soundcloud/test/getEmbed.test.js
@@ -1,0 +1,59 @@
+const test = require('ava');
+const getEmbed = require('../lib/getEmbed.js');
+const pluginDefaults = require('../lib/pluginDefaults.js');
+
+const artistUrl = '<p>https://soundcloud.com/earlxsweatshirtmusic</p>';
+const trackUrl = '<p>https://soundcloud.com/earlxsweatshirtmusic/tisktisk-cookies</p>';
+const setUrl = '<p>https://soundcloud.com/earlxsweatshirtmusic/sets/earl-15</p>';
+const badUrl = '<p>https://soundcloud.com/earlxsweatshirtmusicbutnonexistent</p>';
+const expectedArtistOutput = '<div class="eleventy-plugin-embed-soundcloud"><iframe title="Earl Sweatshirt" width="100%" height="400" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A%2F%2Fapi.soundcloud.com%2Fusers%2F24883142&auto_play=false&cacheDuration=5m&color=%23ff7700&sharing=true&show_artwork=true&show_comments=true&show_playcount=true&show_reposts=false&show_teaser=false&show_user=true&single_active=true&visual=true&iframeTitle=Earl%20Sweatshirt&"></iframe></div>';
+const expectedTrackOutput = '<div class="eleventy-plugin-embed-soundcloud"><iframe title="TISK TISK / COOKIES by Earl Sweatshirt" width="100%" height="400" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A%2F%2Fapi.soundcloud.com%2Ftracks%2F706125730&auto_play=false&cacheDuration=5m&color=%23ff7700&sharing=true&show_artwork=true&show_comments=true&show_playcount=true&show_reposts=false&show_teaser=false&show_user=true&single_active=true&visual=true&iframeTitle=TISK%20TISK%20%2F%20COOKIES%20by%20Earl%20Sweatshirt&"></iframe></div>';
+const expectedSetOutput = '<div class="eleventy-plugin-embed-soundcloud"><iframe title="Earl by Earl Sweatshirt" width="100%" height="400" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A%2F%2Fapi.soundcloud.com%2Fplaylists%2F284902110&auto_play=false&cacheDuration=5m&color=%23ff7700&sharing=true&show_artwork=true&show_comments=true&show_playcount=true&show_reposts=false&show_teaser=false&show_user=true&single_active=true&visual=true&iframeTitle=Earl%20by%20Earl%20Sweatshirt&"></iframe></div>';
+
+const smallPlayer = Object.assign({}, pluginDefaults, {small: true});
+const expectedArtistOutput_sm = '<div class="eleventy-plugin-embed-soundcloud"><iframe title="Earl Sweatshirt" width="100%" height="166" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A%2F%2Fapi.soundcloud.com%2Fusers%2F24883142&auto_play=false&cacheDuration=5m&color=%23ff7700&sharing=true&show_artwork=true&show_comments=true&show_playcount=true&show_reposts=false&show_teaser=false&show_user=true&single_active=true&visual=false&iframeTitle=Earl%20Sweatshirt&"></iframe></div>';
+const expectedTrackOutput_sm = '<div class="eleventy-plugin-embed-soundcloud"><iframe title="TISK TISK / COOKIES by Earl Sweatshirt" width="100%" height="166" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A%2F%2Fapi.soundcloud.com%2Ftracks%2F706125730&auto_play=false&cacheDuration=5m&color=%23ff7700&sharing=true&show_artwork=true&show_comments=true&show_playcount=true&show_reposts=false&show_teaser=false&show_user=true&single_active=true&visual=false&iframeTitle=TISK%20TISK%20%2F%20COOKIES%20by%20Earl%20Sweatshirt&"></iframe></div>';
+const expectedSetOutput_sm = '<div class="eleventy-plugin-embed-soundcloud"><iframe title="Earl by Earl Sweatshirt" width="100%" height="166" scrolling="no" frameborder="no" allow="autoplay" src="https://w.soundcloud.com/player/?url=https%3A%2F%2Fapi.soundcloud.com%2Fplaylists%2F284902110&auto_play=false&cacheDuration=5m&color=%23ff7700&sharing=true&show_artwork=true&show_comments=true&show_playcount=true&show_reposts=false&show_teaser=false&show_user=true&single_active=true&visual=false&iframeTitle=Earl%20by%20Earl%20Sweatshirt&"></iframe></div>';
+
+
+/**
+ * For the three supported URL types, check that the plugin produces 
+ * the expected markup
+ */
+test(`Artist URL`, async t => {
+  let out = await getEmbed(artistUrl, pluginDefaults);
+  t.is(out, expectedArtistOutput);
+});
+test(`Track URL`, async t => {
+  let out = await getEmbed(trackUrl, pluginDefaults);
+  t.is(out, expectedTrackOutput);
+});
+test(`Set URL`, async t => {
+  let out = await getEmbed(setUrl, pluginDefaults);
+  t.is(out, expectedSetOutput);
+});
+
+/**
+ * For the three supported URL types, check that the plugin produces 
+ * the expected markup with the "small" embed type specified
+ */
+test(`Artist URL, small version`, async t => {
+  let out = await getEmbed(artistUrl, smallPlayer);
+  t.is(out, expectedArtistOutput_sm);
+});
+test(`Track URL, small version`, async t => {
+  let out = await getEmbed(trackUrl, smallPlayer);
+  t.is(out, expectedTrackOutput_sm);
+});
+test(`Set URL, small version`, async t => {
+  let out = await getEmbed(setUrl, smallPlayer);
+  t.is(out, expectedSetOutput_sm);
+});
+
+/**
+ * On request failure, return the URL unchanged
+ */
+test(`oEmbed fetch failure`, async t => {
+  let out = await getEmbed(badUrl, pluginDefaults);
+  t.is(out, badUrl);
+});

--- a/packages/soundcloud/test/inc/invalidUrls.js
+++ b/packages/soundcloud/test/inc/invalidUrls.js
@@ -1,0 +1,19 @@
+/**
+ * INVALID URLS
+ * 
+ * Starting with the list of valid URLs, return a list of
+ * invalid strings with text prepended or appended.
+ */
+
+const validUrls = require('./validUrls.js');
+
+const prependedText = validUrls.map(url => {
+  return `Foo ${url}`;
+});
+const appendedText = validUrls.map(url => {
+  return `${url} Foo`;
+});
+
+const invalidUrls = prependedText.concat(appendedText);
+
+module.exports = invalidUrls;

--- a/packages/soundcloud/test/inc/permuteArrays.js
+++ b/packages/soundcloud/test/inc/permuteArrays.js
@@ -1,0 +1,65 @@
+/**
+ * 
+ * @param {String OR Array} term 
+ * @param {Array} prefixes 
+ * @param {Array} suffixes
+ * @returns An array containing all possible permutations 
+ *          of the term for all prefixes and suffixes
+ */
+module.exports = function(term, prefixes, suffixes) {
+  let out = [].concat(prependEach(term, prefixes));
+  out = out.concat(appendEach(out, suffixes));
+  return out;
+}
+
+/**
+ * 
+ * @param {Array | String} term 
+ * @param {Array} prefixes 
+ * @returns An array of each term, prepended with each prefix
+ */
+const prependEach = (term, prefixes) => {  
+  let arr = coerceToArray(term);
+  let out = [];
+  for (let prefix of prefixes){
+    for (let item of arr){
+      out.push(prefix + item)
+    }
+  }
+  return out;
+}
+
+/**
+ * 
+ * @param {Array | String} term 
+ * @param {Array} suffixes 
+ * @returns An array of each term, appended with each prefix
+ */
+const appendEach = (term, suffixes) => {
+  let arr = coerceToArray(term);
+  let out = [];
+  for (let suffix of suffixes) {
+    for (let item of arr){
+      out.push(item + suffix)
+    }
+  }
+  return out;
+}
+
+/**
+ * Coerce a string to a one-item array.
+ * @param {*} mysteryObject 
+ * @returns Array containing one or more items
+ * 
+ * Given an object, check its type. If it's an array, return it.
+ * If if it’s a string, return an array with that string as its
+ * only item.
+ */
+const coerceToArray = (mysteryObject) => {
+  if ( Array.isArray(mysteryObject) ) {
+    return mysteryObject;
+  }
+  if ( typeof mysteryObject === 'string' ) {
+    return [].concat(mysteryObject);
+  }
+}

--- a/packages/soundcloud/test/inc/validUrls.js
+++ b/packages/soundcloud/test/inc/validUrls.js
@@ -1,0 +1,32 @@
+/**
+ * VALID URLS
+ *
+ * Starting with a short list of valid URL fragments, return
+ * all possible valid URL permutations.
+ */
+
+const permute = require('./permuteArrays.js');
+
+/**
+ * Core URL structures accepted by the plugin
+ * Domain and path only
+ */
+const validUrls = [
+  'soundcloud.com/earlxsweatshirtmusic',
+  'soundcloud.com/earlxsweatshirtmusic/tisktisk-cookies',
+  'soundcloud.com/earlxsweatshirtmusic/sets/earl-15'
+]
+
+/**
+ * Non-core URL structures accepted by the plugin
+ * Various protocol variants and URL parameters
+ */
+const validPrefixes = ['', '//', 'http://', 'https://', 'www.', '//www.', 'http://www.', 'https://www.']
+const validSuffixes = ['?', '?foo', '?foo=bar']
+
+/**
+ * Cumulative lists of all URL permutations.
+ */
+const goodUrls = permute(validUrls, validPrefixes, validSuffixes);
+
+module.exports = goodUrls;

--- a/packages/soundcloud/test/test-spotPattern.js
+++ b/packages/soundcloud/test/test-spotPattern.js
@@ -1,0 +1,72 @@
+const test = require('ava');
+const spotPattern = require('../lib/spotPattern.js');
+const validUrls = require('./inc/validUrls.js');
+const invalidUrls = require('./inc/invalidUrls.js');
+
+/**
+ * =====================================================
+ * For all possible valid URLs, test that the pattern is
+ * spotted correctly.
+ * 
+ * Getting indexes with a for...of loop:
+ * https://reactgo.com/javascript-get-index-for-of-loop/
+ */
+for (let [index, url] of validUrls.entries()) {
+  
+  test(`Valid-${index}: without link, without whitespace`, t => {
+    t.truthy(spotPattern(`<p>${url}</p>`));
+  }); 
+  
+  test(`Valid-${index}: without link, with whitespace`, t => {
+    t.truthy(spotPattern(`<p>
+      ${url}
+    </p>`));
+  }); 
+  
+  test(`Valid-${index}: with link, without whitespace`, t => {
+    t.truthy(spotPattern(`<p><a href="${url}">${url}</a></p>`));
+  }); 
+
+  test(`Valid-${index}: with link, with whitespace`, t => {
+    t.truthy(spotPattern(`<p>
+      <a href="${url}">
+        ${url}
+      </a>
+    </p>`));
+  });
+
+}
+
+/**
+ * =======================================================
+ * For all possible invalid URLs, test that the pattern is
+ * rejected correctly.
+ * 
+ * Getting indexes with a for...of loop:
+ * https://reactgo.com/javascript-get-index-for-of-loop/
+ */
+ for (let [index, url] of invalidUrls.entries()) {
+  
+  test(`Invalid-${index}: without link, without whitespace`, t => {
+    t.falsy(spotPattern(`<p>${url}</p>`));
+  }); 
+  
+  test(`Invalid-${index}: without link, with whitespace`, t => {
+    t.falsy(spotPattern(`<p>
+      ${url}
+    </p>`));
+  }); 
+  
+  test(`Invalid-${index}: with link, without whitespace`, t => {
+    t.falsy(spotPattern(`<p><a href="${url}">${url}</a></p>`));
+  }); 
+
+  test(`Invalid-${index}: with link, with whitespace`, t => {
+    t.falsy(spotPattern(`<p>
+      <a href="${url}">
+        ${url}
+      </a>
+    </p>`));
+  });
+
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,7 +19,7 @@ importers:
     specifiers:
       deepmerge: ^4.2.2
       eleventy-plugin-embed-instagram: ^1.2.5
-      eleventy-plugin-embed-soundcloud: ^1.2.5
+      eleventy-plugin-embed-soundcloud: workspace:^
       eleventy-plugin-embed-spotify: workspace:^
       eleventy-plugin-embed-tiktok: ^1.1.5
       eleventy-plugin-embed-twitch: ^1.2.5
@@ -29,13 +29,19 @@ importers:
     dependencies:
       deepmerge: 4.2.2
       eleventy-plugin-embed-instagram: 1.2.5
-      eleventy-plugin-embed-soundcloud: 1.2.5
+      eleventy-plugin-embed-soundcloud: link:../soundcloud
       eleventy-plugin-embed-spotify: link:../spotify
       eleventy-plugin-embed-tiktok: 1.1.5
       eleventy-plugin-embed-twitch: 1.2.5
       eleventy-plugin-embed-twitter: 1.3.5
       eleventy-plugin-vimeo-embed: 1.3.5
       eleventy-plugin-youtube-embed: 1.8.0
+
+  packages/soundcloud:
+    specifiers:
+      '@11ty/eleventy-fetch': ^3.0.0
+    dependencies:
+      '@11ty/eleventy-fetch': 3.0.0
 
   packages/spotify:
     specifiers: {}
@@ -1140,15 +1146,6 @@ packages:
 
   /eleventy-plugin-embed-instagram/1.2.5:
     resolution: {integrity: sha512-H6kBOuh7cvHOhdzSiG75cMFMPSszB9rizyNwU07WBV4sqKe0Lzm4M5CidQOf1GvwpHPQRwJUHcaYe/pQsub9KQ==}
-    dev: false
-
-  /eleventy-plugin-embed-soundcloud/1.2.5:
-    resolution: {integrity: sha512-aKB6wEHcvUkLvPrrCz6gKkzg/hKcmn771CcpmfIozOpXp4/F+k2UcxctSt1KX73RdJJFn9dJDjz53fEO++GVvw==}
-    dependencies:
-      '@11ty/eleventy-fetch': 3.0.0
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
     dev: false
 
   /eleventy-plugin-embed-tiktok/1.1.5:


### PR DESCRIPTION
This PR migrates the `eleventy-plugin-embed-soundcloud` package into the monorepo. As with the previous migration (#128), it includes the complete version history of the original repo.