### PR TITLE
Add option to override Lite Youtube thumbnail quality

### DIFF
--- a/.changeset/lovely-squids-push.md
+++ b/.changeset/lovely-squids-push.md
@@ -1,0 +1,5 @@
+---
+"eleventy-plugin-youtube-embed": minor
+---
+
+Add option to use different image thumbnail sizes in lite mode

--- a/packages/youtube/README.md
+++ b/packages/youtube/README.md
@@ -211,12 +211,6 @@ eleventyConfig.addPlugin(embedYouTube, {
       <td>Pass a custom URL to load the necessary CSS from the source of your choice.</td>
     </tr>
     <tr>
-      <td>✨ <b>New in v1.9.0!</b><br><code>lite.thumbnailQuality</code></td>
-      <td>String</td>
-      <td><code>hqdefault</code></td>
-      <td>Override the requested <a href="https://gist.github.com/protrolium/8831763">YouTube thumbnail image file</a>. Accepted values are <code>default</code>, <code>hqdefault</code>, <code>mqdefault</code>, <code>sddefault</code>, <code>maxresdefault</code>. Note that not all sizes are available for all videos. If the requested resolution isn’t available, YouTube shows a generic placeholder instead.</td>
-    </tr>
-    <tr>
       <td><code>lite.js.enabled</code></td>
       <td>Boolean</td>
       <td><code>true</code></td>
@@ -233,6 +227,12 @@ eleventyConfig.addPlugin(embedYouTube, {
       <td>String</td>
       <td><code>https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@master/src/lite-yt-embed.min.js</code></td>
       <td>Pass a custom URL to load the necessary JavaScript from the source of your choice.</td>
+    </tr>
+    <tr>
+      <td>✨ <b>New in v1.9.0!</b><br><code>lite.thumbnailQuality</code></td>
+      <td>String</td>
+      <td><code>hqdefault</code></td>
+      <td>Override the requested <a href="https://gist.github.com/protrolium/8831763">YouTube thumbnail image file</a>. Accepted values are <code>default</code>, <code>hqdefault</code>, <code>mqdefault</code>, <code>sddefault</code>, <code>maxresdefault</code>. Note that not all sizes are available for all videos. If the requested resolution isn’t available, YouTube shows a generic placeholder instead.</td>
     </tr>
   </tbody>
 </table>

--- a/packages/youtube/README.md
+++ b/packages/youtube/README.md
@@ -124,7 +124,7 @@ The plugin’s default settings reside in [lib/pluginDefaults.js](lib/pluginDefa
       <td>Setting this to <code>true</code> will use Paul Irish’s <a href="https://github.com/paulirish/lite-youtube-embed">Lite YouTube Embed</a> method. See the section on the <a href="#lite">Lite version</a> below for more details.</td>
     </tr>
     <tr>
-      <td>✨ <b>New in v1.7.0!</b><br> <code>modestBranding</code></td>
+      <td><code>modestBranding</code></td>
       <td>Boolean</td>
       <td><code>false</code></td>
       <td>Setting this to <code>true</code> will add a <code>modestbranding=1</code> attribute to the embed url. This will tell YouTube to show <a href="https://developers.google.com/youtube/player_parameters#modestbranding">minimal YouTube branding</a></td>
@@ -136,7 +136,7 @@ The plugin’s default settings reside in [lib/pluginDefaults.js](lib/pluginDefa
       <td>Defaults to the “<a href="https://support.google.com/youtube/answer/171780?hl=en#zippy=,turn-on-privacy-enhanced-mode">privacy-enhanced</a>” <code>www.youtube-nocookie.com</code> domain. Change this to <code>false</code> to use <code>www.youtube.com</code>.</td>
     </tr>
     <tr>
-      <td>✨ <b>New in v1.7.0!</b><br> <code>recommendSelfOnly</code></td>
+      <td><code>recommendSelfOnly</code></td>
       <td>Boolean</td>
       <td><code>false</code></td>
       <td>Setting this to <code>true</code> will add a <code>rel=0</code> attribute to the embed url. This will tell YouTube to <a href="https://developers.google.com/youtube/player_parameters#rel">recommend videos from the same channel.</a></td>
@@ -209,6 +209,12 @@ eleventyConfig.addPlugin(embedYouTube, {
       <td>String</td>
       <td><code>https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@master/src/lite-yt-embed.min.css</code></td>
       <td>Pass a custom URL to load the necessary CSS from the source of your choice.</td>
+    </tr>
+    <tr>
+      <td>✨ <b>New in v1.9.0!</b><br><code>lite.thumbnailQuality</code></td>
+      <td>String</td>
+      <td><code>hqdefault</code></td>
+      <td>Override the requested <a href="https://gist.github.com/protrolium/8831763">YouTube thumbnail image file</a>. Accepted values are <code>default</code>, <code>hqdefault</code>, <code>mqdefault</code>, <code>sddefault</code>, <code>maxresdefault</code>. Note that not all sizes are available for all videos. If the requested resolution isn’t available, YouTube shows a generic placeholder instead.</td>
     </tr>
     <tr>
       <td><code>lite.js.enabled</code></td>

--- a/packages/youtube/lib/buildEmbed.js
+++ b/packages/youtube/lib/buildEmbed.js
@@ -51,6 +51,7 @@ if(params.length > 0) {
 function liteEmbed({id, url}, options, index) {
   options = Object.assign({}, options, parseInputUrlParams(url))
   let liteOpt = liteConfig(options);
+  liteOpt.thumbnailQuality = validateThumbnailSize(liteOpt.thumbnailQuality);
   let out = '';
 
   const fs = require('fs');
@@ -71,7 +72,7 @@ function liteEmbed({id, url}, options, index) {
     out += liteOpt.js.inline ? `<script>${inlineJs}</script>\n` : `<script defer="defer" src="${liteOpt.js.path}"></script>\n`;
   }
   out += `<div id="${id}" class="${options.embedClass}">`;
-  out += `<lite-youtube videoid="${id}" style="background-image: url('https://i.ytimg.com/vi/${id}/hqdefault.jpg');"`
+  out += `<lite-youtube videoid="${id}" style="background-image: url('https://i.ytimg.com/vi/${id}/${liteOpt.thumbnailQuality}.jpg');"`
   out += params ? ` params="${params}"`: "";
   out += `>`;
   out += `<div class="lty-playbtn"></div>`;
@@ -120,3 +121,24 @@ function defaultEmbed({id, url}, options){
   out += '></iframe></div>';
   return out;
 }
+
+/**
+ * 
+ * @param {String} inputString 
+ * @returns {String} that is a valid thumbnail filename.
+ * 
+ * This does *not* check that an image of this size exists, simply
+ * that the filename matches a set of valid filenames. If an invalid
+ * string is passed, it returns the default value.
+ * 
+ */
+const { thumbnails } = require('./pluginDefaults.js');
+
+function validateThumbnailSize(inputString = thumbnails.defaultSize) { 
+  if ( !thumbnails.validSizes.includes(inputString) ) {
+    return thumbnails.defaultSize
+  }
+  return inputString;
+}
+
+module.exports.validateThumbnailSize = validateThumbnailSize;

--- a/packages/youtube/lib/pluginDefaults.js
+++ b/packages/youtube/lib/pluginDefaults.js
@@ -1,4 +1,4 @@
-exports.pluginDefaults = {
+const pluginDefaults = {
   allowAttrs: 'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture',
   allowAutoplay: false,
   allowFullscreen: true,
@@ -10,15 +10,25 @@ exports.pluginDefaults = {
   recommendSelfOnly: false,
 };
 
-exports.liteDefaults = {
+const thumbnails = {
+  validSizes: ["default", "hqdefault", "mqdefault", "sddefault", "maxresdefault"],
+  defaultSize: "hqdefault"
+}
+
+const liteDefaults = {
   css: {
     enabled: true,
     inline: false,
     path: 'https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@master/src/lite-yt-embed.min.css'
   },
+  thumbnailQuality: thumbnails.defaultSize,
   js: {
     enabled: true,
     inline: false,
     path: 'https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@master/src/lite-yt-embed.min.js'
   }
 };
+  
+module.exports.thumbnails = thumbnails;
+module.exports.liteDefaults = liteDefaults;
+module.exports.pluginDefaults = pluginDefaults;

--- a/packages/youtube/lib/pluginDefaults.js
+++ b/packages/youtube/lib/pluginDefaults.js
@@ -21,12 +21,12 @@ const liteDefaults = {
     inline: false,
     path: 'https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@master/src/lite-yt-embed.min.css'
   },
-  thumbnailQuality: thumbnails.defaultSize,
   js: {
     enabled: true,
     inline: false,
     path: 'https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@master/src/lite-yt-embed.min.js'
-  }
+  },
+  thumbnailQuality: thumbnails.defaultSize,
 };
   
 module.exports.thumbnails = thumbnails;

--- a/packages/youtube/test/buildEmbed.test.js
+++ b/packages/youtube/test/buildEmbed.test.js
@@ -2,7 +2,7 @@ const test = require('ava');
 const extractMatches = require('../lib/extractMatches.js');
 const buildEmbed = require('../lib/buildEmbed.js');
 const { validateThumbnailSize } = require('../lib/buildEmbed.js');
-const { pluginDefaults, thumbnails } = require('../lib/pluginDefaults.js');
+const { pluginDefaults } = require('../lib/pluginDefaults.js');
 
 const videoData = extractMatches('<p>https://www.youtube.com/watch?v=hIs5StN8J-0</p>');
 

--- a/packages/youtube/test/buildEmbed.test.js
+++ b/packages/youtube/test/buildEmbed.test.js
@@ -1,7 +1,8 @@
 const test = require('ava');
 const extractMatches = require('../lib/extractMatches.js');
 const buildEmbed = require('../lib/buildEmbed.js');
-const { pluginDefaults } = require('../lib/pluginDefaults.js');
+const { validateThumbnailSize } = require('../lib/buildEmbed.js');
+const { pluginDefaults, thumbnails } = require('../lib/pluginDefaults.js');
 
 const videoData = extractMatches('<p>https://www.youtube.com/watch?v=hIs5StN8J-0</p>');
 
@@ -93,6 +94,16 @@ test(`Build embed lite mode, zero index, lite defaults`, t => {
   `<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@master/src/lite-yt-embed.min.css">\n<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@master/src/lite-yt-embed.min.js"></script>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
   );
 });
+test(`Build embed lite mode, zero index, valid thumbnail quality override`, t => {
+  t.is(buildEmbed(videoData, override({lite: { thumbnailQuality: 'maxresdefault'}}), 0),
+  `<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@master/src/lite-yt-embed.min.css">\n<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@master/src/lite-yt-embed.min.js"></script>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/maxresdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+  );
+});
+test(`Build embed lite mode, zero index, invalid thumbnail quality override`, t => {
+  t.is(buildEmbed(videoData, override({lite: { thumbnailQuality: 'nope'}}), 0),
+  `<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@master/src/lite-yt-embed.min.css">\n<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@master/src/lite-yt-embed.min.js"></script>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+  );
+});
 test(`Build embed lite mode, zero index, lite defaults with URL start time param`, t => {
   t.is(buildEmbed(extractMatches('<p>https://www.youtube.com/watch?v=hIs5StN8J-0&t=30s</p>'), override({lite: true}), 0),
   `<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@master/src/lite-yt-embed.min.css">\n<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@master/src/lite-yt-embed.min.js"></script>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');" params="start=30s"><div class="lty-playbtn"></div></lite-youtube></div>`
@@ -176,4 +187,25 @@ test(`Build embed lite mode, 1+ index, js inline`, t => {
   t.is(buildEmbed(videoData, override({lite:{js:{inline: true}}}), 1),
   `<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
   );
+});
+
+/**
+ * In lite mode, test that the thumbnail size validator returns the expected values.
+*/
+test(`Thumbnail validator returns default value in response to empty parameter`, t => {
+  t.is(validateThumbnailSize(), 'hqdefault');
+});
+test(`Thumbnail validator returns default value in response to incorrect parameter types`, t => {
+  t.is(validateThumbnailSize(1), 'hqdefault');
+  t.is(validateThumbnailSize(true), 'hqdefault');
+});
+test(`Thumbnail validator returns default value in response to invalid string`, t => {
+  t.is(validateThumbnailSize('foo'), 'hqdefault');
+});
+test(`Thumbnail validator returns expected strings when passed expected strings`, t => {
+  t.is(validateThumbnailSize('default'), 'default');
+  t.is(validateThumbnailSize('hqdefault'), 'hqdefault');
+  t.is(validateThumbnailSize('mqdefault'), 'mqdefault');
+  t.is(validateThumbnailSize('sddefault'), 'sddefault');
+  t.is(validateThumbnailSize('maxresdefault'), 'maxresdefault');
 });


### PR DESCRIPTION
Closes #173 

This PR adds the ability to specify additional thumbnail image sizes when using the `lite` option for YouTube. Be aware that not all videos have all resolutions available. If the size you request is doesn't exist, then YouTube will serve a [generic placeholder image](https://i.ytimg.com/vi/example/maxresdefault.jpg) instead.

[Available sizes](https://gist.github.com/protrolium/8831763) are `"default"`, `"hqdefault"`, `"mqdefault"`, `"sddefault"`, and `"maxresdefault"`.

## Usage

In your Eleventy config file, pass a`lite.thumbnailQuality` value to the plugin as part of its options object:

```js
// .eleventy.js or config.eleventy.js, or whatever your config file is

// If using the YouTube plugin on its own
eleventyConfig.addPlugin(embedYouTube, {
  lite: {
    thumbnailQuality: 'maxresdefault'
  }
});

// If using Embed Everything
eleventyConfig.addPlugin(embedEverything, {
  youtube: {
    options: {
      lite: {
        thumbnailQuality: 'maxresdefault'
      }
    }
  }
});
```
