### PR TITLE
Add workflow to sync next branch with main

### DIFF
--- a/.github/workflows/sync_next.yml
+++ b/.github/workflows/sync_next.yml
@@ -1,0 +1,24 @@
+name: Sync “next” branch with main
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  sync:
+    # prevents this action from running on forks
+    if: github.repository == 'gfscott/eleventy-plugin-embed-everything'
+
+    name: Sync “next” branch with main
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+      
+      # Source: modified from a shopify/hydrogen workflow:
+      # https://github.com/Shopify/hydrogen/blob/main/.github/workflows/sync_main.yml
+      - name: Push to “next” branch
+        run: |
+          git show-ref
+          git push origin HEAD:next --force


### PR DESCRIPTION
This will enable automatic prerelease publishing from a `next` branch that's always synchronized with main.