### PR TITLE
Simpler URL parsing

### DIFF
--- a/.changeset/silent-suns-breathe.md
+++ b/.changeset/silent-suns-breathe.md
@@ -1,0 +1,5 @@
+---
+"eleventy-plugin-embed-ted": patch
+---
+
+Simpler regex and URL parsing

--- a/packages/ted/lib/pattern.js
+++ b/packages/ted/lib/pattern.js
@@ -27,9 +27,9 @@
  * 
  * 1. Arbitrary whitespace
  * 2. Arbitrary whitespace
- * 3. The URL. It won't include anything after a trailing '/' character.
+ * 3. The URL path. It won't include anything after a trailing '/' character.
  * 4. Arbitrary whitespace
  * 5. Arbitrary whitespace 
  */
 
-module.exports = /<p>(?=(\s*))\1(?:<a [^>]*?>)??(?=(\s*))\2((?:https?:)??(?:\/\/)??(?:w{3}\.)??(?:ted\.com\/talks\/[0-9a-zA-Z_]+))(?:\/?[^\s<>]*?)??(?=(\s*))\4(?:<\/a>)??(?=(\s*))\5<\/p>/g
+module.exports = /<p>(?=(\s*))\1(?:<a [^>]*?>)??(?=(\s*))\2(?:https?:)??(?:\/\/)??(?:w{3}\.)??(ted\.com\/talks\/[0-9a-zA-Z_]+)(?:\/?[^\s<>]*?)??(?=(\s*))\4(?:<\/a>)??(?=(\s*))\5<\/p>/g

--- a/packages/ted/lib/replace.js
+++ b/packages/ted/lib/replace.js
@@ -1,7 +1,5 @@
 module.exports = function(match, config) {
-  const theUrl = match[3].startsWith('http') ? match[3] : `https://${match[3]}`;
-  
-  const {pathname} = new URL(theUrl);
+  const {pathname} = new URL(`https://${match[3]}`);
   const embedUrl = `https://embed.ted.com${pathname}`
   
   let embed = `<div class="${config.embedClass}" style="${config.containerCss}">`


### PR DESCRIPTION
This PR simplifies some logic for parsing the URL processed by the regular expression:

1. The RegExp no longer includes the (already optional) protocol or `www` subdomain in the URL capturing group
1. Moves the start of the capturing group to the start of the TLD.
1. Eliminates a redundant non-capturing group
1. All of this allows us to eliminate a complicated ternary assignment of dubious reliability.