### PR TITLE
Monorepo migration: YouTube

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,31 @@
+name: e2e
+on: [push]
+jobs:
+  build:
+    runs-on: "ubuntu-latest"
+    name: Run e2e tests
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+      - name: Install pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 7
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: "18"
+          cache: 'pnpm'
+      - name: Install dependencies
+        run: pnpm install
+      - name: Install Playwright browser dependencies
+        run: pnpx playwright install --with-deps
+      - name: Run end-to-end tests using Playwright
+        run: "pnpm test:e2e"
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 30
+      

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -19,13 +19,15 @@ jobs:
       - name: Install dependencies
         run: pnpm install
       - name: Install Playwright browser dependencies
-        run: pnpx playwright install --with-deps
+        run: pnpm playwright install --with-deps
       - name: Run end-to-end tests using Playwright
         run: "pnpm test:e2e"
       - uses: actions/upload-artifact@v3
         if: always()
         with:
           name: playwright-report
-          path: playwright-report/
+          # currently only youtube is being e2e tested
+          # TODO figure out how to handle this with multiple packages
+          path: packages/youtube/playwright-report/
           retention-days: 30
       

--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,16 @@
 # don’t track dist/build folders
 dist/
 build/
+_site/
 
 # don't track yarn cache
 .cache/
 
 # don't track turbo cache
 .turbo
+
+# don't track playwright artifacts
+playwright-report/
 
 # =======================================================================
 # Created by https://www.gitignore.io/api/osx,gpg,node,compressedarchive

--- a/README.md
+++ b/README.md
@@ -19,4 +19,4 @@ TikTok      | [npm](https://www.npmjs.com/package/eleventy-plugin-embed-tiktok) 
 Twitch      | [npm](https://www.npmjs.com/package/eleventy-plugin-embed-twitch)     | [GitHub](https://github.com/gfscott/eleventy-plugin-embed-everything/tree/main/packages/twitch)     | Yes
 Twitter     | [npm](https://www.npmjs.com/package/eleventy-plugin-embed-twitter)    | [GitHub](https://github.com/gfscott/eleventy-plugin-embed-everything/tree/main/packages/twitter)    | Yes
 Vimeo       | [npm](https://www.npmjs.com/package/eleventy-plugin-vimeo-embed)      | [GitHub](https://github.com/gfscott/eleventy-plugin-embed-everything/tree/main/packages/vimeo)      | Yes
-YouTube     | [npm](https://www.npmjs.com/package/eleventy-plugin-youtube-embed)    | [GitHub](https://github.com/gfscott/eleventy-plugin-youtube-embed)    | No
+YouTube     | [npm](https://www.npmjs.com/package/eleventy-plugin-youtube-embed)    | [GitHub](https://github.com/gfscott/eleventy-plugin-embed-everything/tree/main/packages/youtube)    | Yes

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "private": true,
   "scripts": {
     "test": "turbo run test",
+    "test:e2e": "turbo run test:e2e",
     "coverage": "turbo run coverage"
   },
   "license": "MIT",
@@ -20,6 +21,7 @@
   },
   "bugs": "https://github.com/gfscott/eleventy-plugin-embed-everything/issues",
   "devDependencies": {
+    "@playwright/test": "^1.30.0",
     "ava": "^5.1.1",
     "nyc": "^15.1.0",
     "turbo": "^1.7.0"

--- a/packages/everything/package.json
+++ b/packages/everything/package.json
@@ -37,7 +37,7 @@
     "eleventy-plugin-embed-twitch": "workspace:^",
     "eleventy-plugin-embed-twitter": "workspace:^",
     "eleventy-plugin-vimeo-embed": "workspace:^",
-    "eleventy-plugin-youtube-embed": "^1.8.0"
+    "eleventy-plugin-youtube-embed": "workspace:^"
   },
   "author": {
     "name": "Graham F. Scott",

--- a/packages/youtube/.eleventy.js
+++ b/packages/youtube/.eleventy.js
@@ -1,0 +1,24 @@
+const patternPresent = require('./lib/spotPattern.js');
+const extractVideoId = require('./lib/extractMatches.js');
+const buildEmbedCodeString = require('./lib/buildEmbed.js');
+const { pluginDefaults } = require('./lib/pluginDefaults.js');
+
+module.exports = function (eleventyConfig, options) {
+  const pluginConfig = Object.assign(pluginDefaults, options);
+  eleventyConfig.addTransform("embedYouTube", async (content, outputPath) => {
+    if (outputPath && outputPath.endsWith(".html")) {
+      let matches = patternPresent(content);
+      if (!matches) {
+        return content;
+      }
+      matches.forEach(function (stringToReplace, index) {
+        let videoId = extractVideoId(stringToReplace);
+        let embedCode = buildEmbedCodeString(videoId, pluginConfig, index);
+        content = content.replace(stringToReplace, embedCode);
+      });
+      return content;
+    }
+
+    return content;
+  });
+};

--- a/packages/youtube/README.md
+++ b/packages/youtube/README.md
@@ -1,0 +1,279 @@
+# eleventy-plugin-youtube-embed
+
+[![NPM Version](https://img.shields.io/npm/v/eleventy-plugin-youtube-embed?style=for-the-badge)](https://www.npmjs.com/package/eleventy-plugin-youtube-embed)
+[![Build test status](https://img.shields.io/github/actions/workflow/status/gfscott/eleventy-plugin-youtube-embed/test-and-codecov.yml?branch=main&style=for-the-badge)](https://github.com/gfscott/eleventy-plugin-youtube-embed/actions?query=workflow%3A%22Node.js+CI+and+Codecov%22)
+[![codecov](https://img.shields.io/codecov/c/github/gfscott/eleventy-plugin-youtube-embed?style=for-the-badge)](https://codecov.io/gh/gfscott/eleventy-plugin-youtube-embed)\
+[![MIT License](https://img.shields.io/github/license/gfscott/eleventy-plugin-youtube-embed?style=for-the-badge)](https://github.com/gfscott/eleventy-plugin-youtube-embed/blob/master/LICENSE)
+[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v2.0-ff69b4.svg?style=for-the-badge)](code_of_conduct.md)
+
+This [Eleventy](https://www.11ty.dev/) plugin automatically embeds responsive YouTube videos from URLs in Markdown files. It’s part of the [`eleventy-plugin-embed-everything`](https://gfscott.com/embed-everything/) project.
+
+- ⚡️ [Installation](#install-in-eleventy)
+- 🛠 [Usage](#usage)
+- ⚙️ [Settings](#settings)
+- ⚠️ [Notes and caveats](#notes-and-caveats)
+
+---
+<span id="install-in-eleventy"></span>
+
+## ⚡️ Installation
+
+In your Eleventy project, [install the plugin](https://www.11ty.dev/docs/plugins/#adding-a-plugin) through npm:
+
+```sh
+$ npm i eleventy-plugin-youtube-embed
+```
+
+Then add it to your [Eleventy config](https://www.11ty.dev/docs/config/) file:
+
+```javascript
+// `require` the package at the top of the file with all the others
+const embedYouTube = require("eleventy-plugin-youtube-embed");
+
+module.exports = function(eleventyConfig) {
+
+  // There could be quite a lot of surrounding code here...
+
+  eleventyConfig.addPlugin(embedYouTube);
+
+  // There could be quite a lot of surrounding code here...
+
+};
+```
+<span id="usage"></span>
+
+## 🛠 Usage
+
+To embed a YouTube video into any Markdown page, paste its URL into a new line. The URL should be the only thing on that line.
+
+### Markdown file example:
+
+```markdown
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam vehicula, elit vel condimentum porta, purus.
+
+https://www.youtube.com/watch?v=dQw4w9WgXcQ
+
+Maecenas non velit nibh. Aenean eu justo et odio commodo ornare. In scelerisque sapien at.
+```
+
+### Result:
+
+![Rick Astley performing “Never gonna give you up”](https://user-images.githubusercontent.com/547470/73130266-2b8c2980-3fc3-11ea-8a8c-7994175a8490.jpg)
+
+<span id="settings"></span>
+
+## ⚙️ Settings
+
+You can configure the plugin to change its behavior by passing an options object to the `addPlugin` function:
+
+```javascript
+eleventyConfig.addPlugin(embedYouTube, {
+  // just an example, see default values below:
+  embedClass: 'my-alternate-classname'
+});
+```
+
+### Plugin default options
+
+The plugin’s default settings reside in [lib/pluginDefaults.js](lib/pluginDefaults.js). All of these values can be changed with an options object passed to the plugin.
+
+<table style="width: 100%;">
+  <thead>
+    <tr>
+      <td style="width:15%">Option</td>
+      <td style="width:15%">Type</td>
+      <td style="width:15%">Default <br>value</td>
+      <td style="width:40%">Notes</td>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>allowAttrs</code></td>
+      <td>String</td>
+      <td><code>accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture</code></td>
+      <td>Default <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#attr-allow"><code>allow</code> attributes</a> that get applied to the embed <code>iframe</code>. Substitute your preferred string to allow other iframe behaviors and <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Feature_Policy">feature policies</a>.</td>
+    </tr>
+    <tr>
+      <td><code>allowAutoplay</code></td>
+      <td>Boolean</td>
+      <td><code>false</code></td>
+      <td>Setting this to <code>true</code> will cause <b>all</b> embedded videos to autoplay. Be cool: don’t do it! <br>⚠️ This setting will be removed in v2.0.</td>
+    </tr>
+    <tr>
+      <td><code>allowFullscreen</code></td>
+      <td>Boolean</td>
+      <td><code>true</code></td>
+      <td>Default <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#attr-allowfullscreen">allowfullscreen</a> attribute that gets applied to the embed <code>iframe</code>. Changing this to <code>false</code> will disable the fullscreen button on your embeds.</td>
+    </tr>
+    <tr>
+      <td><code>embedClass</code></td>
+      <td>String</td>
+      <td><code>eleventy-plugin-youtube-embed</code></td>
+      <td>Class name applied to the <code>div</code> element that wraps the embedded YouTube <code>iframe</code>. Use the default string to target the embeds with CSS, or substitute your preferred string.</td>
+    </tr>
+    <tr>
+      <td><code>lazy</code></td>
+      <td>Boolean</td>
+      <td><code>false</code></td>
+      <td>Setting this to <code>true</code> will add a <code>loading="lazy"</code> attribute to the standard iframe embed. <a href="https://www.caniuse.com/#feat=loading-lazy-attr">Some browsers</a> will use this to optimize resource loading.</td>
+    </tr>
+    <tr>
+      <td><code>lite</code></td>
+      <td>Boolean <b>or</b> <a href="#lite-options-table">Object</a></td>
+      <td><code>false</code></td>
+      <td>Setting this to <code>true</code> will use Paul Irish’s <a href="https://github.com/paulirish/lite-youtube-embed">Lite YouTube Embed</a> method. See the section on the <a href="#lite">Lite version</a> below for more details.</td>
+    </tr>
+    <tr>
+      <td>✨ <b>New in v1.7.0!</b><br> <code>modestBranding</code></td>
+      <td>Boolean</td>
+      <td><code>false</code></td>
+      <td>Setting this to <code>true</code> will add a <code>modestbranding=1</code> attribute to the embed url. This will tell YouTube to show <a href="https://developers.google.com/youtube/player_parameters#modestbranding">minimal YouTube branding</a></td>
+    </tr>
+    <tr>
+      <td><code>noCookie</code></td>
+      <td>Boolean</td>
+      <td><code>true</code></td>
+      <td>Defaults to the “<a href="https://support.google.com/youtube/answer/171780?hl=en#zippy=,turn-on-privacy-enhanced-mode">privacy-enhanced</a>” <code>www.youtube-nocookie.com</code> domain. Change this to <code>false</code> to use <code>www.youtube.com</code>.</td>
+    </tr>
+    <tr>
+      <td>✨ <b>New in v1.7.0!</b><br> <code>recommendSelfOnly</code></td>
+      <td>Boolean</td>
+      <td><code>false</code></td>
+      <td>Setting this to <code>true</code> will add a <code>rel=0</code> attribute to the embed url. This will tell YouTube to <a href="https://developers.google.com/youtube/player_parameters#rel">recommend videos from the same channel.</a></td>
+    </tr>
+  </tbody>
+</table>
+
+<span id="lite"></span>
+
+### Lite YouTube Embed
+
+You can use the [Lite YouTube Embed](https://github.com/paulirish/lite-youtube-embed) instead of the standard YouTube iframe. In many circumstances this is a performance win because it delays loading the iframe element until the user clicks play.
+
+Be aware that the Lite version defaults to [loading two files from the jsDelivr CDN](https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@master/src/). It loads these files once on any HTML page that includes an embed. You can override both resource URIs if you want to load from a different source, such as [unpkg](https://unpkg.com/browse/lite-youtube-embed@0.0.0/src/) or your own server.
+
+In addition, using the Lite version will cause several of the plugin’s settings to become un-configurable. The `embedClass` option will still work, but the following options will be ignored if you set `lite: true`:
+
+- `allowAttrs`
+- `allowAutoplay`
+- `allowFullscreen`
+- `lazy`
+- `noCookie`
+
+#### Lite embed options
+
+To use the default Lite version, simply pass `lite: true` to the options object when you add the plugin to your Eleventy config:
+
+```javascript
+eleventyConfig.addPlugin(embedYouTube, {
+  lite: true
+});
+```
+
+#### Configuring lite embed options
+
+To manually configure the Lite version, pass an options object to the `lite` setting instead of `true`:
+
+```javascript
+eleventyConfig.addPlugin(embedYouTube, {
+  lite: {
+    // Change settings here
+  }
+});
+```
+
+<table id="lite-options-table" style="width: 100%;">
+  <thead>
+    <tr>
+      <td style="width:15%">Option</td>
+      <td style="width:15%">Type</td>
+      <td style="width:15%">Default <br>value</td>
+      <td style="width:40%">Notes</td>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>lite.css.enabled</code></td>
+      <td>Boolean</td>
+      <td><code>true</code></td>
+      <td>If you change this to <code>false</code>, then the plugin won’t add any CSS to the page. You’ll need to handle loading the necessary CSS yourself.</td>
+    </tr>
+    <tr>
+      <td><code>lite.css.inline</code></td>
+      <td>Boolean</td>
+      <td><code>false</code></td>
+      <td>If you change this to <code>true</code>, then the plugin will load the CSS inline in <code>&lt;style&gt;</code> tags, instead of using the default <code>&lt;link&gt;</code> tag.</td>
+    </tr>
+    <tr>
+      <td><code>lite.css.path</code></td>
+      <td>String</td>
+      <td><code>https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@master/src/lite-yt-embed.min.css</code></td>
+      <td>Pass a custom URL to load the necessary CSS from the source of your choice.</td>
+    </tr>
+    <tr>
+      <td><code>lite.js.enabled</code></td>
+      <td>Boolean</td>
+      <td><code>true</code></td>
+      <td>If you change this to <code>false</code>, then the plugin won’t add any JavaScript to the page. You’ll need to handle loading the necessary JavaScript yourself.</td>
+    </tr>
+    <tr>
+      <td><code>lite.js.inline</code></td>
+      <td>Boolean</td>
+      <td><code>false</code></td>
+      <td>If you change this to <code>true</code>, then the plugin will load the JavaScript inline in <code>&lt;script&gt;</code> tags.</td>
+    </tr>
+    <tr>
+      <td><code>lite.js.path</code></td>
+      <td>String</td>
+      <td><code>https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@master/src/lite-yt-embed.min.js</code></td>
+      <td>Pass a custom URL to load the necessary JavaScript from the source of your choice.</td>
+    </tr>
+  </tbody>
+</table>
+
+### Supported URL patterns
+
+The plugin supports common YouTube URL variants as well. These should also work in your Markdown files.:
+
+```markdown
+<!-- No protocol: -->
+
+youtube.com/watch?v=dQw4w9WgXcQ
+www.youtube.com/watch?v=dQw4w9WgXcQ
+
+<!-- With or without HTTPS: -->
+
+http://www.youtube.com/watch?v=dQw4w9WgXcQ
+https://www.youtube.com/watch?v=dQw4w9WgXcQ
+
+<!-- With or without 'www': -->
+
+https://www.youtube.com/watch?v=dQw4w9WgXcQ
+https://youtube.com/watch?v=dQw4w9WgXcQ
+
+<!-- YouTu.be short-links: -->
+
+https://youtu.be/dQw4w9WgXcQ
+
+<!-- URLs with extra parameters: -->
+
+https://www.youtube.com/watch?v=LQaehcfXvK0&feature=youtu.be
+https://www.youtube.com/watch?v=dQw4w9WgXcQ&list=RDdQw4w9WgXcQ&start_radio=1&t=1
+```
+
+If you really want to get into the weeds, inspect [`test/_inc/validUrls.js`](test/_inc/validUrls.js), which generates the comprehensive list of URL patterns that are explicitly tested. And if you run across a URL pattern that you think should work, but doesn’t, please [file an issue](https://github.com/gfscott/eleventy-plugin-youtube-embed/issues/new)!
+
+<span id="notes-and-caveats"></span>
+
+## ⚠️ Notes and caveats
+
+- This plugin is deliberately designed _only_ to embed videos when the URL is on its own line, and not inline with other text.
+- To do this, it uses [a regular expression](https://github.com/gfscott/eleventy-plugin-youtube-embed/blob/main/lib/spotPattern.js#L1) to recognize YouTube video URLs. Currently these are the limitations on what it can recognize in a Markdown parser’s HTML output:
+  - The URL *must* be wrapped in a paragraph tag: `<p>`
+  - It *may* also be wrapped in an anchor tag, (*inside* the paragraph): `<a>`
+  - The URL string *may* have whitespace around it
+- I’ve tried to accommodate common variants (like short **youtu.be** links, for example), but there are conceivably valid YouTube URLs that wouldn’t get recognized. Please [file an issue](https://github.com/gfscott/eleventy-plugin-youtube-embed/issues/new) if you run into an edge case!
+- This plugin uses [transforms](https://www.11ty.dev/docs/config/#transforms), so it alters Eleventy’s HTML output as it’s generated. It doesn’t alter the source Markdown.
+- Right now it supports only single videos, not playlists.
+- The embedded video is responsive, using the [intrinsic aspect ratio](https://codepen.io/gfscott/pen/qpKqZR?editors=1100) method. It will expand to fill whatever horizontal space is available.
+- The embed dimensions are currently hard-coded to a 16:9 aspect ratio.

--- a/packages/youtube/lib/buildEmbed.js
+++ b/packages/youtube/lib/buildEmbed.js
@@ -1,0 +1,95 @@
+const merge = require('deepmerge');
+
+module.exports = function(id, options, index) {
+  let output;
+  if ( !!options.lite ) {
+    output = liteEmbed(id, options, index);
+  } else {
+    output = defaultEmbed(id, options);
+  }
+  return output;
+}
+
+function urlParams(options){
+  let params = []
+
+  // autoplay is _technically_ possible, but be cool, don't do this
+  if(options.allowAutoplay) params.push('autoplay=1');
+  if(options.recommendSelfOnly) params.push('rel=0');
+  if(options.modestBranding) params.push('modestbranding=1');
+
+if(params.length > 0) {
+  return params.join("&amp;")
+}
+}
+
+function liteEmbed(id, options, index) {
+  let liteOpt = liteConfig(options);
+  let out = '';
+
+  const fs = require('fs');
+  const path = require('path');
+  const isInstalled = __dirname.includes('node_modules');
+  const basePath = isInstalled ? path.resolve(__dirname, '../../') : path.resolve(__dirname, '../node_modules/');
+
+  const liteCssFilePath = path.join(basePath, 'lite-youtube-embed/src/lite-yt-embed.css');
+  const liteJsFilePath = path.join(basePath, 'lite-youtube-embed/src/lite-yt-embed.js');
+  const inlineCss = fs.readFileSync(liteCssFilePath, 'utf-8');
+  const inlineJs = fs.readFileSync(liteJsFilePath, 'utf-8');
+  const params = urlParams(options);
+
+  if ( liteOpt.css.enabled && index === 0 ) {
+    out += liteOpt.css.inline ? `<style>${inlineCss}</style>\n` : `<link rel="stylesheet" href="${liteOpt.css.path}">\n`;
+  }
+  if ( liteOpt.js.enabled && index === 0 ) {
+    out += liteOpt.js.inline ? `<script>${inlineJs}</script>\n` : `<script defer="defer" src="${liteOpt.js.path}"></script>\n`;
+  }
+  out += `<div id="${id}" class="${options.embedClass}">`;
+  out += `<lite-youtube videoid="${id}" style="background-image: url('https://i.ytimg.com/vi/${id}/hqdefault.jpg');"`
+  out += params ? ` params="${params}"`: "";
+  out += `>`;
+  out += `<div class="lty-playbtn"></div>`;
+  out += `</lite-youtube>`;
+  out += `</div>`;
+  return out;
+}
+
+function liteConfig(options){
+  const { liteDefaults } = require('./pluginDefaults.js');
+  if ( options.lite && typeof options.lite === 'boolean') {
+    return liteDefaults;
+  } else {
+    return merge(liteDefaults, options.lite);
+  }
+}
+
+function defaultEmbed(id, options){
+  // Build the string, using config data as we go
+  // unique ID based on youtube video id
+  const params = urlParams(options);
+  let out =
+    '<div id="' + id + '" ';
+  // global class name for all embeds, use this for styling
+  out += 'class="' + options.embedClass + '" ';
+  // intrinsic aspect ratio; currently hard-coded to 16:9
+  // TODO: make configurable somehow
+  out += 'style="position:relative;width:100%;padding-top: 56.25%;">';
+  out +=
+    '<iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" ';
+  out += 'width="100%" height="100%" frameborder="0" title="Embedded YouTube video" ';
+  out += 'src="https://www.';
+  // default to nocookie domain
+  out += options.noCookie ? "youtube-nocookie" : "youtube";
+  out += '.com/embed/';
+  out += id;
+  out += params ? `?${params}` : "";
+  out += '" ';
+  // configurable allow attributes
+  out += 'allow="' + options.allowAttrs + '"';
+  // configurable fullscreen capability
+  out += options.allowFullscreen ? ' allowfullscreen' : '';
+  //configurable iframe lazy-loading
+  out += options.lazy ? ' loading="lazy"' : '';
+  out += '></iframe></div>';
+  return out;
+}

--- a/packages/youtube/lib/extractMatches.js
+++ b/packages/youtube/lib/extractMatches.js
@@ -1,0 +1,13 @@
+/**
+ * Video ID is 4th item in array of matches.
+ * [0]    = full matched string
+ * [1, 2] = zero-backtrack arbitrary whitespace, requires capture for lookahead
+ * [3]    = video ID
+ * [4, 5] = zero-backtrack arbitrary whitespace, requires capture for lookahead
+ */
+
+const pattern = /<p>(?=(\s*))\1(?:<a [^>]*?>)??(?=(\s*))\2(?:https?:\/\/)??(?:w{3}\.)??(?:youtube\.com|youtu\.be)\/(?:watch\?v=|embed\/)??([A-Za-z0-9-_]{11})(?:[^\s<>]*)(?=(\s*))\4(?:<\/a>)??(?=(\s*))\5<\/p>/;
+
+module.exports = function(str) {
+  return str.match(pattern)[3]
+}

--- a/packages/youtube/lib/pluginDefaults.js
+++ b/packages/youtube/lib/pluginDefaults.js
@@ -1,0 +1,22 @@
+exports.pluginDefaults = {
+  allowAttrs: 'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture',
+  allowAutoplay: false,
+  allowFullscreen: true,
+  embedClass: 'eleventy-plugin-youtube-embed',
+  lazy: false,
+  lite: false,
+  noCookie: true
+};
+
+exports.liteDefaults = {
+  css: {
+    enabled: true,
+    inline: false,
+    path: 'https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@master/src/lite-yt-embed.min.css'
+  },
+  js: {
+    enabled: true,
+    inline: false,
+    path: 'https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@master/src/lite-yt-embed.min.js'
+  }
+};

--- a/packages/youtube/lib/spotPattern.js
+++ b/packages/youtube/lib/spotPattern.js
@@ -1,0 +1,5 @@
+const pattern = /<p>(?=(\s*))\1(?:<a [^>]*?>)??(?=(\s*))\2(?:https?:\/\/)??(?:w{3}\.)??(?:youtube\.com|youtu\.be)\/(?:watch\?v=|embed\/)??([A-Za-z0-9-_]{11})(?:[^\s<>]*)(?=(\s*))\4(?:<\/a>)??(?=(\s*))\5<\/p>/g;
+
+module.exports = function(str) {
+  return str.match(pattern);
+}

--- a/packages/youtube/package.json
+++ b/packages/youtube/package.json
@@ -10,7 +10,8 @@
   ],
   "main": ".eleventy.js",
   "scripts": {
-    "test": "nyc --reporter=lcov ava",
+    "test": "npx ava",
+    "coverage": "nyc --reporter=lcov ava",
     "playwright": "npx playwright test"
   },
   "ava": {
@@ -27,14 +28,9 @@
   "homepage": "https://gfscott.com/embed-everything/",
   "repository": {
     "type": "git",
-    "url": "https://github.com/gfscott/eleventy-plugin-youtube-embed.git"
+    "url": "https://github.com/gfscott/eleventy-plugin-embed-everything.git"
   },
-  "bugs": "https://github.com/gfscott/eleventy-plugin-youtube-embed/issues",
-  "devDependencies": {
-    "@playwright/test": "^1.29.2",
-    "ava": "^5.1.0",
-    "nyc": "^15.1.0"
-  },
+  "bugs": "https://github.com/gfscott/eleventy-plugin-embed-everything/issues",
   "dependencies": {
     "deepmerge": "^4.2.2",
     "lite-youtube-embed": "^0.2.0"

--- a/packages/youtube/package.json
+++ b/packages/youtube/package.json
@@ -11,8 +11,8 @@
   "main": ".eleventy.js",
   "scripts": {
     "test": "npx ava",
-    "coverage": "nyc --reporter=lcov ava",
-    "playwright": "npx playwright test"
+    "test:e2e": "npx playwright test",
+    "coverage": "nyc --reporter=lcov ava"
   },
   "ava": {
     "files": [

--- a/packages/youtube/package.json
+++ b/packages/youtube/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "eleventy-plugin-youtube-embed",
+  "version": "1.8.0",
+  "description": "An Eleventy plugin to automatically embed YouTube videos, using just their URLs.",
+  "keywords": [
+    "11ty",
+    "eleventy",
+    "eleventy-plugin",
+    "youtube"
+  ],
+  "main": ".eleventy.js",
+  "scripts": {
+    "test": "nyc --reporter=lcov ava",
+    "playwright": "npx playwright test"
+  },
+  "ava": {
+    "files": [
+      "!test/_inc"
+    ]
+  },
+  "author": {
+    "name": "Graham F. Scott",
+    "email": "gfscott@gmail.com",
+    "url": "https://gfscott.com"
+  },
+  "license": "MIT",
+  "homepage": "https://gfscott.com/embed-everything/",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gfscott/eleventy-plugin-youtube-embed.git"
+  },
+  "bugs": "https://github.com/gfscott/eleventy-plugin-youtube-embed/issues",
+  "devDependencies": {
+    "@playwright/test": "^1.29.2",
+    "ava": "^5.1.0",
+    "nyc": "^15.1.0"
+  },
+  "dependencies": {
+    "deepmerge": "^4.2.2",
+    "lite-youtube-embed": "^0.2.0"
+  }
+}

--- a/packages/youtube/playwright.config.ts
+++ b/packages/youtube/playwright.config.ts
@@ -1,0 +1,107 @@
+import type { PlaywrightTestConfig } from '@playwright/test';
+import { devices } from '@playwright/test';
+
+/**
+ * Read environment variables from file.
+ * https://github.com/motdotla/dotenv
+ */
+// require('dotenv').config();
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+const config: PlaywrightTestConfig = {
+  testDir: './test/e2e',
+  /* Maximum time one test can run for. */
+  timeout: 30 * 1000,
+  expect: {
+    /**
+     * Maximum time expect() should wait for the condition to be met.
+     * For example in `await expect(locator).toHaveText();`
+     */
+    timeout: 5000
+  },
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : undefined,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: 'html',
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
+    actionTimeout: 0,
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    baseURL: 'http://localhost:3000',
+
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: 'on-first-retry',
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+      },
+    },
+
+    {
+      name: 'firefox',
+      use: {
+        ...devices['Desktop Firefox'],
+      },
+    },
+
+    {
+      name: 'webkit',
+      use: {
+        ...devices['Desktop Safari'],
+      },
+    },
+
+    /* Test against mobile viewports. */
+    // {
+    //   name: 'Mobile Chrome',
+    //   use: {
+    //     ...devices['Pixel 5'],
+    //   },
+    // },
+    // {
+    //   name: 'Mobile Safari',
+    //   use: {
+    //     ...devices['iPhone 12'],
+    //   },
+    // },
+
+    /* Test against branded browsers. */
+    // {
+    //   name: 'Microsoft Edge',
+    //   use: {
+    //     channel: 'msedge',
+    //   },
+    // },
+    // {
+    //   name: 'Google Chrome',
+    //   use: {
+    //     channel: 'chrome',
+    //   },
+    // },
+  ],
+
+  /* Folder for test artifacts such as screenshots, videos, traces, etc. */
+  // outputDir: 'test-results/',
+
+  /* Run your local dev server before starting the tests */
+  webServer: {
+    command: 'npx @11ty/eleventy --input=test/e2e/testsite --port=3000 --serve',
+    port: 3000,
+  },
+};
+
+export default config;

--- a/packages/youtube/test/_inc/permuteArrays.js
+++ b/packages/youtube/test/_inc/permuteArrays.js
@@ -1,0 +1,65 @@
+/**
+ * 
+ * @param {String OR Array} term 
+ * @param {Array} prefixes 
+ * @param {Array} suffixes
+ * @returns An array containing all possible permutations 
+ *          of the term for all prefixes and suffixes
+ */
+ module.exports = function(term, prefixes, suffixes) {
+  let out = [].concat(prependEach(term, prefixes));
+  out = out.concat(appendEach(out, suffixes));
+  return out;
+}
+
+/**
+ * 
+ * @param {Array | String} term 
+ * @param {Array} prefixes 
+ * @returns An array of each term, prepended with each prefix
+ */
+const prependEach = (term, prefixes) => {  
+  let arr = coerceToArray(term);
+  let out = [];
+  for (let prefix of prefixes){
+    for (let item of arr){
+      out.push(prefix + item)
+    }
+  }
+  return out;
+}
+
+/**
+ * 
+ * @param {Array | String} term 
+ * @param {Array} suffixes 
+ * @returns An array of each term, appended with each prefix
+ */
+const appendEach = (term, suffixes) => {
+  let arr = coerceToArray(term);
+  let out = [];
+  for (let suffix of suffixes) {
+    for (let item of arr){
+      out.push(item + suffix)
+    }
+  }
+  return out;
+}
+
+/**
+ * Coerce a string to a one-item array.
+ * @param {*} mysteryObject 
+ * @returns Array containing one or more items
+ * 
+ * Given an object, check its type. If it's an array, return it.
+ * If if it’s a string, return an array with that string as its
+ * only item.
+ */
+const coerceToArray = (mysteryObject) => {
+  if ( Array.isArray(mysteryObject) ) {
+    return mysteryObject;
+  }
+  if ( typeof mysteryObject === 'string' ) {
+    return [].concat(mysteryObject);
+  }
+}

--- a/packages/youtube/test/_inc/validUrls.js
+++ b/packages/youtube/test/_inc/validUrls.js
@@ -1,0 +1,48 @@
+/**
+ * VALID URLS
+ * 
+ * Starting with a short list of valid URL fragments, return
+ * all possible valid URL permutations.
+ */
+
+ const permute = require('./permuteArrays.js');
+
+ /**
+  * Core URL structures accepted by the plugin
+  * Domain and path only 
+  */
+const validUrls_params = [
+  'youtube.com/watch?v=hIs5StN8J-0',
+  // This isn't actually a valid YouTube url, but accepted by the plugin regex
+  'youtu.be/watch?v=hIs5StN8J-0',
+]
+const validUrls_noparams = [
+  'youtu.be/hIs5StN8J-0',
+  // This isn't actually a valid YouTube url, but accepted by the plugin regex
+  'youtube.com/hIs5StN8J-0',
+]
+
+
+
+ 
+ /**
+  * Non-core URL structures accepted by the plugin
+  * Various protocol variants and URL parameters
+  * NOTE: We currently don't test for strings starting with `//`,
+  * since spotPattern.js does not actually detect that case.
+  * We probably should, since other plugins in the family do.
+  * Should be a non-breaking change.
+  */
+ const validPrefixes = ['', 'http://', 'https://', 'www.', 'http://www.', 'https://www.']
+ const validSuffixes_params = ['', '&', '&amp;', '%26', '&foo', '&amp;foo', '%26foo', '&foo=bar', '&amp;foo=bar', '%26foo%3Dbar']
+ const validSuffixes_noparams = ['?', '%3F', '?foo', '%3Ffoo', '?foo=bar', '%3Ffoo%3Dbar']
+ 
+ /**
+  * Cumulative lists of all URL permutations.
+  */
+ const goodUrls_params = permute(validUrls_params, validPrefixes, validSuffixes_params);
+ const goodUrls_noparams = permute(validUrls_noparams, validPrefixes, validSuffixes_noparams);
+ 
+const goodUrls = [].concat(goodUrls_params, goodUrls_noparams)
+
+ module.exports = goodUrls;

--- a/packages/youtube/test/buildEmbed.test.js
+++ b/packages/youtube/test/buildEmbed.test.js
@@ -1,0 +1,151 @@
+const test = require('ava');
+const videoId = 'hIs5StN8J-0';
+const buildEmbed = require('../lib/buildEmbed.js');
+const { pluginDefaults } = require('../lib/pluginDefaults.js');
+const fs = require('fs');
+const path = require('path');
+const liteCssFilePath = path.resolve(__dirname, '../node_modules/lite-youtube-embed/src/lite-yt-embed.css');
+const liteJsFilePath = path.resolve(__dirname, '../node_modules/lite-youtube-embed/src/lite-yt-embed.js');
+const inlineCss = fs.readFileSync(liteCssFilePath, 'utf-8');
+const inlineJs = fs.readFileSync(liteJsFilePath, 'utf-8');
+
+/**
+ * Override plugin default settings
+ * @param {object} obj
+ * @returns {object}
+ */
+ const override = (obj) => Object.assign({}, pluginDefaults, obj)
+
+ test(`Build embed default mode, default settings`, t => {
+   t.is(buildEmbed(videoId, pluginDefaults),
+     '<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/hIs5StN8J-0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>'
+   );
+ });
+ test(`Build embed default mode, override nothing`, t => {
+   t.is(buildEmbed(videoId, override({})),
+     '<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/hIs5StN8J-0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>'
+   );
+ });
+ test(`Build embed default mode, override allowAttrs`, t => {
+   t.is(buildEmbed(videoId, override({allowAttrs: 'foo'})),
+     '<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/hIs5StN8J-0" allow="foo" allowfullscreen></iframe></div>'
+   );
+ });
+ test(`Build embed default mode, override allowFullscreen`, t => {
+   t.is(buildEmbed(videoId, override({allowFullscreen: false})),
+     '<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/hIs5StN8J-0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"></iframe></div>'
+   );
+ });
+ test(`Build embed default mode, override allowAutoplay`, t => {
+   t.is(buildEmbed(videoId, override({allowAutoplay: true})),
+     '<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/hIs5StN8J-0?autoplay=1" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>'
+   );
+ });
+ test(`Build embed default mode, override embedClass`, t => {
+   t.is(buildEmbed(videoId, override({embedClass: 'foo'})),
+     '<div id="hIs5StN8J-0" class="foo" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/hIs5StN8J-0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>'
+   );
+ });
+ test(`Build embed default mode, override lazy`, t => {
+   t.is(buildEmbed(videoId, override({lazy: true})),
+     '<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/hIs5StN8J-0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe></div>'
+   );
+ });
+ test(`Build embed default mode, override noCookie`, t => {
+   t.is(buildEmbed(videoId, override({noCookie: false})),
+     '<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube.com/embed/hIs5StN8J-0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>'
+   );
+ });
+ test(`Build embed default mode, override modestBranding`, t => {
+   t.is(buildEmbed(videoId, override({modestBranding: true})),
+     '<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/hIs5StN8J-0?modestbranding=1" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>'
+   );
+ });
+ test(`Build embed default mode, override recommendSelfOnly`, t => {
+   t.is(buildEmbed(videoId, override({recommendSelfOnly: true})),
+     '<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/hIs5StN8J-0?rel=0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>'
+   );
+ });
+
+/**
+ * Lite mode, zero index (first instance on page includes script and CSS)
+ */
+test(`Build embed lite mode, zero index, lite defaults`, t => {
+  t.is(buildEmbed(videoId, override({lite: true}), 0),
+  `<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@master/src/lite-yt-embed.min.css">\n<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@master/src/lite-yt-embed.min.js"></script>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+  );
+});
+test(`Build embed lite mode, zero index, css disabled`, t => {
+  t.is(buildEmbed(videoId, override({lite:{css:{enabled: false}}}), 0),
+  `<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@master/src/lite-yt-embed.min.js"></script>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+  );
+});
+test(`Build embed lite mode, zero index, css inline`, t => {
+  t.is(buildEmbed(videoId, override({lite:{css:{inline: true}}}), 0),
+  `<style>${inlineCss}</style>\n<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@master/src/lite-yt-embed.min.js"></script>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+  );
+});
+test(`Build embed lite mode, zero index, css path override`, t => {
+  t.is(buildEmbed(videoId, override({lite:{css:{path: 'foo'}}}), 0),
+  `<link rel="stylesheet" href="foo">\n<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@master/src/lite-yt-embed.min.js"></script>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+  );
+});
+test(`Build embed lite mode, zero index, js disabled`, t => {
+  t.is(buildEmbed(videoId, override({lite:{js:{enabled: false}}}), 0),
+  `<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@master/src/lite-yt-embed.min.css">\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+  );
+});
+test(`Build embed lite mode, zero index, js inline`, t => {
+  t.is(buildEmbed(videoId, override({lite:{js:{inline: true}}}), 0),
+  `<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@master/src/lite-yt-embed.min.css">\n<script>${inlineJs}</script>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+  );
+});
+test(`Build embed lite mode, zero index, css AND js disabled`, t => {
+  t.is(buildEmbed(videoId, override({lite:{css:{enabled:false},js:{enabled:false}}}), 0),
+  `<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+  );
+});
+test(`Build embed lite mode, zero index, css AND js path override`, t => {
+  t.is(buildEmbed(videoId, override({lite:{css:{path: 'foo'},js:{path: 'foo'}}}), 0),
+  `<link rel="stylesheet" href="foo">\n<script defer="defer" src="foo"></script>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+  );
+});
+test(`Build embed lite mode, zero index, css AND js inline`, t => {
+  t.is(buildEmbed(videoId, override({lite:{css:{inline: true},js:{inline: true}}}), 0),
+  `<style>${inlineCss}</style>\n<script>${inlineJs}</script>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+  );
+});
+
+/**
+ * Lite mode, 1+ index (no style or script on subsequent outputs)
+ */
+test(`Build embed lite mode, 1+ index, lite defaults`, t => {
+  t.is(buildEmbed(videoId, override({lite: true}), 1),
+  `<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+  );
+});
+test(`Build embed lite mode, 1+ index, css disabled`, t => {
+  t.is(buildEmbed(videoId, override({lite:{css:{enabled: false}}}), 1),
+  `<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+  );
+});
+test(`Build embed lite mode, 1+ index, css inline`, t => {
+  t.is(buildEmbed(videoId, override({lite:{css:{inline: true}}}), 1),
+  `<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+  );
+});
+test(`Build embed lite mode, 1+ index, css path override`, t => {
+  t.is(buildEmbed(videoId, override({lite:{css:{path: 'foo'}}}), 1),
+  `<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+  );
+});
+test(`Build embed lite mode, 1+ index, js disabled`, t => {
+  t.is(buildEmbed(videoId, override({lite:{js:{enabled: false}}}), 1),
+  `<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+  );
+});
+test(`Build embed lite mode, 1+ index, js inline`, t => {
+  t.is(buildEmbed(videoId, override({lite:{js:{inline: true}}}), 1),
+  `<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+  );
+});

--- a/packages/youtube/test/e2e/testsite/index.md
+++ b/packages/youtube/test/e2e/testsite/index.md
@@ -1,0 +1,9 @@
+---
+title: Hello world
+---
+
+Lorem ipsum.
+
+https://www.youtube.com/watch?v=hIs5StN8J-0
+
+Dolor sit amet.

--- a/packages/youtube/test/e2e/youtube.spec.ts
+++ b/packages/youtube/test/e2e/youtube.spec.ts
@@ -1,0 +1,46 @@
+import { test, expect } from '@playwright/test';
+
+test('test', async ({ page }) => {
+
+  // Go to http://localhost:3000/
+  await page.goto('http://localhost:3000/')
+  const embedWrapper = page.locator('div.eleventy-plugin-youtube-embed')
+  const embedFrameElement = embedWrapper.locator('iframe')
+  const embedFrame = page.frameLocator('iframe')
+
+  // Expect the wrapper to exist
+  await expect(embedWrapper).toBeTruthy()
+
+  // Expect the iframe to exist
+  await expect(embedFrameElement).toBeTruthy()
+
+  // Expect the iframe to have the correct title
+  await expect(embedFrameElement).toHaveAttribute('title', 'Embedded YouTube video')
+
+  // Expect the iframe to have the correct src
+  await expect(embedFrameElement).toHaveAttribute('src', 'https://www.youtube-nocookie.com/embed/hIs5StN8J-0')
+
+
+  // Click [aria-label="Play"]
+  await embedFrame.locator('[aria-label="Play"]').click();
+
+  // Click [aria-label="Play \(k\)"]
+  await embedFrame.locator('[aria-label="Play \\(k\\)"]').click();
+
+  // Click .ytp-fullscreen-button
+  // This fails on webkit for unknown reasons
+  // await embedFrame.locator('.ytp-fullscreen-button').click();
+
+  // Click [aria-label="Settings"]
+  await embedFrame.locator('[aria-label="Settings"]').click();
+
+  // Click [aria-label="Settings"]
+  await embedFrame.locator('[aria-label="Settings"]').click();
+
+  // Click text=Animotion - Obsession >> nth=0
+  await embedFrame.locator('text=Animotion - Obsession').first().click()
+
+  // Click [aria-label="Copy link"]
+  await embedFrame.locator('[aria-label="Copy link"]').click();
+
+});

--- a/packages/youtube/test/extractMatches.test.js
+++ b/packages/youtube/test/extractMatches.test.js
@@ -1,0 +1,33 @@
+const test = require('ava');
+const extractMatches = require('../lib/extractMatches.js');
+const validUrls = require('./_inc/validUrls.js');
+
+/**
+ * =====================================================
+ * For all possible valid URLs, test that the video ID
+ * is extracted correctly.
+ */
+for (let [index, url] of validUrls.entries()) {
+
+  test(`Valid-${index}: (${url}) without link, without whitespace`, t => {
+    t.is(extractMatches(`<p>${url}</p>`), 'hIs5StN8J-0');
+  });
+
+  test(`Valid-${index}: (${url}) without link, with whitespace`, t => {
+    t.is(extractMatches(`<p>
+      ${url}
+    </p>`), 'hIs5StN8J-0');
+  });
+
+  test(`Valid-${index}: (${url}) with link, without whitespace`, t => {
+    t.is(extractMatches(`<p><a href="${url}">${url}</a></p>`), 'hIs5StN8J-0');
+  });
+
+  test(`Valid-${index}: (${url}) with link, with whitespace`, t => {
+    t.is(extractMatches(`<p>
+      <a href="${url}">
+        ${url}
+      </a>
+    </p>`), 'hIs5StN8J-0');
+  });
+}

--- a/packages/youtube/test/spotPattern.test.js
+++ b/packages/youtube/test/spotPattern.test.js
@@ -1,0 +1,135 @@
+const test = require('ava');
+const spotPattern = require('../lib/spotPattern.js');
+const validUrls = require('./_inc/validUrls.js');
+
+/**
+ * =====================================================
+ * For all possible valid URLs, test that the pattern is
+ * spotted correctly.
+ *
+ * Getting indexes with a for...of loop:
+ * https://reactgo.com/javascript-get-index-for-of-loop/
+ */
+for (let [index, url] of validUrls.entries()) {
+
+  test(`Valid-${index}: (${url}) without link, without whitespace`, t => {
+    t.truthy(spotPattern(`<p>${url}</p>`));
+  });
+  test(`Valid-${index}: (${url}) without link, with whitespace`, t => {
+    t.truthy(spotPattern(`<p>
+      ${url}
+    </p>`));
+  });
+  test(`Valid-${index}: (${url}) with link, without whitespace`, t => {
+    t.truthy(spotPattern(`<p><a href="${url}">${url}</a></p>`));
+  });
+  test(`Valid-${index}: (${url}) with link, with whitespace`, t => {
+    t.truthy(spotPattern(`<p>
+      <a href="${url}">
+        ${url}
+      </a>
+    </p>`));
+  });
+
+  /**
+   * Test that regex rejects paragraphs with prepended text
+   */
+  test(`Invalid-${index}: (${url}) without link, without whitespace, prepend text`, t => {
+    t.falsy(spotPattern(`<p>Foo ${url}</p>`));
+  });
+  test(`Invalid-${index}: (${url}) without link, with whitespace, prepend text`, t => {
+    t.falsy(spotPattern(`<p>Foo
+      ${url}
+    </p>`));
+  });
+  test(`Invalid-${index}: (${url}) with link, without whitespace, prepend text`, t => {
+    t.falsy(spotPattern(`<p>Foo <a href="${url}">${url}</a></p>`));
+  });
+  test(`Invalid-${index}: (${url}) with link, with whitespace, prepend text`, t => {
+    t.falsy(spotPattern(`<p>Foo
+      <a href="${url}">
+        ${url}
+      </a>
+    </p>`));
+  });
+  test(`Invalid-${index}: (${url}) with link, without whitespace, prepend text inside link`, t => {
+    t.falsy(spotPattern(`<p><a href="${url}">Foo ${url}</a></p>`));
+  });
+  test(`Invalid-${index}: (${url}) with link, with whitespace, prepend text inside link`, t => {
+    t.falsy(spotPattern(`<p>
+      <a href="${url}">
+        Foo ${url}
+      </a>
+    </p>`));
+  });
+
+  /**
+   * Test that regex rejects paragraphs with appended text
+   */
+  test(`Invalid-${index}: (${url}) without link, without whitespace, append text`, t => {
+    t.falsy(spotPattern(`<p>${url} Foo</p>`));
+  });
+  test(`Invalid-${index}: (${url}) without link, with whitespace, append text`, t => {
+    t.falsy(spotPattern(`<p>
+      ${url}
+    Foo</p>`));
+  });
+  test(`Invalid-${index}: (${url}) with link, without whitespace, append text`, t => {
+    t.falsy(spotPattern(`<p><a href="${url}">${url}</a> Foo</p>`));
+  });
+  test(`Invalid-${index}: (${url}) with link, with whitespace, append text`, t => {
+    t.falsy(spotPattern(`<p>
+      <a href="${url}">
+        ${url}
+      </a>
+    Foo </p>`));
+  });
+  test(`Invalid-${index}: (${url}) with link, without whitespace, append text inside link`, t => {
+    t.falsy(spotPattern(`<p><a href="${url}">${url} Foo</a></p>`));
+  });
+  test(`Invalid-${index}: (${url}) with link, with whitespace, append text inside link`, t => {
+    t.falsy(spotPattern(`<p>
+      <a href="${url}">
+        ${url} Foo
+      </a>
+    </p>`));
+  });
+
+  /**
+   * Test that regex isn't greedily consuming subsequent paragraphs
+   * in minified HTML.
+   */
+  test(`Valid-${index}: (${url}) without link, non-greedy for minified HTML`, t => {
+    let p = `<p>${url}</p><p>Foo</p>`
+    let expected = `<p>${url}</p>`
+    t.deepEqual(spotPattern(p), [expected]);
+  });
+  test(`Valid-${index}: (${url}) with link, non-greedy for minified HTML`, t => {
+    let p = `<p><a href="${url}">${url}</a></p><p>Foo</p>`
+    let expected = `<p><a href="${url}">${url}</a></p>`
+    t.deepEqual(spotPattern(p), [expected]);
+  });
+}
+
+/**
+ * Test that regex rejects YouTube playlist URLs
+ */
+let playlistUrl = "https://www.youtube.com/playlist?list=PLv0jwu7G_DFVP0SGNlBiBtFVkV5LZ7SOU"
+test(`Invalid playlist URL: (${playlistUrl}) without link, without whitespace`, t => {
+  t.falsy(spotPattern(`<p>${playlistUrl}</p>`));
+});
+test(`Invalid playlist URL: (${playlistUrl}) without link, with whitespace`, t => {
+  t.falsy(spotPattern(`<p>
+    ${playlistUrl}
+  </p>`));
+});
+test(`Invalid playlist URL: (${playlistUrl}) with link, without whitespace`, t => {
+  t.falsy(spotPattern(`<p><a href="${playlistUrl}">${playlistUrl}</a></p>`));
+});
+test(`Invalid playlist URL: (${playlistUrl}) with link, with whitespace`, t => {
+  t.falsy(spotPattern(`<p>
+    <a href="${playlistUrl}">
+      ${playlistUrl}
+    </a>
+  </p>`));
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,12 +5,14 @@ importers:
   .:
     specifiers:
       '@changesets/cli': ^2.26.0
+      '@playwright/test': ^1.30.0
       ava: ^5.1.1
       nyc: ^15.1.0
       turbo: ^1.7.0
     dependencies:
       '@changesets/cli': 2.26.0
     devDependencies:
+      '@playwright/test': 1.30.0
       ava: 5.1.1
       nyc: 15.1.0
       turbo: 1.7.0
@@ -588,6 +590,15 @@ packages:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.15.0
 
+  /@playwright/test/1.30.0:
+    resolution: {integrity: sha512-SVxkQw1xvn/Wk/EvBnqWIq6NLo1AppwbYOjNLmyU0R1RoQ3rLEBtmjTnElcnz8VEtn11fptj1ECxK0tgURhajw==}
+    engines: {node: '>=14'}
+    hasBin: true
+    dependencies:
+      '@types/node': 12.20.55
+      playwright-core: 1.30.0
+    dev: true
+
   /@types/is-ci/3.0.0:
     resolution: {integrity: sha512-Q0Op0hdWbYd1iahB+IFNQcWXFq4O0Q5MwQP7uN0souuQ4rPg1vEYcnIOfr1gY+M+6rc8FGoRaBO1mOOvL29sEQ==}
     dependencies:
@@ -600,7 +611,6 @@ packages:
 
   /@types/node/12.20.55:
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
-    dev: false
 
   /@types/normalize-package-data/2.4.1:
     resolution: {integrity: sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==}
@@ -2464,6 +2474,12 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       find-up: 4.1.0
+
+  /playwright-core/1.30.0:
+    resolution: {integrity: sha512-7AnRmTCf+GVYhHbLJsGUtskWTE33SwMZkybJ0v6rqR1boxq2x36U7p1vDRV7HO2IwTZgmycracLxPEJI49wu4g==}
+    engines: {node: '>=14'}
+    hasBin: true
+    dev: true
 
   /plur/5.1.0:
     resolution: {integrity: sha512-VP/72JeXqak2KiOzjgKtQen5y3IZHn+9GOuLDafPv0eXa47xq0At93XahYBs26MsifCQ4enGKwbjBTKgb9QJXg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,7 +25,7 @@ importers:
       eleventy-plugin-embed-twitch: workspace:^
       eleventy-plugin-embed-twitter: workspace:^
       eleventy-plugin-vimeo-embed: workspace:^
-      eleventy-plugin-youtube-embed: ^1.8.0
+      eleventy-plugin-youtube-embed: workspace:^
     dependencies:
       deepmerge: 4.2.2
       eleventy-plugin-embed-instagram: link:../instagram
@@ -35,7 +35,7 @@ importers:
       eleventy-plugin-embed-twitch: link:../twitch
       eleventy-plugin-embed-twitter: link:../twitter
       eleventy-plugin-vimeo-embed: link:../vimeo
-      eleventy-plugin-youtube-embed: 1.8.0
+      eleventy-plugin-youtube-embed: link:../youtube
 
   packages/instagram:
     specifiers: {}
@@ -68,6 +68,14 @@ importers:
 
   packages/vimeo:
     specifiers: {}
+
+  packages/youtube:
+    specifiers:
+      deepmerge: ^4.2.2
+      lite-youtube-embed: ^0.2.0
+    dependencies:
+      deepmerge: 4.2.2
+      lite-youtube-embed: 0.2.0
 
 packages:
 
@@ -1166,13 +1174,6 @@ packages:
   /electron-to-chromium/1.4.284:
     resolution: {integrity: sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA==}
     dev: true
-
-  /eleventy-plugin-youtube-embed/1.8.0:
-    resolution: {integrity: sha512-k/k23hkba3C0KPp0QehTFhX826LFWKPr6qm9tsFMgRbBjnVj3gC5ps0AtIyj69dmFlzS6tdiIjNd1PcJqQ1Yyw==}
-    dependencies:
-      deepmerge: 4.2.2
-      lite-youtube-embed: 0.2.0
-    dev: false
 
   /emittery/1.0.1:
     resolution: {integrity: sha512-2ID6FdrMD9KDLldGesP6317G78K7km/kMcwItRtVFva7I/cSEOIaLpewaUb+YLXVwdAp3Ctfxh/V5zIl1sj7dQ==}

--- a/turbo.json
+++ b/turbo.json
@@ -6,6 +6,9 @@
     },
     "coverage": {
       "outputs": ["coverage/**", ".nyc_output/**"]
+    },
+    "test:e2e": {
+      "outputs": []
     }
   }
 }


### PR DESCRIPTION
This PR migrates the eleventy-plugin-youtube-embed package into the monorepo. As with the previous migrations (starting with #128), it includes the complete version history of the original repo.