### PR TITLE
Update Spotify defaults to match current embed behavior

### DIFF
--- a/.changeset/lucky-bugs-jump.md
+++ b/.changeset/lucky-bugs-jump.md
@@ -1,0 +1,5 @@
+---
+"eleventy-plugin-embed-spotify": minor
+---
+
+Bring Spotify embed defaults up to date

--- a/packages/spotify/lib/buildEmbed.js
+++ b/packages/spotify/lib/buildEmbed.js
@@ -1,14 +1,8 @@
 module.exports = function(media, options) {
 	let out = `<div id="spotify-${media.type}-${media.id}" class="${options.embedClass} ${options.embedClass}-${media.type}">`;
-	out += `<iframe title="${media.type} on Spotify" src="https://open.spotify.com/embed${media.type ===
-	"episode"
-		? "-podcast"
-		: ""}/${media.type}/${media.id}" `;
-	out += `width="${media.type === "episode" ? "100%" : options.width}" height="${media.type ===
-	"episode"
-		? "232"
-		: options.height}" `;
-	out += `frameborder="0" allowtransparency="true" allow="${options.allowAttrs}"></iframe>`;
+	out += `<iframe style="${options.iframeStyle}" title="Spotify ${media.type}" src="https://open.spotify.com/embed/${media.type}/${media.id}" `;
+	out += `width="${options.width}" height="${options.height}" `;
+	out += `frameborder="0" allowtransparency="true" allow="${options.allowAttrs}" loading="${options.lazy ? 'lazy' : 'eager'}"></iframe>`;
 	out += "</div>";
 	return out;
 };

--- a/packages/spotify/lib/pluginDefaults.js
+++ b/packages/spotify/lib/pluginDefaults.js
@@ -1,10 +1,9 @@
-// Follows defaults used on Spotify’s Play Button generator
-// https://developer.spotify.com/documentation/widgets/generate/play-button/
-// Spotify requires `allow="encrypted-media"` to enable full-track playback in embeds
-// https://web.archive.org/web/20200405163940/https://developer.spotify.com/community/news/2018/07/19/new-updates-to-spotify-play-button/
+// Follows Spotify's embed code defaults
 module.exports = {
-	allowAttrs: "encrypted-media",
+	allowAttrs: "autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture",
 	embedClass: "eleventy-plugin-embed-spotify",
-	height: "380",
-	width: "300",
+	height: "352",
+	iframeStyle: "border-radius:12px;",
+	lazy: true,
+	width: "100%",
 };

--- a/packages/spotify/test/test-buildEmbed.js
+++ b/packages/spotify/test/test-buildEmbed.js
@@ -14,7 +14,7 @@ test(
 	"URL string returns expected HTML string for albums, default options",
 	(t) => {
 		let str = "<p>https://open.spotify.com/album/75qojmHz1id8sL2LDR5qVz</p>";
-		let expected = '<div id="spotify-album-75qojmHz1id8sL2LDR5qVz" class="eleventy-plugin-embed-spotify eleventy-plugin-embed-spotify-album"><iframe title="album on Spotify" src="https://open.spotify.com/embed/album/75qojmHz1id8sL2LDR5qVz" width="300" height="380" frameborder="0" allowtransparency="true" allow="encrypted-media"></iframe></div>';
+		let expected = '<div id="spotify-album-75qojmHz1id8sL2LDR5qVz" class="eleventy-plugin-embed-spotify eleventy-plugin-embed-spotify-album"><iframe style="border-radius:12px;" title="Spotify album" src="https://open.spotify.com/embed/album/75qojmHz1id8sL2LDR5qVz" width="100%" height="352" frameborder="0" allowtransparency="true" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe></div>';
 		let out = buildEmbed(extractMatch(str), pluginDefaults);
 		t.is(out, expected);
 	},
@@ -24,7 +24,7 @@ test(
 	"URL string returns expected HTML string for artists, default options",
 	(t) => {
 		let str = "<p>https://open.spotify.com/artist/066X20Nz7iquqkkCW6Jxy6</p>";
-		let expected = '<div id="spotify-artist-066X20Nz7iquqkkCW6Jxy6" class="eleventy-plugin-embed-spotify eleventy-plugin-embed-spotify-artist"><iframe title="artist on Spotify" src="https://open.spotify.com/embed/artist/066X20Nz7iquqkkCW6Jxy6" width="300" height="380" frameborder="0" allowtransparency="true" allow="encrypted-media"></iframe></div>';
+		let expected = '<div id="spotify-artist-066X20Nz7iquqkkCW6Jxy6" class="eleventy-plugin-embed-spotify eleventy-plugin-embed-spotify-artist"><iframe style="border-radius:12px;" title="Spotify artist" src="https://open.spotify.com/embed/artist/066X20Nz7iquqkkCW6Jxy6" width="100%" height="352" frameborder="0" allowtransparency="true" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe></div>';
 		let out = buildEmbed(extractMatch(str), pluginDefaults);
 		t.is(out, expected);
 	},
@@ -34,7 +34,7 @@ test(
 	"URL string returns expected HTML string for playlists, default options",
 	(t) => {
 		let str = "<p>https://open.spotify.com/playlist/7zv2xFPTH1MBynYafuvtCj</p>";
-		let expected = '<div id="spotify-playlist-7zv2xFPTH1MBynYafuvtCj" class="eleventy-plugin-embed-spotify eleventy-plugin-embed-spotify-playlist"><iframe title="playlist on Spotify" src="https://open.spotify.com/embed/playlist/7zv2xFPTH1MBynYafuvtCj" width="300" height="380" frameborder="0" allowtransparency="true" allow="encrypted-media"></iframe></div>';
+		let expected = '<div id="spotify-playlist-7zv2xFPTH1MBynYafuvtCj" class="eleventy-plugin-embed-spotify eleventy-plugin-embed-spotify-playlist"><iframe style="border-radius:12px;" title="Spotify playlist" src="https://open.spotify.com/embed/playlist/7zv2xFPTH1MBynYafuvtCj" width="100%" height="352" frameborder="0" allowtransparency="true" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe></div>';
 		let out = buildEmbed(extractMatch(str), pluginDefaults);
 		t.is(out, expected);
 	},
@@ -44,7 +44,7 @@ test(
 	"URL string returns expected HTML string for user-specific playlists, default options",
 	(t) => {
 		let str = "<p>https://open.spotify.com/user/gfscott/playlist/7zv2xFPTH1MBynYafuvtCj</p>";
-		let expected = '<div id="spotify-playlist-7zv2xFPTH1MBynYafuvtCj" class="eleventy-plugin-embed-spotify eleventy-plugin-embed-spotify-playlist"><iframe title="playlist on Spotify" src="https://open.spotify.com/embed/playlist/7zv2xFPTH1MBynYafuvtCj" width="300" height="380" frameborder="0" allowtransparency="true" allow="encrypted-media"></iframe></div>';
+		let expected = '<div id="spotify-playlist-7zv2xFPTH1MBynYafuvtCj" class="eleventy-plugin-embed-spotify eleventy-plugin-embed-spotify-playlist"><iframe style="border-radius:12px;" title="Spotify playlist" src="https://open.spotify.com/embed/playlist/7zv2xFPTH1MBynYafuvtCj" width="100%" height="352" frameborder="0" allowtransparency="true" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe></div>';
 		let out = buildEmbed(extractMatch(str), pluginDefaults);
 		t.is(out, expected);
 	},
@@ -54,7 +54,7 @@ test(
 	"URL string returns expected HTML string for tracks, default options",
 	(t) => {
 		let str = "<p>https://open.spotify.com/track/3gsCAGsWr6pUm1Vy7CPPob</p>";
-		let expected = '<div id="spotify-track-3gsCAGsWr6pUm1Vy7CPPob" class="eleventy-plugin-embed-spotify eleventy-plugin-embed-spotify-track"><iframe title="track on Spotify" src="https://open.spotify.com/embed/track/3gsCAGsWr6pUm1Vy7CPPob" width="300" height="380" frameborder="0" allowtransparency="true" allow="encrypted-media"></iframe></div>';
+		let expected = '<div id="spotify-track-3gsCAGsWr6pUm1Vy7CPPob" class="eleventy-plugin-embed-spotify eleventy-plugin-embed-spotify-track"><iframe style="border-radius:12px;" title="Spotify track" src="https://open.spotify.com/embed/track/3gsCAGsWr6pUm1Vy7CPPob" width="100%" height="352" frameborder="0" allowtransparency="true" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe></div>';
 		let out = buildEmbed(extractMatch(str), pluginDefaults);
 		t.is(out, expected);
 	},
@@ -67,7 +67,7 @@ test(
 	"URL string returns expected HTML string for podcast episodes, default options",
 	(t) => {
 		let str = "<p>https://open.spotify.com/episode/7G5O2wWmch1ciYDPZS4a4O</p>";
-		let expected = '<div id="spotify-episode-7G5O2wWmch1ciYDPZS4a4O" class="eleventy-plugin-embed-spotify eleventy-plugin-embed-spotify-episode"><iframe title="episode on Spotify" src="https://open.spotify.com/embed-podcast/episode/7G5O2wWmch1ciYDPZS4a4O" width="100%" height="232" frameborder="0" allowtransparency="true" allow="encrypted-media"></iframe></div>';
+		let expected = '<div id="spotify-episode-7G5O2wWmch1ciYDPZS4a4O" class="eleventy-plugin-embed-spotify eleventy-plugin-embed-spotify-episode"><iframe style="border-radius:12px;" title="Spotify episode" src="https://open.spotify.com/embed/episode/7G5O2wWmch1ciYDPZS4a4O" width="100%" height="352" frameborder="0" allowtransparency="true" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe></div>';
 		let out = buildEmbed(extractMatch(str), pluginDefaults);
 		t.is(out, expected);
 	},
@@ -77,7 +77,7 @@ test(
 	"URL string returns expected HTML string for podcast profiles, default options",
 	(t) => {
 		let str = "<p>https://open.spotify.com/show/3rDR8CfpIEMpITG2UC3w5W</p>";
-		let expected = '<div id="spotify-show-3rDR8CfpIEMpITG2UC3w5W" class="eleventy-plugin-embed-spotify eleventy-plugin-embed-spotify-show"><iframe title="show on Spotify" src="https://open.spotify.com/embed/show/3rDR8CfpIEMpITG2UC3w5W" width="300" height="380" frameborder="0" allowtransparency="true" allow="encrypted-media"></iframe></div>';
+		let expected = '<div id="spotify-show-3rDR8CfpIEMpITG2UC3w5W" class="eleventy-plugin-embed-spotify eleventy-plugin-embed-spotify-show"><iframe style="border-radius:12px;" title="Spotify show" src="https://open.spotify.com/embed/show/3rDR8CfpIEMpITG2UC3w5W" width="100%" height="352" frameborder="0" allowtransparency="true" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe></div>';
 		let out = buildEmbed(extractMatch(str), pluginDefaults);
 		t.is(out, expected);
 	},


### PR DESCRIPTION
Spotify has made some updates to its embeds over the last little while, and we'd gotten out of step. This PR updates the default options so they match current embed behaviors more closely. These include:

- All players now use the same default height of 352 pixels (Podcast players used to be sized differently)
- All players now default to 100% width (they used to have a fixed pixel width; they now work better with mobile)
- Embed iframes are now lazy-loaded by default
- Embed iframes have expanded their `allow` attributes
- Embed iframes have a default inline style applied, with a border-radius of 12 pixels

While each of these values has been updated to reflect the service's current defaults, you can configure them each individually.

In addition, embed URLs have been simplified and standardized (podcasts no longer have their own unique player, so the old logic was no longer necessary.) This change isn't configurable.



