### PR TITLE
Switch console log dependency from chalk to kleur

### DIFF
--- a/.changeset/soft-trees-matter.md
+++ b/.changeset/soft-trees-matter.md
@@ -1,0 +1,5 @@
+---
+"eleventy-plugin-embed-twitch": patch
+---
+
+Switch dependency from chalk to kleur to display parent console warning

--- a/packages/twitch/lib/buildEmbed.js
+++ b/packages/twitch/lib/buildEmbed.js
@@ -1,4 +1,4 @@
-const chalk = require('chalk');
+const kleur = require('kleur');
 
 module.exports = function(media, options) {
 
@@ -9,9 +9,9 @@ module.exports = function(media, options) {
    * We coerce the empty string to falsy with the triple-bang trick.
    */
   if ( !!!options.parent ) {
-    console.error(`⚠️  ${ chalk.red('Error embedding Twitch video') }
-  Eleventy plugin ${chalk.cyan('eleventy-plugin-embed-twitch')} requires a \`parent\` option to be set.
-  🔗  See ${chalk.cyan.underline('https://bit.ly/11ty-plugin-twitch-parent-error')} for details.`);
+    console.error(`⚠️  ${ kleur.red('Error embedding Twitch video') }
+  Eleventy plugin ${kleur.cyan('eleventy-plugin-embed-twitch')} requires a \`parent\` option to be set.
+  🔗  See ${kleur.cyan().underline('https://bit.ly/11ty-plugin-twitch-parent-error')} for details.`);
 }
   
   // Build the string, using config data as we go

--- a/packages/twitch/package.json
+++ b/packages/twitch/package.json
@@ -29,7 +29,7 @@
     "url": "https://github.com/gfscott/eleventy-plugin-embed-everything.git"
   },
   "bugs": "https://github.com/gfscott/eleventy-plugin-embed-everything/issues",
-  "dependencies": {
-    "chalk": "^4.1.2"
+  "devDependencies": {
+    "kleur": "^4.1.5"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,9 +58,9 @@ importers:
 
   packages/twitch:
     specifiers:
-      chalk: ^4.1.2
-    dependencies:
-      chalk: 4.1.2
+      kleur: ^4.1.5
+    devDependencies:
+      kleur: 4.1.5
 
   packages/twitter:
     specifiers:
@@ -2004,7 +2004,6 @@ packages:
   /kleur/4.1.5:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
     engines: {node: '>=6'}
-    dev: false
 
   /lines-and-columns/1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}


### PR DESCRIPTION
Following on from #140, this PR switches from [chalk](https://www.npmjs.com/package/chalk) to [kleur](https://www.npmjs.com/package/kleur). Chose it because it's what 11ty uses.