### PR TITLE
Update YouTube regex to enable future features based on URL params

### DIFF
--- a/.changeset/polite-panthers-press.md
+++ b/.changeset/polite-panthers-press.md
@@ -1,0 +1,5 @@
+---
+"eleventy-plugin-youtube-embed": patch
+---
+
+Update internal workings of YouTube regex to enable future functionality

--- a/packages/youtube/.eleventy.js
+++ b/packages/youtube/.eleventy.js
@@ -12,7 +12,7 @@ module.exports = function (eleventyConfig, options) {
         return content;
       }
       matches.forEach(function (stringToReplace, index) {
-        let videoId = extractVideoId(stringToReplace);
+        let {id: videoId} = extractVideoId(stringToReplace);
         let embedCode = buildEmbedCodeString(videoId, pluginConfig, index);
         content = content.replace(stringToReplace, embedCode);
       });

--- a/packages/youtube/lib/extractMatches.js
+++ b/packages/youtube/lib/extractMatches.js
@@ -2,12 +2,17 @@
  * Video ID is 4th item in array of matches.
  * [0]    = full matched string
  * [1, 2] = zero-backtrack arbitrary whitespace, requires capture for lookahead
- * [3]    = video ID
- * [4, 5] = zero-backtrack arbitrary whitespace, requires capture for lookahead
+ * [3]    = full YouTube url
+ * [4]    = video ID
+ * [5, 6] = zero-backtrack arbitrary whitespace, requires capture for lookahead
  */
 
-const pattern = /<p>(?=(\s*))\1(?:<a [^>]*?>)??(?=(\s*))\2(?:https?:\/\/)??(?:w{3}\.)??(?:youtube\.com|youtu\.be)\/(?:watch\?v=|embed\/)??([A-Za-z0-9-_]{11})(?:[^\s<>]*)(?=(\s*))\4(?:<\/a>)??(?=(\s*))\5<\/p>/;
+const pattern = /<p>(?=(\s*))\1(?:<a [^>]*?>)??(?=(\s*))\2((?:https?:\/\/)??(?:w{3}\.)??(?:youtube\.com|youtu\.be)\/(?:watch\?v=|embed\/)??([A-Za-z0-9-_]{11})(?:[^\s<>]*))(?=(\s*))\5(?:<\/a>)??(?=(\s*))\6<\/p>/;
 
 module.exports = function(str) {
-  return str.match(pattern)[3]
+  const matchArray = str.match(pattern);
+  return {
+    id: matchArray[4],
+    url: matchArray[3]
+  }
 }

--- a/packages/youtube/test/extractMatches.test.js
+++ b/packages/youtube/test/extractMatches.test.js
@@ -10,24 +10,32 @@ const validUrls = require('./_inc/validUrls.js');
 for (let [index, url] of validUrls.entries()) {
 
   test(`Valid-${index}: (${url}) without link, without whitespace`, t => {
-    t.is(extractMatches(`<p>${url}</p>`), 'hIs5StN8J-0');
+    const {id: videoId, url: videoUrl } = extractMatches(`<p>${url}</p>`)
+    t.is(videoId, 'hIs5StN8J-0');
+    t.is(videoUrl, url)
   });
 
   test(`Valid-${index}: (${url}) without link, with whitespace`, t => {
-    t.is(extractMatches(`<p>
-      ${url}
-    </p>`), 'hIs5StN8J-0');
+    const {id: videoId, url: videoUrl } = extractMatches(`<p>
+    ${url}
+  </p>`)
+    t.is(videoId, 'hIs5StN8J-0');
+    t.is(videoUrl, url)
   });
 
   test(`Valid-${index}: (${url}) with link, without whitespace`, t => {
-    t.is(extractMatches(`<p><a href="${url}">${url}</a></p>`), 'hIs5StN8J-0');
+    const {id: videoId, url: videoUrl } = extractMatches(`<p><a href="${url}">${url}</a></p>`)
+    t.is(videoId, 'hIs5StN8J-0');
+    t.is(videoUrl, url)
   });
 
   test(`Valid-${index}: (${url}) with link, with whitespace`, t => {
-    t.is(extractMatches(`<p>
-      <a href="${url}">
-        ${url}
-      </a>
-    </p>`), 'hIs5StN8J-0');
+    const {id: videoId, url: videoUrl } = extractMatches(`<p>
+    <a href="${url}">
+      ${url}
+    </a>
+  </p>`)
+    t.is(videoId, 'hIs5StN8J-0');
+    t.is(videoUrl, url)
   });
 }


### PR DESCRIPTION
For certain future functionality (including: playlists, non-zero start times, and YouTube Shorts), it would be helpful to have access to the full YouTube URL, including params, instead of just the video ID value. This PR adds the ability to extract and, in future, return the full URL. Currently unused but this lays the groundwork.