### PR TITLE
Make two implicit defaults explicit

### DIFF
--- a/.changeset/slimy-crabs-float.md
+++ b/.changeset/slimy-crabs-float.md
@@ -1,0 +1,5 @@
+---
+"eleventy-plugin-youtube-embed": patch
+---
+
+Make implicit defaults explicit

--- a/packages/youtube/lib/pluginDefaults.js
+++ b/packages/youtube/lib/pluginDefaults.js
@@ -5,7 +5,9 @@ exports.pluginDefaults = {
   embedClass: 'eleventy-plugin-youtube-embed',
   lazy: false,
   lite: false,
-  noCookie: true
+  modestBranding: false,
+  noCookie: true,
+  recommendSelfOnly: false,
 };
 
 exports.liteDefaults = {


### PR DESCRIPTION
In 1.7.0 we introduced two new options, `modestBranding` and `recommendSelfOnly`, which affect some presentational behaviors of the default YouTube embed. Both were documented as being false by default, which is functionally true, but the options themselves were not added to the plugin default options, so they were really just `undefined`.

This PR adds those options to the plugin defaults so they're explicitly set as `false`.