### PR TITLE
Update supported Node.js version matrix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,12 +24,12 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v2
         with:
-          version: 7
+          version: 8
       
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 20
           cache: 'pnpm'
 
       - name: Install dependencies
@@ -89,12 +89,12 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v2
         with:
-          version: 7
+          version: 8
       
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 20
           cache: 'pnpm'
 
       - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,14 +11,14 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        node: ["14", "16", "18", "20"]
+        node: ["18", "20"]
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
       - name: Install pnpm
         uses: pnpm/action-setup@v2
         with:
-          version: 7
+          version: 8
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
@@ -39,11 +39,11 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v2
         with:
-          version: 7
+          version: 8
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: "18"
+          node-version: "20"
           cache: 'pnpm'
       - name: Install dependencies
         run: pnpm install
@@ -72,11 +72,11 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v2
         with:
-          version: 7
+          version: 8
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: "18"
+          node-version: "20"
           cache: 'pnpm'
       - name: Install dependencies
         run: pnpm install


### PR DESCRIPTION
This PR removes Node.js 14 and 16 from the CI testing pipeline, since they're both marked EOL. This allows us to keep dev dependencies up to date and [aligns](https://github.com/11ty/eleventy/commit/2f91de111ab70d5f7d2a74f2f9bf452acfbf607a) with 11ty's current practice.

This doesn't change any of the plugins' public APIs and everything should continue to work on older Node versions.