### PR TITLE
Remove Node.js v19 testing, add v20

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        node: ["14", "16", "18", "19"]
+        node: ["14", "16", "18", "20"]
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3


### PR DESCRIPTION
Node.js 19 is EOL as of June 1, 2023 and v20 was released in the spring. This PR updates CI testing to reflect that.