### PR TITLE
Monorepo migration: Instagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ As of early 2023, all the plugins in this collection reside in their own repos, 
 
 Service | Package | Repository | Migrated?
 ------- | ------- | ---------- | ---------
-Instagram   | [npm](https://www.npmjs.com/package/eleventy-plugin-embed-instagram)  | [GitHub](https://github.com/gfscott/eleventy-plugin-embed-instagram)  | No
+Instagram   | [npm](https://www.npmjs.com/package/eleventy-plugin-embed-instagram)  | [GitHub](https://github.com/gfscott/eleventy-plugin-embed-everything/tree/main/packages/instagram)  | Yes
 SoundCloud  | [npm](https://www.npmjs.com/package/eleventy-plugin-embed-soundcloud) | [GitHub](https://github.com/gfscott/eleventy-plugin-embed-everything/tree/main/packages/soundcloud) | Yes
 Spotify     | [npm](https://www.npmjs.com/package/eleventy-plugin-embed-spotify)    | [GitHub](https://github.com/gfscott/eleventy-plugin-embed-everything/tree/main/packages/spotify)    | Yes
 TikTok      | [npm](https://www.npmjs.com/package/eleventy-plugin-embed-tiktok)     | [GitHub](https://github.com/gfscott/eleventy-plugin-embed-everything/tree/main/packages/tiktok)     | Yes 

--- a/packages/everything/package.json
+++ b/packages/everything/package.json
@@ -30,7 +30,7 @@
   "license": "MIT",
   "dependencies": {
     "deepmerge": "^4.2.2",
-    "eleventy-plugin-embed-instagram": "^1.2.5",
+    "eleventy-plugin-embed-instagram": "workspace:^",
     "eleventy-plugin-embed-soundcloud": "workspace:^",
     "eleventy-plugin-embed-spotify": "workspace:^",
     "eleventy-plugin-embed-tiktok": "workspace:^",

--- a/packages/instagram/.eleventy.js
+++ b/packages/instagram/.eleventy.js
@@ -1,0 +1,24 @@
+const patternPresent = require('./lib/spotPattern.js');
+const extractId = require('./lib/extractMatches.js');
+const buildEmbed = require('./lib/buildEmbed.js');
+const pluginDefaults = require('./lib/pluginDefaults.js');
+
+module.exports = function (eleventyConfig, options) {
+  const pluginConfig = Object.assign(pluginDefaults, options);
+  eleventyConfig.addTransform("embedInstagram", async (content, outputPath) => {
+    if (outputPath && outputPath.endsWith(".html")) {
+      let matches = patternPresent(content);
+      if (!matches) {
+        return content;
+      }
+      // index is used to limit the number of script tags added to each page to one
+      matches.forEach(function (stringToReplace, index) {
+        let mediaId = extractId(stringToReplace);
+        let embedCode = buildEmbed(mediaId, pluginConfig, index);
+        content = content.replace(stringToReplace, embedCode);
+      });
+      return content;
+    }
+    return content;
+  });
+};

--- a/packages/instagram/README.md
+++ b/packages/instagram/README.md
@@ -1,0 +1,98 @@
+# eleventy-plugin-embed-instagram
+
+[![NPM Version](https://img.shields.io/npm/v/eleventy-plugin-embed-instagram?style=for-the-badge)](https://www.npmjs.com/package/eleventy-plugin-embed-instagram)
+[![Build test status](https://img.shields.io/github/actions/workflow/status/gfscott/eleventy-plugin-embed-instagram/test-and-codecov.yml?branc=main&style=for-the-badge)](https://github.com/gfscott/eleventy-plugin-embed-instagram/actions?query=workflow%3A%22Node.js+CI+and+Codecov%22)
+[![codecov](https://img.shields.io/codecov/c/github/gfscott/eleventy-plugin-embed-instagram?style=for-the-badge)](https://codecov.io/gh/gfscott/eleventy-plugin-embed-instagram)\
+[![MIT License](https://img.shields.io/github/license/gfscott/eleventy-plugin-embed-instagram?style=for-the-badge)](https://github.com/gfscott/eleventy-plugin-embed-instagram/blob/master/LICENSE)
+[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v2.0-ff69b4.svg?style=for-the-badge)](CODE_OF_CONDUCT.md)
+
+This [Eleventy](https://www.11ty.dev/) plugin automatically embeds Instagram photos and videos from URLs in markdown files.
+
+## Install in Eleventy
+
+In your Eleventy project, [install the plugin](https://www.11ty.dev/docs/plugins/#adding-a-plugin) through npm:
+
+```sh
+$ npm i eleventy-plugin-embed-instagram
+```
+
+Then add it to your [Eleventy config](https://www.11ty.dev/docs/config/) file (usually `.eleventy.js`):
+
+```javascript
+const embedInstagram = require("eleventy-plugin-embed-instagram");
+
+module.exports = function(eleventyConfig) {
+  eleventyConfig.addPlugin(embedInstagram);
+};
+```
+
+## Usage
+
+To embed an Instagram photo or video into any markdown page, paste its URL into a new line. The URL should be the only thing on that line.
+
+### Markdown file example:
+
+```markdown
+...
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam vehicula, elit vel condimentum porta, purus.
+
+https://www.instagram.com/p/B9XK4J3jVui/
+
+Maecenas non velit nibh. Aenean eu justo et odio commodo ornare. In scelerisque sapien at.
+
+...
+```
+
+### Result:
+
+![Screenshot of an Instagram photo of pine trees in fog](https://user-images.githubusercontent.com/547470/76152810-1b6f6b80-6092-11ea-832e-e231f0942c8b.png)
+
+The plugin supports common URL variants as well. These will also work:
+
+```markdown
+<!-- No protocol: -->
+
+instagram.com/p/B9XK4J3jVui/
+www.instagram.com/p/B9XK4J3jVui/
+
+<!-- With or without HTTPS: -->
+
+http://www.instagram.com/p/B9XK4J3jVui/
+https://www.instagram.com/p/B9XK4J3jVui/
+
+<!-- With or without 'www': -->
+
+https://www.instagram.com/p/B9XK4J3jVui/
+https://instagram.com/p/B9XK4J3jVui/
+
+<!-- URLs with extra parameters: -->
+https://www.instagram.com/p/B9XK4J3jVui/?foo=bar
+
+```
+
+## Notes and caveats
+
+- This plugin is deliberately designed _only_ to embed when the URL is on its own line, and not inline with other text.
+- To do this, it uses a regular expression to recognize Instagram URLs, wrapped in an HTML `<p>` tag. If your Markdown parser produces any other output, it won’t be recognized.
+- I’ve tried to [accommodate common variants](https://regex101.com/r/cwLcjL/5), but there are conceivably valid Instagram URLs that wouldn’t get recognized. Please [file an issue](https://github.com/gfscott/eleventy-plugin-embed-instagram/issues/new) if you run into an edge case!
+- This plugin uses [transforms](https://www.11ty.dev/docs/config/#transforms), so it alters Eleventy’s HTML output as it’s generated. It doesn’t alter the source markdown.
+- By necessity, this plugin will add a call to Instagram’s third-party javascript file. It does this once per page, if that page contains an Instagram embed.
+- Because the aspect ratio of Instagram media can vary widely, the embed is not currently responsive. By default, Instagram’s script injects an iframe with a hard-coded width of 326 pixels. I’ve opted to lead this default behavior intact.
+- To make your Instagram embeds responsive, you can change their widths with CSS. Give them a standard pixel size, or set them to fill their full available horizontal width. Instagram’s embed script will automatically upscale them to fill the available space.
+
+```css
+.eleventy-plugin-embed-instagram {
+  width: 100%;
+}
+```
+
+- You can change the class name to whatever you prefer by passing an options object when you configure the plugin in your `.eleventy.js` file:
+```javascript
+module.exports = function(eleventyConfig) {
+  eleventyConfig.addPlugin(embedInstagram, {
+    embedClass: 'alternate-class-string'
+});
+};
+```
+

--- a/packages/instagram/lib/buildEmbed.js
+++ b/packages/instagram/lib/buildEmbed.js
@@ -1,0 +1,10 @@
+module.exports = function(id, options, index) {
+  let out = '<blockquote ';
+    // class MUST include "instagram-media" because Instagram's script uses it for DOM parsing
+    out += `class="${options.embedClass} instagram-media"`;
+    out += ` data-instgrm-permalink="https://www.instagram.com/p/${id}">`;
+    out += '</blockquote>';
+    // Only add the script tag on the first instance per page, otherwise script tag added multiple times
+    out += index === 0 ? '<script async defer src="https://www.instagram.com/embed.js"></script>' : '';
+    return out;
+}

--- a/packages/instagram/lib/extractMatches.js
+++ b/packages/instagram/lib/extractMatches.js
@@ -1,0 +1,29 @@
+/**
+ * Regular expression to extract the Instagram ID from the URL.
+ * 
+ * Why out[3]?
+ * -----------
+ * `\s*`, necessary to accomodate arbitrary whitespace, is 
+ * vulnerable to catastrophic backtracking that can lead to 
+ * regular expression denial-of-service. JS/Node doesn’t support
+ * RegEx atomic groups like other languages do. The workaround
+ * requires capturing groups for whitespace with positive
+ * lookaheads:
+ * 
+ * https://blog.stevenlevithan.com/archives/mimic-atomic-groups
+ * 
+ * Until we formally drop support for Node 8 and can start using
+ * named capture groups, we have to count matches in the returned
+ * RegEx array.
+ *  
+ * out[0]           = full match
+ * out[1], out[2]   = optional whitespace characters 
+ * out[3]           = Instagram media ID
+ * out[4], out[5]   = optional whitespace characters
+ */
+
+const pattern = /<p>(?=(\s*))\1(?:<a [^>]*?>)??(?=(\s*))\2(?:https?:\/\/)?(?:w{3}\.)?(?:instagram\.com)\/(?:p\/)?([0-9a-zA-Z-_]{11})(?:\S*)(?=(\s*))\4(?:<\/a>)?(?=(\s*))\5<\/p>/;
+module.exports = function(str) {
+  let out = pattern.exec(str);
+  return out[3];
+}

--- a/packages/instagram/lib/pluginDefaults.js
+++ b/packages/instagram/lib/pluginDefaults.js
@@ -1,0 +1,3 @@
+module.exports = {
+  embedClass: 'eleventy-plugin-embed-instagram'
+}

--- a/packages/instagram/lib/spotPattern.js
+++ b/packages/instagram/lib/spotPattern.js
@@ -1,0 +1,4 @@
+const pattern = /<p>(?=(\s*))\1(?:<a [^>]*?>)??(?=(\s*))\2(?:https?:\/\/)?(?:w{3}\.)?(?:instagram\.com\/p\/)(?:[0-9a-zA-Z_-]{11})[^\s]*?(?=(\s*))\3(?:<\/a>)??(?=(\s*))\4<\/p>/g;
+module.exports = function(str) {
+  return str.match(pattern);
+}

--- a/packages/instagram/package.json
+++ b/packages/instagram/package.json
@@ -10,9 +10,13 @@
   ],
   "main": ".eleventy.js",
   "scripts": {
-    "test": "nyc --reporter=lcov ava",
-    "coverage": "coverage"
+    "test": "npx ava",
+    "coverage": "nyc --reporter=lcov ava"
   },
+  "files": [
+    ".eleventy.js",
+    "lib/**"
+  ],
   "author": {
     "name": "Graham F. Scott",
     "email": "gfscott@gmail.com",
@@ -22,14 +26,7 @@
   "homepage": "https://gfscott.com/embed-everything/",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/gfscott/eleventy-plugin-embed-instagram.git"
+    "url": "https://github.com/gfscott/eleventy-plugin-embed-everything.git"
   },
-  "bugs": {
-    "url": "https://github.com/gfscott/eleventy-plugin-embed-instagram/issues"
-  },
-  "devDependencies": {
-    "ava": "^5.1.0",
-    "codecov": "^3.8.3",
-    "nyc": "^15.1.0"
-  }
+  "bugs": "https://github.com/gfscott/eleventy-plugin-embed-everything/issues"
 }

--- a/packages/instagram/package.json
+++ b/packages/instagram/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "eleventy-plugin-embed-instagram",
+  "version": "1.2.5",
+  "description": "An Eleventy plugin to automatically embed Instagram photos and videos, using just their URLs.",
+  "keywords": [
+    "11ty",
+    "eleventy",
+    "eleventy-plugin",
+    "instagram"
+  ],
+  "main": ".eleventy.js",
+  "scripts": {
+    "test": "nyc --reporter=lcov ava",
+    "coverage": "coverage"
+  },
+  "author": {
+    "name": "Graham F. Scott",
+    "email": "gfscott@gmail.com",
+    "url": "https://gfscott.com"
+  },
+  "license": "MIT",
+  "homepage": "https://gfscott.com/embed-everything/",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/gfscott/eleventy-plugin-embed-instagram.git"
+  },
+  "bugs": {
+    "url": "https://github.com/gfscott/eleventy-plugin-embed-instagram/issues"
+  },
+  "devDependencies": {
+    "ava": "^5.1.0",
+    "codecov": "^3.8.3",
+    "nyc": "^15.1.0"
+  }
+}

--- a/packages/instagram/test.js
+++ b/packages/instagram/test.js
@@ -1,0 +1,176 @@
+const test = require('ava');
+const patternPresent = require('./lib/spotPattern.js');
+const extractId = require('./lib/extractMatches.js');
+const buildEmbed = require('./lib/buildEmbed.js');
+const pluginDefaults = require('./lib/pluginDefaults.js');
+
+
+const validStrings = [
+  {type: 'Standard', str: 'https://www.instagram.com/p/B-rRt1MjKZD/'},
+  {type: 'With http', str: 'http://www.instagram.com/p/B-rRt1MjKZD/'},
+  {type: 'Without protocol', str: 'www.instagram.com/p/B-rRt1MjKZD/'},
+  {type: 'Without trailing slash', str: 'https://www.instagram.com/p/B-rRt1MjKZD'},
+  {type: 'With https, without www', str: 'https://instagram.com/p/B-rRt1MjKZD/'},
+  {type: 'With http, without www', str: 'https://www.instagram.com/p/B-rRt1MjKZD/'},
+  {type: 'Without https, without www', str: 'instagram.com/p/B-rRt1MjKZD/'},
+]
+
+const invalidStrings = [
+  {type: 'Incomplete photo ID', str: 'https://www.instagram.com/p/abcde/'},
+  {type: 'With prepended text', str: 'foo https://www.instagram.com/p/B-rRt1MjKZD/'},
+  {type: 'With malformed protocol', str: 'https//www.instagram.com/p/B-rRt1MjKZD/'},
+  {type: 'With prepended text, with link', str: 'foo <a href="">https://www.instagram.com/p/B-rRt1MjKZD/</a>'},
+  {type: 'With appended text', str: 'https://www.instagram.com/p/B-rRt1MjKZD/ bar'},
+  {type: 'With appended text, with link', str: '<a href="">https://www.instagram.com/p/B-rRt1MjKZD/</a> bar'},
+]
+
+/**
+ * Ensure that valid strings pass
+ */
+validStrings.forEach(function(obj){
+  test(`String is valid: ${obj.type} ideal case`, t => {
+    let idealCase = `<p>${obj.str}</p>`;
+    t.truthy(patternPresent(idealCase));
+  });
+  test(`String is valid: ${obj.type} with links`, t => {
+    let withLinks = `<p><a href="">${obj.str}</a></p>`;
+    t.truthy(patternPresent(withLinks));
+    });
+  test(`String is valid: ${obj.type} with whitespace`, t => {
+    let withWhitespace = `<p>
+      ${obj.str}
+    </p>`;
+    t.truthy(patternPresent(withWhitespace));
+  });
+  test(`String is valid: ${obj.type} with links and whitespace`, t => {
+    let withLinksAndWhitespace = `<p>
+      <a href="">
+        ${obj.str}
+      </a>
+    </p>`;
+    t.truthy(patternPresent(withLinksAndWhitespace));
+  });
+  test(`String is valid: ${obj.type} with links and whitespace surrounding wrapping paragraph`, t => {
+    let withLinksAndWhitespace = `   <p>
+      <a href="">
+        ${obj.str}
+      </a>
+    </p>   `;
+    t.truthy(patternPresent(withLinksAndWhitespace));
+  });
+});
+/**
+ * Ensure that valid strings produce the expected media ID as output
+ */
+validStrings.forEach(function(obj){
+  test(`Proper ID returned: ${obj.type} ideal case`, t => {
+    let idealCase = `<p>${obj.str}</p>`;
+    t.is(extractId(idealCase), 'B-rRt1MjKZD');
+  });
+  test(`Proper ID returned: ${obj.type} with links`, t => {
+    let withLinks = `<p><a href="">${obj.str}</a></p>`;
+    t.is(extractId(withLinks), 'B-rRt1MjKZD');
+  });
+  test(`Proper ID returned: ${obj.type} with whitespace`, t => {
+    let withWhitespace = `<p>
+      ${obj.str}
+    </p>`;
+    t.is(extractId(withWhitespace), 'B-rRt1MjKZD');
+  });
+  test(`Proper ID returned: ${obj.type} with links and whitespace`, t => {
+    let withLinksAndWhitespace = `<p>
+      <a href="">
+        ${obj.str}
+      </a>
+    </p>`;
+    t.is(extractId(withLinksAndWhitespace), 'B-rRt1MjKZD');
+  });
+});
+
+/**
+ * Ensure that build script produces expected HTML output on first instance
+ */
+validStrings.forEach(function(obj){
+  test(`Proper HTML output, zero-index: ${obj.type} ideal case`, t => {
+    let idealCase = `<p>${obj.str}</p>`;
+    t.is(buildEmbed(extractId(idealCase), pluginDefaults, 0),
+      `<blockquote class="eleventy-plugin-embed-instagram instagram-media" data-instgrm-permalink="https://www.instagram.com/p/B-rRt1MjKZD"></blockquote><script async defer src="https://www.instagram.com/embed.js"></script>`
+    );
+  });
+  test(`Proper HTML output, zero-index: ${obj.type} with links`, t => {
+    let withLinks = `<p><a href="">${obj.str}</a></p>`;
+    t.is(buildEmbed(extractId(withLinks), pluginDefaults, 0),
+      `<blockquote class="eleventy-plugin-embed-instagram instagram-media" data-instgrm-permalink="https://www.instagram.com/p/B-rRt1MjKZD"></blockquote><script async defer src="https://www.instagram.com/embed.js"></script>`
+    );
+  });
+  test(`Proper HTML output, zero-index: ${obj.type} with whitespace`, t => {
+    let withWhitespace = `<p>
+      ${obj.str}
+    </p>`;
+    t.is(buildEmbed(extractId(withWhitespace), pluginDefaults, 0),
+      `<blockquote class="eleventy-plugin-embed-instagram instagram-media" data-instgrm-permalink="https://www.instagram.com/p/B-rRt1MjKZD"></blockquote><script async defer src="https://www.instagram.com/embed.js"></script>`
+    );
+  });
+  test(`Proper HTML output, zero-index: ${obj.type} with links and whitespace`, t => {
+    let withLinksAndWhitespace = `<p>
+      <a href="">
+        ${obj.str}
+      </a>
+    </p>`;
+    t.is(buildEmbed(extractId(withLinksAndWhitespace), pluginDefaults, 0),
+      `<blockquote class="eleventy-plugin-embed-instagram instagram-media" data-instgrm-permalink="https://www.instagram.com/p/B-rRt1MjKZD"></blockquote><script async defer src="https://www.instagram.com/embed.js"></script>`
+    );
+  });
+});
+/**
+ * Ensure that valid strings pass
+ */
+validStrings.forEach(function(obj){
+  test(`Proper HTML output, >0 index: ${obj.type} ideal case`, t => {
+    let idealCase = `<p>${obj.str}</p>`;
+    t.is(buildEmbed(extractId(idealCase), pluginDefaults, 1),
+      `<blockquote class="eleventy-plugin-embed-instagram instagram-media" data-instgrm-permalink="https://www.instagram.com/p/B-rRt1MjKZD"></blockquote>`
+    );
+  });
+  test(`Proper HTML output, >0 index: ${obj.type} with links`, t => {
+    let withLinks = `<p><a href="">${obj.str}</a></p>`;
+    t.is(buildEmbed(extractId(withLinks), pluginDefaults, 1),
+      `<blockquote class="eleventy-plugin-embed-instagram instagram-media" data-instgrm-permalink="https://www.instagram.com/p/B-rRt1MjKZD"></blockquote>`
+    );
+  });
+  test(`Proper HTML output, >0 index: ${obj.type} with whitespace`, t => {
+    let withWhitespace = `<p>
+      ${obj.str}
+    </p>`;
+    t.is(buildEmbed(extractId(withWhitespace), pluginDefaults, 1),
+      `<blockquote class="eleventy-plugin-embed-instagram instagram-media" data-instgrm-permalink="https://www.instagram.com/p/B-rRt1MjKZD"></blockquote>`
+    );
+  });
+  test(`Proper HTML output, >0 index: ${obj.type} with links and whitespace`, t => {
+    let withLinksAndWhitespace = `<p>
+      <a href="">
+        ${obj.str}
+      </a>
+    </p>`;
+    t.is(buildEmbed(extractId(withLinksAndWhitespace), pluginDefaults, 1),
+      `<blockquote class="eleventy-plugin-embed-instagram instagram-media" data-instgrm-permalink="https://www.instagram.com/p/B-rRt1MjKZD"></blockquote>`
+    );
+  });
+});
+
+/**
+ * Ensure that invalid strings fail
+ */
+
+invalidStrings.forEach(function(obj){
+  test(`${obj.type} ideal case`, t => {
+    let idealCase = `<p>${obj.str}</p>`;
+    t.falsy(patternPresent(idealCase));
+  });
+  test(`${obj.type} with whitespace`, t => {
+    let withWhitespace = `<p>
+      ${obj.str}
+    </p>`;
+    t.falsy(patternPresent(withWhitespace));
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,7 +18,7 @@ importers:
   packages/everything:
     specifiers:
       deepmerge: ^4.2.2
-      eleventy-plugin-embed-instagram: ^1.2.5
+      eleventy-plugin-embed-instagram: workspace:^
       eleventy-plugin-embed-soundcloud: workspace:^
       eleventy-plugin-embed-spotify: workspace:^
       eleventy-plugin-embed-tiktok: workspace:^
@@ -28,7 +28,7 @@ importers:
       eleventy-plugin-youtube-embed: ^1.8.0
     dependencies:
       deepmerge: 4.2.2
-      eleventy-plugin-embed-instagram: 1.2.5
+      eleventy-plugin-embed-instagram: link:../instagram
       eleventy-plugin-embed-soundcloud: link:../soundcloud
       eleventy-plugin-embed-spotify: link:../spotify
       eleventy-plugin-embed-tiktok: link:../tiktok
@@ -36,6 +36,9 @@ importers:
       eleventy-plugin-embed-twitter: 1.3.5
       eleventy-plugin-vimeo-embed: 1.3.5
       eleventy-plugin-youtube-embed: 1.8.0
+
+  packages/instagram:
+    specifiers: {}
 
   packages/soundcloud:
     specifiers:
@@ -1146,10 +1149,6 @@ packages:
   /electron-to-chromium/1.4.284:
     resolution: {integrity: sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA==}
     dev: true
-
-  /eleventy-plugin-embed-instagram/1.2.5:
-    resolution: {integrity: sha512-H6kBOuh7cvHOhdzSiG75cMFMPSszB9rizyNwU07WBV4sqKe0Lzm4M5CidQOf1GvwpHPQRwJUHcaYe/pQsub9KQ==}
-    dev: false
 
   /eleventy-plugin-embed-twitch/1.2.5:
     resolution: {integrity: sha512-xYuE22/qkN42QjtTc6uTyj4+1rvz+xuPj5uYSibbFBWTrBUvhRUFj9fe3u/TBrLw89AB++ppTrYx9/wca1ASpQ==}


### PR DESCRIPTION
This PR migrates the eleventy-plugin-embed-instagram package into the monorepo. As with the previous migrations (starting with #128), it includes the complete version history of the original repo.