### PR TITLE
Monorepo migration: Vimeo

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,5 +18,5 @@ Spotify     | [npm](https://www.npmjs.com/package/eleventy-plugin-embed-spotify)
 TikTok      | [npm](https://www.npmjs.com/package/eleventy-plugin-embed-tiktok)     | [GitHub](https://github.com/gfscott/eleventy-plugin-embed-everything/tree/main/packages/tiktok)     | Yes 
 Twitch      | [npm](https://www.npmjs.com/package/eleventy-plugin-embed-twitch)     | [GitHub](https://github.com/gfscott/eleventy-plugin-embed-everything/tree/main/packages/twitch)     | Yes
 Twitter     | [npm](https://www.npmjs.com/package/eleventy-plugin-embed-twitter)    | [GitHub](https://github.com/gfscott/eleventy-plugin-embed-everything/tree/main/packages/twitter)    | Yes
-Vimeo       | [npm](https://www.npmjs.com/package/eleventy-plugin-vimeo-embed)      | [GitHub](https://github.com/gfscott/eleventy-plugin-vimeo-embed)      | No
+Vimeo       | [npm](https://www.npmjs.com/package/eleventy-plugin-vimeo-embed)      | [GitHub](https://github.com/gfscott/eleventy-plugin-embed-everything/tree/main/packages/vimeo)      | Yes
 YouTube     | [npm](https://www.npmjs.com/package/eleventy-plugin-youtube-embed)    | [GitHub](https://github.com/gfscott/eleventy-plugin-youtube-embed)    | No

--- a/packages/everything/package.json
+++ b/packages/everything/package.json
@@ -36,7 +36,7 @@
     "eleventy-plugin-embed-tiktok": "workspace:^",
     "eleventy-plugin-embed-twitch": "workspace:^",
     "eleventy-plugin-embed-twitter": "workspace:^",
-    "eleventy-plugin-vimeo-embed": "^1.3.5",
+    "eleventy-plugin-vimeo-embed": "workspace:^",
     "eleventy-plugin-youtube-embed": "^1.8.0"
   },
   "author": {

--- a/packages/vimeo/.eleventy.js
+++ b/packages/vimeo/.eleventy.js
@@ -1,0 +1,23 @@
+const patternPresent = require('./lib/spotPattern.js');
+const extractVideoId = require('./lib/extractMatches.js');
+const buildEmbedCodeString = require('./lib/buildEmbed.js');
+const pluginDefaults = require('./lib/pluginDefaults.js');
+
+module.exports = function(eleventyConfig, options) {
+  const pluginConfig = Object.assign(pluginDefaults, options);
+  eleventyConfig.addTransform("embedVimeo", async (content, outputPath) => {
+    if (outputPath && outputPath.endsWith(".html")) {
+      let matches = patternPresent(content);
+      if (!matches) {
+        return content;
+      }
+      matches.forEach(function (stringToReplace) {
+        let videoId = extractVideoId(stringToReplace);
+        let embedCode = buildEmbedCodeString(videoId, pluginConfig);
+        content = content.replace(stringToReplace, embedCode);
+      });
+      return content;
+    }
+    return content;
+  });
+};

--- a/packages/vimeo/README.md
+++ b/packages/vimeo/README.md
@@ -1,0 +1,120 @@
+# eleventy-plugin-vimeo-embed
+
+[![NPM Version](https://img.shields.io/npm/v/eleventy-plugin-vimeo-embed?style=for-the-badge)](https://www.npmjs.com/package/eleventy-plugin-vimeo-embed)
+[![Build test status](https://img.shields.io/github/actions/workflow/status/gfscott/eleventy-plugin-vimeo-embed/test-and-codecov.yml?branch=main&style=for-the-badge)](https://github.com/gfscott/eleventy-plugin-vimeo-embed/actions?query=workflow%3A%22Node.js+CI+and+Codecov%22)
+[![codecov](https://img.shields.io/codecov/c/github/gfscott/eleventy-plugin-vimeo-embed?style=for-the-badge)](https://codecov.io/gh/gfscott/eleventy-plugin-vimeo-embed)\
+[![MIT License](https://img.shields.io/github/license/gfscott/eleventy-plugin-vimeo-embed?style=for-the-badge)](https://github.com/gfscott/eleventy-plugin-vimeo-embed/blob/master/LICENSE)
+[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v2.0-ff69b4.svg?style=for-the-badge)](CODE_OF_CONDUCT.md)
+
+This [Eleventy](https://www.11ty.dev/) plugin automatically embeds responsive Vimeo videos from URLs in Markdown files.
+
+- ⚡️ [Installation](#install-in-eleventy)
+- 🛠 [Usage](#usage)
+- ⚙️ [Settings](#settings)
+- ⚠️ [Notes and caveats](#notes-and-caveats)
+
+---
+
+## ⚡️ Installation
+
+In your Eleventy project, [install the plugin](https://www.11ty.dev/docs/plugins/#adding-a-plugin) through npm:
+
+```sh
+$ npm i eleventy-plugin-vimeo-embed
+```
+
+Then add it to your [Eleventy config](https://www.11ty.dev/docs/config/) file:
+
+```javascript
+const embedVimeo = require("eleventy-plugin-vimeo-embed");
+
+module.exports = function(eleventyConfig) {
+  eleventyConfig.addPlugin(embedVimeo);
+};
+```
+
+## 🛠 Usage
+
+To embed a Vimeo video into any Markdown page, paste its URL into a new line. The URL should be the only thing on that line.
+
+### Markdown file example:
+
+```markdown
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam vehicula, elit vel condimentum porta, purus.
+
+https://vimeo.com/347565673
+
+Maecenas non velit nibh. Aenean eu justo et odio commodo ornare. In scelerisque sapien at.
+```
+
+### Result:
+
+![Screenshot of a Vimeo embed of Christian Stangl’s “The Comet”](https://user-images.githubusercontent.com/547470/75613532-cd3ff280-5afc-11ea-865a-1e02d41b2957.png)
+
+## ⚙️ Settings
+
+You can configure the plugin to change its behavior by passing an options object to the `addPlugin` function:
+
+```javascript
+eleventyConfig.addPlugin(embedVimeo, {
+  // edit options here
+});
+```
+
+### Plugin default options
+
+Edit any of the default values in this options object to override the plugin behavior. These are the default settings, which will apply to all embed instances. Currently there’s no way to configure individual embeds.
+
+```javascript
+{
+  // Default “allowfullscreen” boolean attribute that gets applied to the embed <iframe>.
+  // Change to false to disable fullscreen.
+  allowFullscreen: true,
+  // Default “dnt” (“do-not-track”) boolean attribute that gets applied to the embed URL.
+  // Change to false to allow cookies and other tracking technology.
+  dnt: true,
+  // Default class that gets applied to the wrapper <div>.
+  // Substitute your preferred string to target embeds with CSS.
+  embedClass: 'eleventy-plugin-vimeo-embed'
+});
+```
+
+### Supported URL patterns
+
+The plugin supports common Vimeo URL variants as well. These should also work in your Markdown files.:
+
+```markdown
+<!-- No protocol: -->
+
+vimeo.com/347565673
+www.vimeo.com/347565673
+
+<!-- With or without HTTPS: -->
+
+http://vimeo.com/347565673
+https://vimeo.com/347565673
+
+<!-- With or without 'www': -->
+
+https://www.vimeo.com/347565673
+https://vimeo.com/347565673
+
+<!-- URLs with extra parameters or fragments: -->
+
+https://vimeo.com/347565673?autoplay=1
+https://vimeo.com/347565673#t30s
+```
+
+If you run across a URL pattern that you think should work, but doesn’t, please [file an issue](https://github.com/gfscott/eleventy-plugin-vimeo-embed/issues/new)!
+
+## ⚠️ Notes and caveats
+
+- This plugin is deliberately designed _only_ to embed videos when the URL is on its own line, and not inline with other text.
+- To do this, it uses [a regular expression](https://regex101.com/r/wSkwtj/13) to recognize Vimeo video URLs. Currently these are the limitations on what it can recognize in a Markdown parser’s HTML output:
+  - The URL *must* be wrapped in a paragraph tag: `<p>`
+  - It *may* also be wrapped in an anchor tag, (*inside* the paragraph): `<a>`
+  - The URL string *may* have whitespace around it
+- I’ve tried to accommodate common variants, but there are conceivably valid Vimeo URLs that wouldn’t get recognized. Please [file an issue](https://github.com/gfscott/eleventy-plugin-vimeo-embed/issues/new) if you run into an edge case!
+- This plugin uses [transforms](https://www.11ty.dev/docs/config/#transforms), so it alters Eleventy’s HTML output as it’s generated. It doesn’t alter the source Markdown.
+- The embedded video is responsive, using the [intrinsic aspect ratio](https://codepen.io/gfscott/pen/qpKqZR?editors=1100) method. It will expand to fill whatever horizontal space is available.
+- The embed dimensions are currently hard-coded to a 16:9 aspect ratio.

--- a/packages/vimeo/lib/buildEmbed.js
+++ b/packages/vimeo/lib/buildEmbed.js
@@ -1,0 +1,16 @@
+module.exports = function(id, options) {
+  // Build the string, using config data as we go
+  // unique ID based on video id and global class name for all embeds
+  let out = `<div id="vimeo-${id}" class="${options.embedClass}"`;
+  out += options.wrapperStyle ? ` style="${options.wrapperStyle}">` : ">";
+  out += `<iframe`
+  out += options.iframeStyle ? ` style="${options.iframeStyle}"` : "";
+  out += ' frameborder="0"';
+  out += ' src="https://player.vimeo.com/video/';
+  out += id;
+  out += options.dnt ? '?dnt=1' : '?dnt=0';
+  out += '"';
+  out += options.allowFullscreen ? ' allowfullscreen' : '';
+  out += '></iframe></div>';
+  return out;
+}

--- a/packages/vimeo/lib/extractMatches.js
+++ b/packages/vimeo/lib/extractMatches.js
@@ -1,0 +1,12 @@
+/**
+ * Video ID is 4th item in array of matches.
+ * [0]    = full matched string
+ * [1, 2] = zero-backtrack arbitrary whitespace, requires capture for lookahead
+ * [3]    = video ID
+ * [4, 5] = zero-backtrack arbitrary whitespace, requires capture for lookahead
+ */
+const pattern = /<p>(?=(\s*))\1(?:<a [^>]*?>)??(?=(\s*))\2(?:https?:\/\/)??(?:w{3}\.)??(?:vimeo\.com)\/(\d{1,20})(?:[^\s<>]*)(?=(\s*))\4(?:<\/a>)??(?=(\s*))\5<\/p>/;
+
+module.exports = function(str) {
+  return str.match(pattern)[3];
+}

--- a/packages/vimeo/lib/pluginDefaults.js
+++ b/packages/vimeo/lib/pluginDefaults.js
@@ -1,0 +1,13 @@
+module.exports = {
+  allowFullscreen: true,
+  dnt: true,
+  embedClass: 'eleventy-plugin-vimeo-embed',
+  
+  /**
+   * By default, uses the Intrinsic Aspect Ratio technique
+   * https://codepen.io/gfscott/pen/qpKqZR?editors=1100
+   * Pass an options object with alternate inline styles to override
+   */
+  iframeStyle: 'position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;',
+  wrapperStyle: 'position:relative;width:100%;padding-top:56.25%;',
+};

--- a/packages/vimeo/lib/spotPattern.js
+++ b/packages/vimeo/lib/spotPattern.js
@@ -1,0 +1,13 @@
+/**
+ * Regex details:
+ * - (?=(\s*))\1 -- Mimics atomic groups in JavaScript RegEx using positive lookaheads.
+ * @see https://blog.stevenlevithan.com/archives/mimic-atomic-groups
+ * 
+ * - (\d{1,20}). Maximum 64-bit integer is 20 digits long. Capping the group length is more efficient than `\d*`
+ * @see https://www.wolframalpha.com/input/?i=2%5E64
+ */
+const pattern = /<p>(?=(\s*))\1(?:<a [^>]*?>)??(?=(\s*))\2(?:https?:\/\/)??(?:w{3}\.)??(?:vimeo\.com)\/(?:\d{1,20})(?:[^\s<>]*)(?=(\s*))\3(?:<\/a>)??(?=(\s*))\4<\/p>/g;
+
+module.exports = function(str) {
+  return str.match(pattern);
+}

--- a/packages/vimeo/package.json
+++ b/packages/vimeo/package.json
@@ -10,8 +10,13 @@
   ],
   "main": ".eleventy.js",
   "scripts": {
-    "test": "ava"
+    "test": "npx ava",
+    "coverage": "nyc --reporter=lcov ava"
   },
+  "files": [
+    ".eleventy.js",
+    "lib/**"
+  ],
   "author": {
     "name": "Graham F. Scott",
     "email": "gfscott@gmail.com",
@@ -21,12 +26,7 @@
   "homepage": "https://gfscott.com/embed-everything/",
   "repository": {
     "type": "git",
-    "url": "https://github.com/gfscott/eleventy-plugin-vimeo-embed.git"
+    "url": "https://github.com/gfscott/eleventy-plugin-embed-everything.git"
   },
-  "bugs": "https://github.com/gfscott/eleventy-plugin-vimeo-embed/issues",
-  "devDependencies": {
-    "ava": "^5.1.0",
-    "codecov": "^3.8.3",
-    "nyc": "^15.1.0"
-  }
+  "bugs": "https://github.com/gfscott/eleventy-plugin-embed-everything/issues"
 }

--- a/packages/vimeo/package.json
+++ b/packages/vimeo/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "eleventy-plugin-vimeo-embed",
+  "version": "1.3.5",
+  "description": "An Eleventy plugin to automatically embed Vimeo videos, using just their URLs.",
+  "keywords": [
+    "11ty",
+    "eleventy",
+    "eleventy-plugin",
+    "vimeo"
+  ],
+  "main": ".eleventy.js",
+  "scripts": {
+    "test": "ava"
+  },
+  "author": {
+    "name": "Graham F. Scott",
+    "email": "gfscott@gmail.com",
+    "url": "https://gfscott.com"
+  },
+  "license": "MIT",
+  "homepage": "https://gfscott.com/embed-everything/",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gfscott/eleventy-plugin-vimeo-embed.git"
+  },
+  "bugs": "https://github.com/gfscott/eleventy-plugin-vimeo-embed/issues",
+  "devDependencies": {
+    "ava": "^5.1.0",
+    "codecov": "^3.8.3",
+    "nyc": "^15.1.0"
+  }
+}

--- a/packages/vimeo/test.js
+++ b/packages/vimeo/test.js
@@ -1,0 +1,243 @@
+const test = require('ava');
+const patternPresent = require('./lib/spotPattern.js');
+const extractId = require('./lib/extractMatches.js');
+const buildEmbed = require('./lib/buildEmbed.js');
+const pluginDefaults = require('./lib/pluginDefaults.js');
+
+// These should PASS
+const validStrings = [
+  {type: 'Standard', str: 'https://vimeo.com/400344311'},
+  {type: 'With http', str: 'http://vimeo.com/400344311'},
+  {type: 'Without protocol', str: 'vimeo.com/400344311'},
+  {type: 'With arbitrary params', str: 'https://vimeo.com/400344311?foo=bar&baz'},
+]
+
+// These should FAIL
+const invalidStrings = [
+  {type: 'With prepended text', str: 'foo https://vimeo.com/400344311'},
+  {type: 'With prepended text, with link', str: 'foo <a href="">https://vimeo.com/400344311</a>'},
+  {type: 'With appended text', str: 'https://vimeo.com/400344311 bar'},
+  {type: 'With appended text, with link', str: '<a href="">https://vimeo.com/400344311</a> bar'},
+]
+
+/**
+ * Test that regex returns true for valid strings
+ */
+validStrings.forEach(function(obj){
+  test(`Valid string returns true: ${obj.type} ideal case`, t => {
+    let idealCase = `<p>${obj.str}</p>`;
+    t.truthy(patternPresent(idealCase));
+  });
+  test(`Valid string returns true: ${obj.type} with links`, t => {
+    let withLinks = `<p><a href="">${obj.str}</a></p>`;
+    t.truthy(patternPresent(withLinks));
+  });
+  test(`Valid string returns true: ${obj.type} with whitespace`, t => {
+    let withWhitespace = `<p>
+      ${obj.str}
+    </p>`;
+    t.truthy(patternPresent(withWhitespace));
+  });
+  test(`Valid string returns true: ${obj.type} with links and whitespace`, t => {
+    let withLinksAndWhitespace = `<p>
+      <a href="">
+        ${obj.str}
+      </a>
+    </p>`;
+    t.truthy(patternPresent(withLinksAndWhitespace));
+  });
+});
+
+/**
+ * Test that extractor returns proper video ID string
+ */
+validStrings.forEach(function(obj){
+  test(`Proper ID returned: ${obj.type} ideal case`, t => {
+    let idealCase = `<p>${obj.str}</p>`;
+    t.is(extractId(idealCase), '400344311');
+  });
+  test(`Proper ID returned: ${obj.type} with links`, t => {
+    let withLinks = `<p><a href="">${obj.str}</a></p>`;
+    t.is(extractId(withLinks), '400344311');
+  });
+  test(`Proper ID returned: ${obj.type} with whitespace`, t => {
+    let withWhitespace = `<p>
+      ${obj.str}
+    </p>`;
+    t.is(extractId(withWhitespace), '400344311');
+  });
+  test(`Proper ID returned: ${obj.type} with links and whitespace`, t => {
+    let withLinksAndWhitespace = `<p>
+      <a href="">
+        ${obj.str}
+      </a>
+    </p>`;
+    t.is(extractId(withLinksAndWhitespace), '400344311');
+  });
+});
+
+/**
+ * Test that embed builder returns expected HTML
+ */
+validStrings.forEach(function(obj){
+  test(`Expected HTML returned: ${obj.type} ideal case`, t => {
+    let idealCase = `<p>${obj.str}</p>`;
+    t.is(buildEmbed(extractId(idealCase), pluginDefaults),
+      `<div id="vimeo-400344311" class="eleventy-plugin-vimeo-embed" style="position:relative;width:100%;padding-top:56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" frameborder="0" src="https://player.vimeo.com/video/400344311?dnt=1" allowfullscreen></iframe></div>`
+    );
+  });
+  test(`Expected HTML returned: ${obj.type} with links`, t => {
+    let withLinks = `<p><a href="">${obj.str}</a></p>`;
+    t.is(buildEmbed(extractId(withLinks), pluginDefaults),
+      `<div id="vimeo-400344311" class="eleventy-plugin-vimeo-embed" style="position:relative;width:100%;padding-top:56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" frameborder="0" src="https://player.vimeo.com/video/400344311?dnt=1" allowfullscreen></iframe></div>`
+    );
+  });
+  test(`Expected HTML returned: ${obj.type} with whitespace`, t => {
+    let withWhitespace = `<p>
+      ${obj.str}
+    </p>`;
+    t.is(buildEmbed(extractId(withWhitespace), pluginDefaults),
+      `<div id="vimeo-400344311" class="eleventy-plugin-vimeo-embed" style="position:relative;width:100%;padding-top:56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" frameborder="0" src="https://player.vimeo.com/video/400344311?dnt=1" allowfullscreen></iframe></div>`
+    );
+  });
+  test(`Expected HTML returned: ${obj.type} with links and whitespace`, t => {
+    let withLinksAndWhitespace = `<p>
+      <a href="">
+        ${obj.str}
+      </a>
+    </p>`;
+    t.is(buildEmbed(extractId(withLinksAndWhitespace), pluginDefaults),
+      `<div id="vimeo-400344311" class="eleventy-plugin-vimeo-embed" style="position:relative;width:100%;padding-top:56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" frameborder="0" src="https://player.vimeo.com/video/400344311?dnt=1" allowfullscreen></iframe></div>`
+    );
+  });
+});
+
+/**
+ * Test that embed builder returns expected HTML with non-default options
+ */
+
+const optionsDntFalse = Object.assign({}, pluginDefaults, { dnt: false });
+validStrings.forEach(function(obj){
+  test(`Expected HTML returned; case: DNT false: ${obj.type} ideal case`, t => {
+    let idealCase = `<p>${obj.str}</p>`;
+    t.is(buildEmbed(extractId(idealCase), optionsDntFalse),
+      `<div id="vimeo-400344311" class="eleventy-plugin-vimeo-embed" style="position:relative;width:100%;padding-top:56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" frameborder="0" src="https://player.vimeo.com/video/400344311?dnt=0" allowfullscreen></iframe></div>`
+    );
+  });
+  test(`Expected HTML returned; case: DNT false: ${obj.type} with links`, t => {
+    let withLinks = `<p><a href="">${obj.str}</a></p>`;
+    t.is(buildEmbed(extractId(withLinks), optionsDntFalse),
+      `<div id="vimeo-400344311" class="eleventy-plugin-vimeo-embed" style="position:relative;width:100%;padding-top:56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" frameborder="0" src="https://player.vimeo.com/video/400344311?dnt=0" allowfullscreen></iframe></div>`
+    );
+  });
+  test(`Expected HTML returned; case: DNT false: ${obj.type} with whitespace`, t => {
+    let withWhitespace = `<p>
+      ${obj.str}
+    </p>`;
+    t.is(buildEmbed(extractId(withWhitespace), optionsDntFalse),
+      `<div id="vimeo-400344311" class="eleventy-plugin-vimeo-embed" style="position:relative;width:100%;padding-top:56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" frameborder="0" src="https://player.vimeo.com/video/400344311?dnt=0" allowfullscreen></iframe></div>`
+    );
+  });
+  test(`Expected HTML returned; case: DNT false: ${obj.type} with links and whitespace`, t => {
+    let withLinksAndWhitespace = `<p>
+      <a href="">
+        ${obj.str}
+      </a>
+    </p>`;
+    t.is(buildEmbed(extractId(withLinksAndWhitespace), optionsDntFalse),
+      `<div id="vimeo-400344311" class="eleventy-plugin-vimeo-embed" style="position:relative;width:100%;padding-top:56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" frameborder="0" src="https://player.vimeo.com/video/400344311?dnt=0" allowfullscreen></iframe></div>`
+    );
+  });
+});
+
+/**
+ * Test that embed builder returns expected HTML with non-default options
+ */
+
+const optionsFullscreenFalse = Object.assign({}, pluginDefaults, { allowFullscreen: false });
+validStrings.forEach(function(obj){
+  test(`Expected HTML returned; case: allowFullscreen false: ${obj.type} ideal case`, t => {
+    let idealCase = `<p>${obj.str}</p>`;
+    t.is(buildEmbed(extractId(idealCase), optionsFullscreenFalse),
+      `<div id="vimeo-400344311" class="eleventy-plugin-vimeo-embed" style="position:relative;width:100%;padding-top:56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" frameborder="0" src="https://player.vimeo.com/video/400344311?dnt=1"></iframe></div>`
+    );
+  });
+  test(`Expected HTML returned; case: allowFullscreen false: ${obj.type} with links`, t => {
+    let withLinks = `<p><a href="">${obj.str}</a></p>`;
+    t.is(buildEmbed(extractId(withLinks), optionsFullscreenFalse),
+      `<div id="vimeo-400344311" class="eleventy-plugin-vimeo-embed" style="position:relative;width:100%;padding-top:56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" frameborder="0" src="https://player.vimeo.com/video/400344311?dnt=1"></iframe></div>`
+    );
+  });
+  test(`Expected HTML returned; case: allowFullscreen false: ${obj.type} with whitespace`, t => {
+    let withWhitespace = `<p>
+      ${obj.str}
+    </p>`;
+    t.is(buildEmbed(extractId(withWhitespace), optionsFullscreenFalse),
+      `<div id="vimeo-400344311" class="eleventy-plugin-vimeo-embed" style="position:relative;width:100%;padding-top:56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" frameborder="0" src="https://player.vimeo.com/video/400344311?dnt=1"></iframe></div>`
+    );
+  });
+  test(`Expected HTML returned; case: allowFullscreen false: ${obj.type} with links and whitespace`, t => {
+    let withLinksAndWhitespace = `<p>
+      <a href="">
+        ${obj.str}
+      </a>
+    </p>`;
+    t.is(buildEmbed(extractId(withLinksAndWhitespace), optionsFullscreenFalse),
+      `<div id="vimeo-400344311" class="eleventy-plugin-vimeo-embed" style="position:relative;width:100%;padding-top:56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" frameborder="0" src="https://player.vimeo.com/video/400344311?dnt=1"></iframe></div>`
+    );
+  });
+});
+
+/**
+ * Test that embed builder returns expected HTML with non-default options
+ */
+const customStyles = {
+  wrapperStyle: '',
+  iframeStyle: '',
+}
+const optionsCustomStyleStrings = Object.assign({}, pluginDefaults, customStyles);
+validStrings.forEach(function(obj){
+  test(`Expected HTML returned; case: custom style strings: ${obj.type} ideal case`, t => {
+    let idealCase = `<p>${obj.str}</p>`;
+    t.is(buildEmbed(extractId(idealCase), optionsCustomStyleStrings),
+      `<div id="vimeo-400344311" class="eleventy-plugin-vimeo-embed"><iframe frameborder="0" src="https://player.vimeo.com/video/400344311?dnt=1" allowfullscreen></iframe></div>`
+    );
+  });
+  test(`Expected HTML returned; case: custom style strings: ${obj.type} with links`, t => {
+    let withLinks = `<p><a href="">${obj.str}</a></p>`;
+    t.is(buildEmbed(extractId(withLinks), optionsCustomStyleStrings),
+      `<div id="vimeo-400344311" class="eleventy-plugin-vimeo-embed"><iframe frameborder="0" src="https://player.vimeo.com/video/400344311?dnt=1" allowfullscreen></iframe></div>`
+    );
+  });
+  test(`Expected HTML returned; case: custom style strings: ${obj.type} with whitespace`, t => {
+    let withWhitespace = `<p>
+      ${obj.str}
+    </p>`;
+    t.is(buildEmbed(extractId(withWhitespace), optionsCustomStyleStrings),
+      `<div id="vimeo-400344311" class="eleventy-plugin-vimeo-embed"><iframe frameborder="0" src="https://player.vimeo.com/video/400344311?dnt=1" allowfullscreen></iframe></div>`
+    );
+  });
+  test(`Expected HTML returned; case: custom style strings: ${obj.type} with links and whitespace`, t => {
+    let withLinksAndWhitespace = `<p>
+      <a href="">
+        ${obj.str}
+      </a>
+    </p>`;
+    t.is(buildEmbed(extractId(withLinksAndWhitespace), optionsCustomStyleStrings),
+      `<div id="vimeo-400344311" class="eleventy-plugin-vimeo-embed"><iframe frameborder="0" src="https://player.vimeo.com/video/400344311?dnt=1" allowfullscreen></iframe></div>`
+    );
+  });
+});
+
+invalidStrings.forEach(function(obj){
+  test(`Invalid string returns false: ${obj.type} ideal case`, t => {
+    let idealCase = `<p>${obj.str}</p>`;
+    t.falsy(patternPresent(idealCase));
+  });
+  test(`Invalid string returns false: ${obj.type} with whitespace`, t => {
+    let withWhitespace = `<p>
+      ${obj.str}
+    </p>`;
+    t.falsy(patternPresent(withWhitespace));
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,7 +24,7 @@ importers:
       eleventy-plugin-embed-tiktok: workspace:^
       eleventy-plugin-embed-twitch: workspace:^
       eleventy-plugin-embed-twitter: workspace:^
-      eleventy-plugin-vimeo-embed: ^1.3.5
+      eleventy-plugin-vimeo-embed: workspace:^
       eleventy-plugin-youtube-embed: ^1.8.0
     dependencies:
       deepmerge: 4.2.2
@@ -34,7 +34,7 @@ importers:
       eleventy-plugin-embed-tiktok: link:../tiktok
       eleventy-plugin-embed-twitch: link:../twitch
       eleventy-plugin-embed-twitter: link:../twitter
-      eleventy-plugin-vimeo-embed: 1.3.5
+      eleventy-plugin-vimeo-embed: link:../vimeo
       eleventy-plugin-youtube-embed: 1.8.0
 
   packages/instagram:
@@ -65,6 +65,9 @@ importers:
     dependencies:
       '@11ty/eleventy-cache-assets': 2.3.0
       deepmerge: 4.2.2
+
+  packages/vimeo:
+    specifiers: {}
 
 packages:
 
@@ -1163,10 +1166,6 @@ packages:
   /electron-to-chromium/1.4.284:
     resolution: {integrity: sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA==}
     dev: true
-
-  /eleventy-plugin-vimeo-embed/1.3.5:
-    resolution: {integrity: sha512-E1DGHEeg+zT6xz1+6hGFDj6xw/jtH0p7hpxxOLNUQbAL13cUEq1FuRucT4UpkJkcC9QG0jpyBfbRd6eDxodSig==}
-    dev: false
 
   /eleventy-plugin-youtube-embed/1.8.0:
     resolution: {integrity: sha512-k/k23hkba3C0KPp0QehTFhX826LFWKPr6qm9tsFMgRbBjnVj3gC5ps0AtIyj69dmFlzS6tdiIjNd1PcJqQ1Yyw==}


### PR DESCRIPTION
This PR migrates the eleventy-plugin-vimeo-embed package into the monorepo. As with the previous migrations (starting with #128), it includes the complete version history of the original repo.