### PR TITLE
Updates to package readmes

### DIFF
--- a/.changeset/beige-turtles-melt.md
+++ b/.changeset/beige-turtles-melt.md
@@ -1,0 +1,13 @@
+---
+"eleventy-plugin-embed-everything": patch
+"eleventy-plugin-embed-instagram": patch
+"eleventy-plugin-embed-soundcloud": patch
+"eleventy-plugin-embed-spotify": patch
+"eleventy-plugin-embed-tiktok": patch
+"eleventy-plugin-embed-twitch": patch
+"eleventy-plugin-embed-twitter": patch
+"eleventy-plugin-vimeo-embed": patch
+"eleventy-plugin-youtube-embed": patch
+---
+
+Minor updates to package READMEs. Mostly URL changes related to migrating to the new monorepo.

--- a/packages/everything/README.md
+++ b/packages/everything/README.md
@@ -1,10 +1,10 @@
 # eleventy-plugin-embed-everything
 
 [![NPM Version](https://img.shields.io/npm/v/eleventy-plugin-embed-everything?style=for-the-badge)](https://www.npmjs.com/package/eleventy-plugin-embed-everything)
-[![Build test status](https://img.shields.io/github/actions/workflow/status/gfscott/eleventy-plugin-embed-everything/test-and-codecov.yml?branch=main&style=for-the-badge)](https://github.com/gfscott/eleventy-plugin-embed-everything/actions?query=workflow%3A%22Node.js+CI+and+Codecov%22)
+[![Build test status](https://img.shields.io/github/actions/workflow/status/gfscott/eleventy-plugin-embed-everything/test.yml?branch=main&style=for-the-badge)](https://github.com/gfscott/eleventy-plugin-embed-everything/actions/workflows/test.yml?query=branch%3Amain)
 [![codecov](https://img.shields.io/codecov/c/github/gfscott/eleventy-plugin-embed-everything?style=for-the-badge)](https://codecov.io/gh/gfscott/eleventy-plugin-embed-everything)\
-[![MIT License](https://img.shields.io/github/license/gfscott/eleventy-plugin-embed-everything?style=for-the-badge)](https://github.com/gfscott/eleventy-plugin-embed-everything/blob/master/LICENSE)
-[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v2.0-ff69b4.svg?style=for-the-badge)](CODE_OF_CONDUCT.md)
+[![MIT License](https://img.shields.io/github/license/gfscott/eleventy-plugin-embed-everything?style=for-the-badge)](https://github.com/gfscott/eleventy-plugin-embed-everything/blob/main/LICENSE)
+[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v2.0-ff69b4.svg?style=for-the-badge)](https://github.com/gfscott/eleventy-plugin-embed-everything/blob/main/CODE_OF_CONDUCT.md)
 
 This [Eleventy](https://11ty.dev) plugin will automatically embed common media formats in your pages, requiring only a URL in your markdown files.
 
@@ -119,8 +119,8 @@ Substitute `vimeo`, `instagram`, and so on in place of `youtube`. Consult the [i
 
 - This plugin does very little on its own. Instead, it _aggregates_ other embed plugins in a single place.
 - Each service is itself a standalone Eleventy plugin, each of which you can install individually.
-- This plugin is in its early stages, with only a few supported embed patterns right now. If there’s a specific service you want added, please [open an issue](https://github.com/gfscott/eleventy-plugin-embed-everything/issues).
-- This plugin is not tested against Node.js 8 (since [ava](https://github.com/avajs/ava) doesn’t support it). I believe the plugin still works, but Node.js < 10 compatibility is best-effort only at this point, and will be explicitly dropped in future.
+- If there’s a specific service you’d want added, please [open an issue](https://github.com/gfscott/eleventy-plugin-embed-everything/issues).
+- This plugin is not tested against Node.js < 14 (since [ava](https://github.com/avajs/ava) doesn’t support it). I believe the plugin still works on older, officially unsupported Node.js versions but this can’t be guaranteed.
 
 ### Aggregated plugins
 
@@ -128,11 +128,11 @@ For more about each [supported service](#supported-services), consult this table
 
 | Service | Package | Repository | Options |
 | ------- | ------- | ---------- | ------- |
-| Instagram | [npm](https://www.npmjs.com/package/eleventy-plugin-embed-instagram) | [GitHub](https://github.com/gfscott/eleventy-plugin-embed-instagram) | [Options](https://github.com/gfscott/eleventy-plugin-embed-instagram/blob/main/lib/pluginDefaults.js) |
-| SoundCloud | [npm](https://www.npmjs.com/package/eleventy-plugin-embed-soundcloud) | [GitHub](https://github.com/gfscott/eleventy-plugin-embed-soundcloud) | [Options](https://github.com/gfscott/eleventy-plugin-embed-soundcloud/blob/main/lib/pluginDefaults.js) |
-| Spotify | [npm](https://www.npmjs.com/package/eleventy-plugin-embed-spotify) | [GitHub](https://github.com/gfscott/eleventy-plugin-embed-spotify) | [Options](https://github.com/gfscott/eleventy-plugin-embed-spotify/blob/main/lib/pluginDefaults.js) |
-| TikTok | [npm](https://www.npmjs.com/package/eleventy-plugin-embed-tiktok) | [GitHub](https://github.com/gfscott/eleventy-plugin-embed-tiktok) | [Options](https://github.com/gfscott/eleventy-plugin-embed-tiktok/blob/main/lib/pluginDefaults.js) |
-| Twitch | [npm](https://www.npmjs.com/package/eleventy-plugin-embed-twitch) | [GitHub](https://github.com/gfscott/eleventy-plugin-embed-twitch) | [Options](https://github.com/gfscott/eleventy-plugin-embed-twitch/blob/main/lib/pluginDefaults.js) |
-| Twitter | [npm](https://www.npmjs.com/package/eleventy-plugin-embed-twitter) | [GitHub](https://github.com/gfscott/eleventy-plugin-embed-twitter) | [Options](https://github.com/gfscott/eleventy-plugin-embed-twitter/blob/main/lib/pluginDefaults.js) |
-| Vimeo | [npm](https://www.npmjs.com/package/eleventy-plugin-vimeo-embed) | [GitHub](https://github.com/gfscott/eleventy-plugin-vimeo-embed) | [Options](https://github.com/gfscott/eleventy-plugin-vimeo-embed/blob/main/lib/pluginDefaults.js) |
-| YouTube | [npm](https://www.npmjs.com/package/eleventy-plugin-youtube-embed) | [GitHub](https://github.com/gfscott/eleventy-plugin-youtube-embed) | [Options](https://github.com/gfscott/eleventy-plugin-youtube-embed/blob/main/lib/pluginDefaults.js) |
+| Instagram | [npm](https://www.npmjs.com/package/eleventy-plugin-embed-instagram) | [GitHub](/packages/instagram) | [Options](/packages/instagram/lib/pluginDefaults.js) |
+| SoundCloud | [npm](https://www.npmjs.com/package/eleventy-plugin-embed-soundcloud) | [GitHub](/packages/soundcloud) | [Options](/packages/soundcloud/lib/pluginDefaults.js) |
+| Spotify | [npm](https://www.npmjs.com/package/eleventy-plugin-embed-spotify) | [GitHub](/packages/spotify) | [Options](/packages/spotify/lib/pluginDefaults.js) |
+| TikTok | [npm](https://www.npmjs.com/package/eleventy-plugin-embed-tiktok) | [GitHub](/packages/tiktok) | [Options](/packages/tiktok/lib/pluginDefaults.js) |
+| Twitch | [npm](https://www.npmjs.com/package/eleventy-plugin-embed-twitch) | [GitHub](/packages/twitch) | [Options](/packages/twitch/lib/pluginDefaults.js) |
+| Twitter | [npm](https://www.npmjs.com/package/eleventy-plugin-embed-twitter) | [GitHub](/packages/twitter) | [Options](/packages/twitter/lib/pluginDefaults.js) |
+| Vimeo | [npm](https://www.npmjs.com/package/eleventy-plugin-vimeo-embed) | [GitHub](/packages/vimeo) | [Options](/packages/vimeo/lib/pluginDefaults.js) |
+| YouTube | [npm](https://www.npmjs.com/package/eleventy-plugin-youtube-embed) | [GitHub](/packages/youtube) | [Options](/packages/youtube/lib/pluginDefaults.js) |

--- a/packages/instagram/README.md
+++ b/packages/instagram/README.md
@@ -1,10 +1,10 @@
 # eleventy-plugin-embed-instagram
 
 [![NPM Version](https://img.shields.io/npm/v/eleventy-plugin-embed-instagram?style=for-the-badge)](https://www.npmjs.com/package/eleventy-plugin-embed-instagram)
-[![Build test status](https://img.shields.io/github/actions/workflow/status/gfscott/eleventy-plugin-embed-instagram/test-and-codecov.yml?branc=main&style=for-the-badge)](https://github.com/gfscott/eleventy-plugin-embed-instagram/actions?query=workflow%3A%22Node.js+CI+and+Codecov%22)
-[![codecov](https://img.shields.io/codecov/c/github/gfscott/eleventy-plugin-embed-instagram?style=for-the-badge)](https://codecov.io/gh/gfscott/eleventy-plugin-embed-instagram)\
-[![MIT License](https://img.shields.io/github/license/gfscott/eleventy-plugin-embed-instagram?style=for-the-badge)](https://github.com/gfscott/eleventy-plugin-embed-instagram/blob/master/LICENSE)
-[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v2.0-ff69b4.svg?style=for-the-badge)](CODE_OF_CONDUCT.md)
+[![Build test status](https://img.shields.io/github/actions/workflow/status/gfscott/eleventy-plugin-embed-everything/test.yml?branch=main&style=for-the-badge)](https://github.com/gfscott/eleventy-plugin-embed-everything/actions/workflows/test.yml?query=branch%3Amain)
+[![codecov](https://img.shields.io/codecov/c/github/gfscott/eleventy-plugin-embed-everything?style=for-the-badge)](https://codecov.io/gh/gfscott/eleventy-plugin-embed-everything)\
+[![MIT License](https://img.shields.io/github/license/gfscott/eleventy-plugin-embed-everything?style=for-the-badge)](https://github.com/gfscott/eleventy-plugin-embed-everything/blob/main/LICENSE)
+[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v2.0-ff69b4.svg?style=for-the-badge)](https://github.com/gfscott/eleventy-plugin-embed-everything/blob/main/CODE_OF_CONDUCT.md)
 
 This [Eleventy](https://www.11ty.dev/) plugin automatically embeds Instagram photos and videos from URLs in markdown files.
 
@@ -75,7 +75,7 @@ https://www.instagram.com/p/B9XK4J3jVui/?foo=bar
 
 - This plugin is deliberately designed _only_ to embed when the URL is on its own line, and not inline with other text.
 - To do this, it uses a regular expression to recognize Instagram URLs, wrapped in an HTML `<p>` tag. If your Markdown parser produces any other output, it won’t be recognized.
-- I’ve tried to [accommodate common variants](https://regex101.com/r/cwLcjL/5), but there are conceivably valid Instagram URLs that wouldn’t get recognized. Please [file an issue](https://github.com/gfscott/eleventy-plugin-embed-instagram/issues/new) if you run into an edge case!
+- I’ve tried to [accommodate common variants](https://regex101.com/r/cwLcjL/5), but there are conceivably valid Instagram URLs that wouldn’t get recognized. Please [file an issue](https://github.com/gfscott/eleventy-plugin-embed-everything/issues/new) if you run into an edge case!
 - This plugin uses [transforms](https://www.11ty.dev/docs/config/#transforms), so it alters Eleventy’s HTML output as it’s generated. It doesn’t alter the source markdown.
 - By necessity, this plugin will add a call to Instagram’s third-party javascript file. It does this once per page, if that page contains an Instagram embed.
 - Because the aspect ratio of Instagram media can vary widely, the embed is not currently responsive. By default, Instagram’s script injects an iframe with a hard-coded width of 326 pixels. I’ve opted to lead this default behavior intact.

--- a/packages/soundcloud/README.md
+++ b/packages/soundcloud/README.md
@@ -1,9 +1,9 @@
 # eleventy-plugin-embed-soundcloud
 
 [![NPM Version](https://img.shields.io/npm/v/eleventy-plugin-embed-soundcloud?style=for-the-badge)](https://www.npmjs.com/package/eleventy-plugin-embed-soundcloud)
-[![Build test status](https://img.shields.io/github/actions/workflow/status/gfscott/eleventy-plugin-embed-soundcloud/test-and-codecov.yml?branch=main&style=for-the-badge)](https://github.com/gfscott/eleventy-plugin-embed-soundcloud/actions?query=workflow%3A%22Node.js+CI+and+Codecov%22)\
-[![MIT License](https://img.shields.io/github/license/gfscott/eleventy-plugin-embed-soundcloud?style=for-the-badge)](https://github.com/gfscott/eleventy-plugin-embed-soundcloud/blob/master/LICENSE)
-[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v2.0-ff69b4.svg?style=for-the-badge)](CODE_OF_CONDUCT.md)
+[![Build test status](https://img.shields.io/github/actions/workflow/status/gfscott/eleventy-plugin-embed-everything/test.yml?branch=main&style=for-the-badge)](https://github.com/gfscott/eleventy-plugin-embed-everything/actions/workflows/test.yml?query=branch%3Amain)\
+[![MIT License](https://img.shields.io/github/license/gfscott/eleventy-plugin-embed-everything?style=for-the-badge)](https://github.com/gfscott/eleventy-plugin-embed-everything/blob/main/LICENSE)
+[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v2.0-ff69b4.svg?style=for-the-badge)](https://github.com/gfscott/eleventy-plugin-embed-everything/blob/main/CODE_OF_CONDUCT.md)
 
 This [Eleventy](https://www.11ty.dev/) plugin automatically embeds responsive SoundCloud players from URLs in Markdown files.
 
@@ -110,7 +110,7 @@ http://soundcloud.com/...
 soundcloud.com/...
 ```
 
-If you run across a URL pattern that you think should work, but doesn’t, please [file an issue](https://github.com/gfscott/eleventy-plugin-embed-soundcloud/issues/new)!
+If you run across a URL pattern that you think should work, but doesn’t, please [file an issue](https://github.com/gfscott/eleventy-plugin-embed-everything/issues/new)!
 
 ## ⚠️ Notes and caveats
 
@@ -121,5 +121,5 @@ If you run across a URL pattern that you think should work, but doesn’t, pleas
   - The URL *must* be wrapped in a paragraph tag: `<p>`
   - It *may* also be wrapped in an anchor tag, (*inside* the paragraph): `<a>`
   - The URL string *may* have whitespace around it
-- I’ve tried to accommodate common URL variants, but there are conceivably valid SoundCloud URLs that wouldn’t get recognized. Please [file an issue](https://github.com/gfscott/eleventy-plugin-embed-soundcloud/issues/new) if you run into an edge case!
+- I’ve tried to accommodate common URL variants, but there are conceivably valid SoundCloud URLs that wouldn’t get recognized. Please [file an issue](https://github.com/gfscott/eleventy-plugin-embed-everything/issues/new) if you run into an edge case!
 - This plugin uses [transforms](https://www.11ty.dev/docs/config/#transforms), so it alters Eleventy’s HTML output as it’s generated. It doesn’t alter the source Markdown.

--- a/packages/spotify/README.md
+++ b/packages/spotify/README.md
@@ -1,10 +1,10 @@
 # eleventy-plugin-embed-spotify
 
 [![NPM Version](https://img.shields.io/npm/v/eleventy-plugin-embed-spotify?style=for-the-badge)](https://www.npmjs.com/package/eleventy-plugin-embed-spotify)
-[![Build test status](https://img.shields.io/github/actions/workflow/status/gfscott/eleventy-plugin-embed-spotify/test-and-codecov.yml?branch=main&style=for-the-badge)](https://github.com/gfscott/eleventy-plugin-embed-spotify/actions?query=workflow%3A%22Node.js+CI+and+Codecov%22)
-[![Code coverage](https://img.shields.io/codecov/c/gh/gfscott/eleventy-plugin-embed-spotify/main?style=for-the-badge)](https://codecov.io/gh/gfscott/eleventy-plugin-embed-spotify)\
-[![MIT License](https://img.shields.io/github/license/gfscott/eleventy-plugin-embed-spotify?style=for-the-badge)](https://github.com/gfscott/eleventy-plugin-embed-spotify/blob/master/LICENSE)
-[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v2.0-ff69b4.svg?style=for-the-badge)](code_of_conduct.md)
+[![Build test status](https://img.shields.io/github/actions/workflow/status/gfscott/eleventy-plugin-embed-everything/test.yml?branch=main&style=for-the-badge)](https://github.com/gfscott/eleventy-plugin-embed-everything/actions/workflows/test.yml?query=branch%3Amain)
+[![codecov](https://img.shields.io/codecov/c/github/gfscott/eleventy-plugin-embed-everything?style=for-the-badge)](https://codecov.io/gh/gfscott/eleventy-plugin-embed-everything)\
+[![MIT License](https://img.shields.io/github/license/gfscott/eleventy-plugin-embed-everything?style=for-the-badge)](https://github.com/gfscott/eleventy-plugin-embed-everything/blob/main/LICENSE)
+[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v2.0-ff69b4.svg?style=for-the-badge)](https://github.com/gfscott/eleventy-plugin-embed-everything/blob/main/CODE_OF_CONDUCT.md)
 
 This [Eleventy](https://www.11ty.dev/) plugin automatically embeds responsive Spotify tracks from URLs in Markdown files.
 
@@ -122,7 +122,7 @@ https://spotify.com/track/7nJZ9LplJ3ZAyhQyJCJk0K
 https://open.spotify.com/track/7nJZ9LplJ3ZAyhQyJCJk0K?si=3qc9p-sGR3es3e8kkP9VFA
 ```
 
-If you run across a URL pattern that you think should work, but doesn’t, please [file an issue](https://github.com/gfscott/eleventy-plugin-embed-spotify/issues/new)!
+If you run across a URL pattern that you think should work, but doesn’t, please [file an issue](https://github.com/gfscott/eleventy-plugin-embed-everything/issues/new)!
 
 <span id="notes-and-caveats"></span>
 ## ⚠️ Notes and caveats
@@ -132,7 +132,7 @@ If you run across a URL pattern that you think should work, but doesn’t, pleas
   - The URL *must* be wrapped in a paragraph tag: `<p>`
   - It *may* also be wrapped in an anchor tag, (*inside* the paragraph): `<a>`
   - The URL string *may* have whitespace around it
-- I’ve tried to accommodate common variants, but there are conceivably valid Spotify URLs that wouldn’t get recognized. Please [file an issue](https://github.com/gfscott/eleventy-plugin-embed-spotify/issues/new) if you run into an edge case!
+- I’ve tried to accommodate common variants, but there are conceivably valid Spotify URLs that wouldn’t get recognized. Please [file an issue](https://github.com/gfscott/eleventy-plugin-embed-everything/issues/new) if you run into an edge case!
 - This plugin uses [transforms](https://www.11ty.dev/docs/config/#transforms), so it alters Eleventy’s HTML output as it’s generated. It doesn’t alter the source Markdown.
 - The embedded player is not responsive by default. Spotify’s default player is 300 pixels wide by 380 pixels tall.
 - **New in 1.1.0:** The embedded podcast player _is_ responsive, in keeping with Spotify’s defaults. Currently, all podcast episode players will be 232 pixels tall, with 100% width.

--- a/packages/tiktok/README.md
+++ b/packages/tiktok/README.md
@@ -1,9 +1,9 @@
 # eleventy-plugin-embed-tiktok
 
 [![NPM Version](https://img.shields.io/npm/v/eleventy-plugin-embed-tiktok?style=for-the-badge)](https://www.npmjs.com/package/eleventy-plugin-embed-tiktok)
-[![Build test status](https://img.shields.io/github/actions/workflow/status/gfscott/eleventy-plugin-embed-tiktok/test-and-codecov.yml?branch=main&style=for-the-badge)](https://github.com/gfscott/eleventy-plugin-embed-tiktok/actions?query=workflow%3A%22Node.js+CI+and+Codecov%22)\
-[![MIT License](https://img.shields.io/github/license/gfscott/eleventy-plugin-embed-tiktok?style=for-the-badge)](https://github.com/gfscott/eleventy-plugin-embed-tiktok/blob/master/LICENSE)
-[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v2.0-ff69b4.svg?style=for-the-badge)](CODE_OF_CONDUCT.md)
+[![Build test status](https://img.shields.io/github/actions/workflow/status/gfscott/eleventy-plugin-embed-everything/test.yml?branch=main&style=for-the-badge)](https://github.com/gfscott/eleventy-plugin-embed-everything/actions/workflows/test.yml?query=branch%3Amain)\
+[![MIT License](https://img.shields.io/github/license/gfscott/eleventy-plugin-embed-everything?style=for-the-badge)](https://github.com/gfscott/eleventy-plugin-embed-everything/blob/main/LICENSE)
+[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v2.0-ff69b4.svg?style=for-the-badge)](https://github.com/gfscott/eleventy-plugin-embed-everything/blob/main/CODE_OF_CONDUCT.md)
 
 This [Eleventy](https://www.11ty.dev/) plugin automatically embeds TikTok videos from URLs in markdown files.
 
@@ -74,7 +74,7 @@ https://www.tiktok.com/@guiltyaesthetic/video/6806676200652655877?lang=en
 
 - This plugin is deliberately designed _only_ to embed when the URL is on its own line, and not inline with other text.
 - To do this, it uses a regular expression to recognize TikTok URLs, wrapped in an HTML `<p>` tag. If your Markdown parser produces any other output, it won’t be recognized.
-- I’ve tried to accommodate common URL variants, but there are conceivably valid TikTok URLs that wouldn’t get recognized. Please [file an issue](https://github.com/gfscott/eleventy-plugin-embed-tiktok/issues/new) if you run into an edge case!
+- I’ve tried to accommodate common URL variants, but there are conceivably valid TikTok URLs that wouldn’t get recognized. Please [file an issue](https://github.com/gfscott/eleventy-plugin-embed-everything/issues/new) if you run into an edge case!
 - This plugin uses [transforms](https://www.11ty.dev/docs/config/#transforms), so it alters Eleventy’s HTML output as it’s generated. It doesn’t alter the source markdown.
 - By necessity, this plugin will add a call to TikTok’s third-party JavaScript file. It does this once per page, if that page contains one or more TikTok embeds.
 - TikTok’s embed script applies a bunch of styles. For now this plugin uses TikTok’s default styling, which has has max-width of 605 pixels and a min-width of 325 pixels. 

--- a/packages/twitch/README.md
+++ b/packages/twitch/README.md
@@ -1,9 +1,9 @@
 # eleventy-plugin-embed-twitch
 
 [![NPM Version](https://img.shields.io/npm/v/eleventy-plugin-embed-twitch?style=for-the-badge)](https://www.npmjs.com/package/eleventy-plugin-embed-twitch)
-[![Build test status](https://img.shields.io/github/actions/workflow/status/gfscott/eleventy-plugin-embed-twitch/test-and-codecov.yml?branch=main&style=for-the-badge)](https://github.com/gfscott/eleventy-plugin-embed-twitch/actions?query=workflow%3A%22Node.js+CI+and+Codecov%22)\
-[![MIT License](https://img.shields.io/github/license/gfscott/eleventy-plugin-embed-twitch?style=for-the-badge)](https://github.com/gfscott/eleventy-plugin-embed-twitch/blob/master/LICENSE)
-[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v2.0-ff69b4.svg?style=for-the-badge)](CODE_OF_CONDUCT.md)
+[![Build test status](https://img.shields.io/github/actions/workflow/status/gfscott/eleventy-plugin-embed-everything/test.yml?branch=main&style=for-the-badge)](https://github.com/gfscott/eleventy-plugin-embed-everything/actions/workflows/test.yml?query=branch%3Amain)\
+[![MIT License](https://img.shields.io/github/license/gfscott/eleventy-plugin-embed-everything?style=for-the-badge)](https://github.com/gfscott/eleventy-plugin-embed-everything/blob/main/LICENSE)
+[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v2.0-ff69b4.svg?style=for-the-badge)](https://github.com/gfscott/eleventy-plugin-embed-everything/blob/main/CODE_OF_CONDUCT.md)
 
 This [Eleventy](https://www.11ty.dev/) plugin automatically embeds responsive Twitch videos from URLs in Markdown files.
 
@@ -117,7 +117,7 @@ https://www.twitch.tv/videos/597008599
 
 ```
 
-If you run across a URL pattern that you think should work, but doesn’t, please [file an issue](https://github.com/gfscott/eleventy-plugin-embed-twitch/issues/new)!
+If you run across a URL pattern that you think should work, but doesn’t, please [file an issue](https://github.com/gfscott/eleventy-plugin-embed-everything/issues/new)!
 
 <span id="notes-and-caveats"></span>
 
@@ -128,7 +128,7 @@ If you run across a URL pattern that you think should work, but doesn’t, pleas
   - The URL *must* be wrapped in a paragraph tag: `<p>`
   - It *may* also be wrapped in an anchor tag, (*inside* the paragraph): `<a>`
   - The URL string *may* have whitespace around it
-- I’ve tried to accommodate common variants, but there are conceivably valid URLs that wouldn’t get recognized. Please [file an issue](https://github.com/gfscott/eleventy-plugin-embed-twitch/issues/new) if you run into an edge case!
+- I’ve tried to accommodate common variants, but there are conceivably valid URLs that wouldn’t get recognized. Please [file an issue](https://github.com/gfscott/eleventy-plugin-embed-everything/issues/new) if you run into an edge case!
 - This plugin uses [transforms](https://www.11ty.dev/docs/config/#transforms), so it alters Eleventy’s HTML output as it’s generated. It doesn’t alter the source Markdown.
 - The embedded video is responsive, using the [intrinsic aspect ratio](https://codepen.io/gfscott/pen/qpKqZR?editors=1100) method. It will expand to fill whatever horizontal space is available.
 - The embed dimensions are currently hard-coded to a 16:9 aspect ratio.

--- a/packages/twitter/README.md
+++ b/packages/twitter/README.md
@@ -1,10 +1,10 @@
 # eleventy-plugin-embed-twitter
 
 [![NPM Version](https://img.shields.io/npm/v/eleventy-plugin-embed-twitter?style=for-the-badge)](https://www.npmjs.com/package/eleventy-plugin-embed-twitter)
-[![Build test status](https://img.shields.io/github/actions/workflow/status/gfscott/eleventy-plugin-embed-twitter/test-and-codecov.yml?branch=main&style=for-the-badge)](https://github.com/gfscott/eleventy-plugin-embed-twitter/actions?query=workflow%3A%22Node.js+CI+and+Codecov%22)
-[![codecov](https://img.shields.io/codecov/c/github/gfscott/eleventy-plugin-embed-twitter?style=for-the-badge)](https://codecov.io/gh/gfscott/eleventy-plugin-embed-twitter)\
-[![MIT License](https://img.shields.io/github/license/gfscott/eleventy-plugin-embed-twitter?style=for-the-badge)](https://github.com/gfscott/eleventy-plugin-embed-twitter/blob/master/LICENSE)
-[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v2.0-ff69b4.svg?style=for-the-badge)](CODE_OF_CONDUCT.md)
+[![Build test status](https://img.shields.io/github/actions/workflow/status/gfscott/eleventy-plugin-embed-everything/test.yml?branch=main&style=for-the-badge)](https://github.com/gfscott/eleventy-plugin-embed-everything/actions/workflows/test.yml?query=branch%3Amain)
+[![codecov](https://img.shields.io/codecov/c/github/gfscott/eleventy-plugin-embed-everything?style=for-the-badge)](https://codecov.io/gh/gfscott/eleventy-plugin-embed-everything)\
+[![MIT License](https://img.shields.io/github/license/gfscott/eleventy-plugin-embed-everything?style=for-the-badge)](https://github.com/gfscott/eleventy-plugin-embed-everything/blob/main/LICENSE)
+[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v2.0-ff69b4.svg?style=for-the-badge)](https://github.com/gfscott/eleventy-plugin-embed-everything/blob/main/CODE_OF_CONDUCT.md)
 
 This [Eleventy](https://www.11ty.dev/) plugin automatically embeds Tweets from URLs in markdown files.
 
@@ -179,7 +179,7 @@ As of v1.3.0, `cacheText` uses [`eleventy-cache-assets`](https://www.11ty.dev/do
 
 - This plugin is deliberately designed _only_ to embed when the URL is on its own line, and not inline with other text.
 - To do this, it uses a regular expression to recognize Twitter URLs, wrapped in an HTML `<p>` tag or, optionally, additionally wrapped in an anchor tag. If your Markdown parser produces any other output, it won’t be recognized.
-- The plugin supports common URL variants as well. Check the [supported URL variants](test/inc/validStrings.js) to see the complete list, but there are conceivably valid Twitter URLs that wouldn’t be recognized. Please [file an issue](https://github.com/gfscott/eleventy-plugin-embed-twitter/issues/new) if you run into an edge case!
+- The plugin supports common URL variants as well. Check the [supported URL variants](test/inc/validStrings.js) to see the complete list, but there are conceivably valid Twitter URLs that wouldn’t be recognized. Please [file an issue](https://github.com/gfscott/eleventy-plugin-embed-everything/issues/new) if you run into an edge case!
 - This plugin uses [transforms](https://www.11ty.dev/docs/config/#transforms), so it alters Eleventy’s HTML output as it’s generated. It doesn’t alter the source markdown.
 - By necessity, this plugin will add a call to Twitter’s third-party JavaScript file. It does this once per page, if that page contains a Twitter embed.
 - Currently the plugin supports only individual Tweets. Embedding timelines, lists, or Twitter Moments isn’t possible right now.

--- a/packages/vimeo/README.md
+++ b/packages/vimeo/README.md
@@ -1,10 +1,10 @@
 # eleventy-plugin-vimeo-embed
 
 [![NPM Version](https://img.shields.io/npm/v/eleventy-plugin-vimeo-embed?style=for-the-badge)](https://www.npmjs.com/package/eleventy-plugin-vimeo-embed)
-[![Build test status](https://img.shields.io/github/actions/workflow/status/gfscott/eleventy-plugin-vimeo-embed/test-and-codecov.yml?branch=main&style=for-the-badge)](https://github.com/gfscott/eleventy-plugin-vimeo-embed/actions?query=workflow%3A%22Node.js+CI+and+Codecov%22)
-[![codecov](https://img.shields.io/codecov/c/github/gfscott/eleventy-plugin-vimeo-embed?style=for-the-badge)](https://codecov.io/gh/gfscott/eleventy-plugin-vimeo-embed)\
-[![MIT License](https://img.shields.io/github/license/gfscott/eleventy-plugin-vimeo-embed?style=for-the-badge)](https://github.com/gfscott/eleventy-plugin-vimeo-embed/blob/master/LICENSE)
-[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v2.0-ff69b4.svg?style=for-the-badge)](CODE_OF_CONDUCT.md)
+[![Build test status](https://img.shields.io/github/actions/workflow/status/gfscott/eleventy-plugin-embed-everything/test.yml?branch=main&style=for-the-badge)](https://github.com/gfscott/eleventy-plugin-embed-everything/actions/workflows/test.yml?query=branch%3Amain)
+[![codecov](https://img.shields.io/codecov/c/github/gfscott/eleventy-plugin-embed-everything?style=for-the-badge)](https://codecov.io/gh/gfscott/eleventy-plugin-embed-everything)\
+[![MIT License](https://img.shields.io/github/license/gfscott/eleventy-plugin-embed-everything?style=for-the-badge)](https://github.com/gfscott/eleventy-plugin-embed-everything/blob/main/LICENSE)
+[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v2.0-ff69b4.svg?style=for-the-badge)](https://github.com/gfscott/eleventy-plugin-embed-everything/blob/main/CODE_OF_CONDUCT.md)
 
 This [Eleventy](https://www.11ty.dev/) plugin automatically embeds responsive Vimeo videos from URLs in Markdown files.
 
@@ -105,7 +105,7 @@ https://vimeo.com/347565673?autoplay=1
 https://vimeo.com/347565673#t30s
 ```
 
-If you run across a URL pattern that you think should work, but doesn’t, please [file an issue](https://github.com/gfscott/eleventy-plugin-vimeo-embed/issues/new)!
+If you run across a URL pattern that you think should work, but doesn’t, please [file an issue](https://github.com/gfscott/eleventy-plugin-embed-everything/issues/new)!
 
 ## ⚠️ Notes and caveats
 
@@ -114,7 +114,7 @@ If you run across a URL pattern that you think should work, but doesn’t, pleas
   - The URL *must* be wrapped in a paragraph tag: `<p>`
   - It *may* also be wrapped in an anchor tag, (*inside* the paragraph): `<a>`
   - The URL string *may* have whitespace around it
-- I’ve tried to accommodate common variants, but there are conceivably valid Vimeo URLs that wouldn’t get recognized. Please [file an issue](https://github.com/gfscott/eleventy-plugin-vimeo-embed/issues/new) if you run into an edge case!
+- I’ve tried to accommodate common variants, but there are conceivably valid Vimeo URLs that wouldn’t get recognized. Please [file an issue](https://github.com/gfscott/eleventy-plugin-embed-everything/issues/new) if you run into an edge case!
 - This plugin uses [transforms](https://www.11ty.dev/docs/config/#transforms), so it alters Eleventy’s HTML output as it’s generated. It doesn’t alter the source Markdown.
 - The embedded video is responsive, using the [intrinsic aspect ratio](https://codepen.io/gfscott/pen/qpKqZR?editors=1100) method. It will expand to fill whatever horizontal space is available.
 - The embed dimensions are currently hard-coded to a 16:9 aspect ratio.

--- a/packages/youtube/README.md
+++ b/packages/youtube/README.md
@@ -1,10 +1,10 @@
 # eleventy-plugin-youtube-embed
 
 [![NPM Version](https://img.shields.io/npm/v/eleventy-plugin-youtube-embed?style=for-the-badge)](https://www.npmjs.com/package/eleventy-plugin-youtube-embed)
-[![Build test status](https://img.shields.io/github/actions/workflow/status/gfscott/eleventy-plugin-youtube-embed/test-and-codecov.yml?branch=main&style=for-the-badge)](https://github.com/gfscott/eleventy-plugin-youtube-embed/actions?query=workflow%3A%22Node.js+CI+and+Codecov%22)
-[![codecov](https://img.shields.io/codecov/c/github/gfscott/eleventy-plugin-youtube-embed?style=for-the-badge)](https://codecov.io/gh/gfscott/eleventy-plugin-youtube-embed)\
-[![MIT License](https://img.shields.io/github/license/gfscott/eleventy-plugin-youtube-embed?style=for-the-badge)](https://github.com/gfscott/eleventy-plugin-youtube-embed/blob/master/LICENSE)
-[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v2.0-ff69b4.svg?style=for-the-badge)](code_of_conduct.md)
+[![Build test status](https://img.shields.io/github/actions/workflow/status/gfscott/eleventy-plugin-embed-everything/test.yml?branch=main&style=for-the-badge)](https://github.com/gfscott/eleventy-plugin-embed-everything/actions/workflows/test.yml?query=branch%3Amain)
+[![codecov](https://img.shields.io/codecov/c/github/gfscott/eleventy-plugin-embed-everything?style=for-the-badge)](https://codecov.io/gh/gfscott/eleventy-plugin-embed-everything)\
+[![MIT License](https://img.shields.io/github/license/gfscott/eleventy-plugin-embed-everything?style=for-the-badge)](https://github.com/gfscott/eleventy-plugin-embed-everything/blob/main/LICENSE)
+[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v2.0-ff69b4.svg?style=for-the-badge)](https://github.com/gfscott/eleventy-plugin-embed-everything/blob/main/CODE_OF_CONDUCT.md)
 
 This [Eleventy](https://www.11ty.dev/) plugin automatically embeds responsive YouTube videos from URLs in Markdown files. It’s part of the [`eleventy-plugin-embed-everything`](https://gfscott.com/embed-everything/) project.
 
@@ -261,18 +261,18 @@ https://www.youtube.com/watch?v=LQaehcfXvK0&feature=youtu.be
 https://www.youtube.com/watch?v=dQw4w9WgXcQ&list=RDdQw4w9WgXcQ&start_radio=1&t=1
 ```
 
-If you really want to get into the weeds, inspect [`test/_inc/validUrls.js`](test/_inc/validUrls.js), which generates the comprehensive list of URL patterns that are explicitly tested. And if you run across a URL pattern that you think should work, but doesn’t, please [file an issue](https://github.com/gfscott/eleventy-plugin-youtube-embed/issues/new)!
+If you really want to get into the weeds, inspect [`test/_inc/validUrls.js`](test/_inc/validUrls.js), which generates the comprehensive list of URL patterns that are explicitly tested. And if you run across a URL pattern that you think should work, but doesn’t, please [file an issue](/issues/new)!
 
 <span id="notes-and-caveats"></span>
 
 ## ⚠️ Notes and caveats
 
 - This plugin is deliberately designed _only_ to embed videos when the URL is on its own line, and not inline with other text.
-- To do this, it uses [a regular expression](https://github.com/gfscott/eleventy-plugin-youtube-embed/blob/main/lib/spotPattern.js#L1) to recognize YouTube video URLs. Currently these are the limitations on what it can recognize in a Markdown parser’s HTML output:
+- To do this, it uses [a regular expression](lib/spotPattern.js#L1) to recognize YouTube video URLs. Currently these are the limitations on what it can recognize in a Markdown parser’s HTML output:
   - The URL *must* be wrapped in a paragraph tag: `<p>`
   - It *may* also be wrapped in an anchor tag, (*inside* the paragraph): `<a>`
   - The URL string *may* have whitespace around it
-- I’ve tried to accommodate common variants (like short **youtu.be** links, for example), but there are conceivably valid YouTube URLs that wouldn’t get recognized. Please [file an issue](https://github.com/gfscott/eleventy-plugin-youtube-embed/issues/new) if you run into an edge case!
+- I’ve tried to accommodate common variants (like short **youtu.be** links, for example), but there are conceivably valid YouTube URLs that wouldn’t get recognized. Please [file an issue](/issues/new) if you run into an edge case!
 - This plugin uses [transforms](https://www.11ty.dev/docs/config/#transforms), so it alters Eleventy’s HTML output as it’s generated. It doesn’t alter the source Markdown.
 - Right now it supports only single videos, not playlists.
 - The embedded video is responsive, using the [intrinsic aspect ratio](https://codepen.io/gfscott/pen/qpKqZR?editors=1100) method. It will expand to fill whatever horizontal space is available.


### PR DESCRIPTION
Following the completion of the migration to the monorepo (See #145) this PR brings each of the individual package readmes up to date.

- Updating URLs for opening new issues
- Updating badge image URLs and links
- General cleanup