### PR TITLE
Switch from old eleventy-cache-assets package to eleventy-fetch

### DIFF
--- a/.changeset/dull-trainers-vanish.md
+++ b/.changeset/dull-trainers-vanish.md
@@ -1,0 +1,5 @@
+---
+"eleventy-plugin-embed-twitter": patch
+---
+
+Switch to @11ty/eleventy-fetch package for optional data caching

--- a/packages/twitter/README.md
+++ b/packages/twitter/README.md
@@ -74,7 +74,7 @@ The plugin’s default settings reside in [lib/pluginDefaults.js](lib/pluginDefa
       <td>✨ <b>New in v1.3.0!</b><br><code>cacheDuration</code></td>
       <td>String</td>
       <td><code>5m</code></td>
-      <td>How long to cache the response from Twitter’s servers when <code>cacheText</code> is <code>true</code>. Use the <a href="https://www.11ty.dev/docs/plugins/cache/#change-the-cache-duration"><code>eleventy-cache-assets</code></a> syntax to set the duration. See also <a href="#cacheText">Caching Tweet content as plain HTML</a>.</td>
+      <td>How long to cache the response from Twitter’s servers when <code>cacheText</code> is <code>true</code>. Use the <a href="https://www.11ty.dev/docs/plugins/fetch/#change-the-cache-duration"><code>eleventy-fetch</code></a> syntax to set the duration. See also <a href="#cacheText">Caching Tweet content as plain HTML</a>.</td>
     </tr>
     <tr>
       <td><code>cacheText</code></td>
@@ -173,7 +173,7 @@ eleventyConfig.addPlugin(embedTwitter, {
 });
 ```
 
-As of v1.3.0, `cacheText` uses [`eleventy-cache-assets`](https://www.11ty.dev/docs/plugins/cache/) to download the text of the Tweet and cache it locally for up to 5 minutes, which reduces the overall number of network calls and speeds up builds. You can configure the cache timing with the `cacheDuration` option. If the plugin experiences any network failure (such as if you're not connected to the internet), then it simply won’t complete the embed and the Tweet URL will be rendered as plain text.
+As of v1.3.6, `cacheText` uses [`eleventy-fetch`](https://www.11ty.dev/docs/plugins/fetch/) to download the text of the Tweet and cache it locally for up to 5 minutes, which reduces the overall number of network calls and speeds up builds. You can configure the cache timing with the `cacheDuration` option. If the plugin experiences any network failure (such as if you're not connected to the internet), then it simply won’t complete the embed and the Tweet URL will be rendered as plain text.
 
 ## Notes and caveats
 

--- a/packages/twitter/lib/buildEmbed.js
+++ b/packages/twitter/lib/buildEmbed.js
@@ -1,5 +1,5 @@
 const {URL} = require("url");
-const Cache = require("@11ty/eleventy-cache-assets");
+const Cache = require("@11ty/eleventy-fetch");
 const buildOptions = require("./buildOptions.js");
 const merge = require("deepmerge");
 

--- a/packages/twitter/package.json
+++ b/packages/twitter/package.json
@@ -36,7 +36,7 @@
   },
   "bugs": "https://github.com/gfscott/eleventy-plugin-embed-everything/issues",
   "dependencies": {
-    "@11ty/eleventy-cache-assets": "^2.3.0",
+    "@11ty/eleventy-fetch": "^3.0.0",
     "deepmerge": "^4.3.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,10 +64,10 @@ importers:
 
   packages/twitter:
     specifiers:
-      '@11ty/eleventy-cache-assets': ^2.3.0
+      '@11ty/eleventy-fetch': ^3.0.0
       deepmerge: ^4.3.0
     dependencies:
-      '@11ty/eleventy-cache-assets': 2.3.0
+      '@11ty/eleventy-fetch': 3.0.0
       deepmerge: 4.3.0
 
   packages/vimeo:
@@ -82,20 +82,6 @@ importers:
       lite-youtube-embed: 0.2.0
 
 packages:
-
-  /@11ty/eleventy-cache-assets/2.3.0:
-    resolution: {integrity: sha512-W8tvO00GlWaKt3ccpEStaUBoj9BE3EgzuD8uYChCfYbN2Q4HkEItkiapvIJT0zJwAwoMfnSq6VHPLScYlX2XCg==}
-    engines: {node: '>=10'}
-    dependencies:
-      debug: 4.3.4
-      flat-cache: 3.0.4
-      node-fetch: 2.6.8
-      p-queue: 6.6.2
-      short-hash: 1.0.0
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
-    dev: false
 
   /@11ty/eleventy-fetch/3.0.0:
     resolution: {integrity: sha512-qJvfb331rYQAmlCS71Ygg0/XHUdB4/qXBOLsG0DJ1m61WL5JNha52OtKVeQq34u2J2Nfzim+X4TIL/+QyesB7Q==}
@@ -1642,10 +1628,6 @@ packages:
       function-bind: 1.1.1
     dev: false
 
-  /hash-string/1.0.0:
-    resolution: {integrity: sha512-dtNNyxXobzHavayZwOwRWhBTqS9GX4jDjIMsGc0fDyaN2A+4zMn5Ua9ODDCggN6w3Spma6mAHL3ImmW3BkWDmQ==}
-    dev: false
-
   /hasha/5.2.2:
     resolution: {integrity: sha512-Hrp5vIK/xr5SkeN2onO32H0MgNZ0f17HRNH39WfL0SYUNOTZ5Lz1TJ8Pajo/87dYGEFlLMm7mIc/k/s6Bvz9HQ==}
     engines: {node: '>=8'}
@@ -2728,12 +2710,6 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
     dev: true
-
-  /short-hash/1.0.0:
-    resolution: {integrity: sha512-qbUCD2Pkl4IXRyVqneEjGnUr0NGDGLzZnBUVGJngIQZf/FrhOL0yJhH+JQzak0t8xMmScIKpoX1SxOsPHdwa4w==}
-    dependencies:
-      hash-string: 1.0.0
-    dev: false
 
   /side-channel/1.0.4:
     resolution: {integrity: sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==}


### PR DESCRIPTION
There was one package still using the old [eleventy-cache-assets](https://www.npmjs.com/package/@11ty/eleventy-cache-assets) package. This PR upgrades to [eleventy-fetch](https://www.npmjs.com/package/@11ty/eleventy-fetch).