### PR TITLE
Decode ampersands before parsing URL params

### DIFF
--- a/.changeset/tame-years-fold.md
+++ b/.changeset/tame-years-fold.md
@@ -1,0 +1,5 @@
+---
+"eleventy-plugin-youtube-embed": patch
+---
+
+Decode HTML-encoded ampersands before parsing URL params

--- a/packages/youtube/lib/buildEmbed.js
+++ b/packages/youtube/lib/buildEmbed.js
@@ -20,7 +20,10 @@ module.exports = function(videoData, options, index) {
  * is higher,so we let them override general plugin-level settings.
  */
 function parseInputUrlParams(url) {
-  let params = new URL(url).searchParams;
+  // URLSearchParams object doesn't escape HTML-encoded ampersands, 
+  // so replace them before parsing
+  let unescapedUrl = url.replace("&amp;", "&")
+  let params = new URL(unescapedUrl).searchParams;
   let urlOptions = new Object;
   
   // YouTube treats 'start' and 't' params as synonymous but 't' is the


### PR DESCRIPTION
Followup to #167 — discovered during prerelease testing that the [URLSearchParams](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams) API doesn't interpret `&amp;` in a URL as a literal `&` character. Therefore, a parameter that appears in markdown as `&start=10` would get encoded by 11ty as `&amp;start=10`, then get parsed by URLSearchParams inside the plugin as a param key of `amp;start`, not `start` as intended.

As a result, `?t=10` would be parsed correctly, but `?v={id}&t=10` wouldn't. This PR decodes the ampersand character before continuing to parse the URL.