### PR TITLE
Fix Turbo workspace directory traversal error

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,3 @@
 packages:
   - "packages/*"
-  - "demo/"
+  - "demo"


### PR DESCRIPTION
Turbo recently started [choking](https://github.com/vercel/turbo/issues/6748) on `pnpm-workspace.yml` entries where the directory name has a trailing `/`. It's not needed so this removes it.