### PR TITLE
Fix E2E test order of operations

### DIFF
--- a/packages/youtube/test/e2e/youtube.spec.ts
+++ b/packages/youtube/test/e2e/youtube.spec.ts
@@ -19,30 +19,28 @@ test('test', async ({ page }) => {
 
   // Expect the iframe to have the correct src
   await expect(embedFrameElement).toHaveAttribute('src', 'https://www.youtube-nocookie.com/embed/hIs5StN8J-0')
-
-
+  
   // Click [aria-label="Play"]
   await embedFrame.locator('[aria-label="Play"]').click();
-
+  
   // Click [aria-label="Play \(k\)"]
   // Started failing for unknown reasons around August 2023
   // await embedFrame.locator('[aria-label="Play \\(k\\)"]').click();
-
+  
   // Click .ytp-fullscreen-button
   // This used to fail on webkit for unknown reasons
   // now it succeeds for unknown reasons
   await embedFrame.locator('.ytp-fullscreen-button').click();
-
+  
   // Click [aria-label="Settings"]
   await embedFrame.locator('[aria-label="Settings"]').click();
-
+  
   // Click [aria-label="Settings"]
   await embedFrame.locator('[aria-label="Settings"]').click();
-
-  // Click text=Animotion - Obsession >> nth=0
-  await embedFrame.locator('text=Animotion - Obsession').first().click()
 
   // Click [aria-label="Copy link"]
   await embedFrame.locator('[aria-label="Copy link"]').click();
-
+  
+  // Click text=Animotion - Obsession >> nth=0
+  await embedFrame.locator('.ytp-title-link').first().click()
 });


### PR DESCRIPTION
This PR moves one of the end-to-end test actions to the end of the list, because it clicks the YouTube iframe title to open the YouTube website in a new tab. This seems to have interfered with some of the other click-tasks, I assume because the new tab is now "in the way" but it's hard to tell exactly? It stopped working for some reason and now it works again ¯\_(ツ)_/¯