### PR TITLE
Better handling of URL edge cases

### DIFF
--- a/.changeset/spotty-cobras-impress.md
+++ b/.changeset/spotty-cobras-impress.md
@@ -1,0 +1,5 @@
+---
+"eleventy-plugin-youtube-embed": patch
+---
+
+More error-resistant handling of URL edge cases

--- a/packages/youtube/lib/buildEmbed.js
+++ b/packages/youtube/lib/buildEmbed.js
@@ -20,6 +20,10 @@ module.exports = function(videoData, options, index) {
  * is higher,so we let them override general plugin-level settings.
  */
 function parseInputUrlParams(url) {
+  // Regex accpets protocol-less URLs, but Node's URL constructor can't.
+  // So prepend https:// if it's missing.
+  url = url.startsWith('http') ? url : `https://${url}`;
+
   // URLSearchParams object doesn't escape HTML-encoded ampersands, 
   // so replace them before parsing
   let unescapedUrl = url.replace("&amp;", "&")
@@ -28,8 +32,10 @@ function parseInputUrlParams(url) {
   
   // YouTube treats 'start' and 't' params as synonymous but 't' is the
   // official param so if you pass both 't' wins by being parsed last.
-  if ( params.has('start') ) urlOptions.startTime = params.get('start');
-  if ( params.has('t') ) urlOptions.startTime = params.get('t');
+  // In addition, we parseInt these values to ensure they're numbers in seconds.
+  // YouTube's embed URLs don't accept a start time if the 's' is included.
+  if ( params.has('start') ) urlOptions.startTime = parseInt(params.get('start'));
+  if ( params.has('t') ) urlOptions.startTime = parseInt(params.get('t'));
 
   return urlOptions;
 }

--- a/packages/youtube/test/buildEmbed.test.js
+++ b/packages/youtube/test/buildEmbed.test.js
@@ -71,13 +71,13 @@ const inlineJs = fs.readFileSync(liteJsFilePath, 'utf-8');
    );
  });
  test(`Build embed default mode, override start time`, t => {
-   t.is(buildEmbed(videoData, override({startTime: '30s'})),
-     '<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/hIs5StN8J-0?start=30s" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>'
+   t.is(buildEmbed(videoData, override({startTime: 30})),
+     '<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/hIs5StN8J-0?start=30" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>'
    );
  });
  test(`Build embed default mode, override start time via URL`, t => {
    t.is(buildEmbed(extractMatches('<p>https://www.youtube.com/watch?v=hIs5StN8J-0&t=30s</p>'), override({})),
-     '<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/hIs5StN8J-0?start=30s" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>'
+     '<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/hIs5StN8J-0?start=30" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>'
    );
  });
  test(`Build embed default mode, short link with override start time via URL`, t => {
@@ -106,7 +106,7 @@ test(`Build embed lite mode, zero index, invalid thumbnail quality override`, t 
 });
 test(`Build embed lite mode, zero index, lite defaults with URL start time param`, t => {
   t.is(buildEmbed(extractMatches('<p>https://www.youtube.com/watch?v=hIs5StN8J-0&t=30s</p>'), override({lite: true}), 0),
-  `<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@master/src/lite-yt-embed.min.css">\n<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@master/src/lite-yt-embed.min.js"></script>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');" params="start=30s"><div class="lty-playbtn"></div></lite-youtube></div>`
+  `<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@master/src/lite-yt-embed.min.css">\n<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@master/src/lite-yt-embed.min.js"></script>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');" params="start=30"><div class="lty-playbtn"></div></lite-youtube></div>`
   );
 });
 test(`Build embed lite mode, zero index, css disabled`, t => {
@@ -160,7 +160,7 @@ test(`Build embed lite mode, 1+ index, lite defaults`, t => {
 });
 test(`Build embed lite mode, 1+ index, lite defaults with URL start time param`, t => {
   t.is(buildEmbed(extractMatches('<p>https://www.youtube.com/watch?v=hIs5StN8J-0&t=30s</p>'), override({lite: true}), 1),
-  `<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');" params="start=30s"><div class="lty-playbtn"></div></lite-youtube></div>`
+  `<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');" params="start=30"><div class="lty-playbtn"></div></lite-youtube></div>`
   );
 });
 test(`Build embed lite mode, 1+ index, css disabled`, t => {


### PR DESCRIPTION
Two changes to URL handling in this PR.

##  Handle missing URL protocol

I made some internal changes in #167 that allow parsing YouTube URLs to get non-zero start times. It uses the native Node.js URL constructor to parse the required parameters. That throws an error if you pass it a string that doesn't start with a recognized protocol. Meanwhile, the plugin regex can spot URLs with or without a protocol, so in some cases it was passing a "URL" string that the constructor wouldn't accept. 

This PR checks for and patches those cases.

## Coerce the start time value to an integer

You can start an embedded YouTube video playing 30 seconds in by passing a `t=30` parameter on the embed URL. I discovered through trial and error that if you pass `t=30s` on the embed URL, however, the player doesn't recognize the value and starts playing from zero. This is annoying because the YouTube web app appends an `s` character (for seconds) at the end of that parameter when creating a time-stamped shareable short URL. So the embed player literally can't read the equivalent parameter created by its own web app.

So this PR also adds a rule to always coerce the timestamp value to an integer so it won't have the appended `s` messing things up.