### PR TITLE
Add options for YouTube iframe title, including downloading

### DIFF
--- a/.changeset/perfect-spiders-collect.md
+++ b/.changeset/perfect-spiders-collect.md
@@ -1,0 +1,6 @@
+---
+"eleventy-plugin-youtube-embed": minor
+"eleventy-plugin-embed-everything": minor
+---
+
+Add option to download and cache video title from YouTube

--- a/packages/youtube/README.md
+++ b/packages/youtube/README.md
@@ -75,7 +75,7 @@ eleventyConfig.addPlugin(embedYouTube, {
 
 ### Plugin default options
 
-The plugin’s default settings reside in [lib/pluginDefaults.js](lib/pluginDefaults.js). All of these values can be changed with an options object passed to the plugin.
+The plugin’s default settings reside in [lib/defaults.js](lib/defaults.js). All of these values can be changed with an options object passed to the plugin.
 
 <table style="width: 100%;">
   <thead>
@@ -141,6 +141,27 @@ The plugin’s default settings reside in [lib/pluginDefaults.js](lib/pluginDefa
       <td><code>false</code></td>
       <td>Setting this to <code>true</code> will add a <code>rel=0</code> attribute to the embed url. This will tell YouTube to <a href="https://developers.google.com/youtube/player_parameters#rel">recommend videos from the same channel.</a></td>
     </tr>
+    <tr>
+      <td><code>title</code><br>✨ <b>New in v1.10.0!</b></td>
+      <td>String</td>
+      <td><code>Embedded YouTube video</code></td>
+      <td>Edit this value to change the default <code>title</code> attribute for the embedded iframe.</td>
+    </tr>
+    <tr>
+      <td colspan="4"><code>titleOptions</code>✨ <b>New in v1.10.0!</b></td>
+    </tr>
+    <tr>
+      <td><code>titleOptions.download</code></td>
+      <td>Boolean</td>
+      <td><code>false</code></td>
+      <td>Setting this to true will download and cache the title of the video from YouTube, then override the default value of <code>title</code>. <b>Note:</b> Turning this feature on will cause a network call to YouTube’s servers.</td>
+    </tr>
+    <tr>
+      <td><code>titleOptions.cacheDuration</code></td>
+      <td>String</td>
+      <td><code>5m</code></td>
+      <td>The length of time to cache the data from YouTube when <code>titleOptions.download</code> is set to true. Use the cache duration syntax from <a href="https://www.11ty.dev/docs/plugins/fetch/#change-the-cache-duration">@11ty/eleventy-fetch</a> to set this value.</td>
+    </tr>
   </tbody>
 </table>
 
@@ -159,6 +180,7 @@ In addition, using the Lite version will cause several of the plugin’s setting
 - `allowFullscreen`
 - `lazy`
 - `noCookie`
+- `title` and `titleOptions`
 
 #### Lite embed options
 
@@ -229,7 +251,7 @@ eleventyConfig.addPlugin(embedYouTube, {
       <td>Pass a custom URL to load the necessary JavaScript from the source of your choice.</td>
     </tr>
     <tr>
-      <td>✨ <b>New in v1.10.0!</b><br><code>lite.responsive</code></td>
+      <td><code>lite.responsive</code><br>✨ <b>New in v1.10.0!</b></td>
       <td>Boolean</td>
       <td><code>false</code></td>
       <td>If you change this to <code>true</code>, then the plugin adds a CSS rule to override the default max-width of <code>&lt;lite-youtube&gt;</code> elements, which are <a href="https://github.com/paulirish/lite-youtube-embed/blob/f9fc3a2475ade166d0cf7bb3e3caa3ec236ee74e/src/lite-yt-embed.css#L9">hard coded</a> to a maximum of 720 pixels.</td>

--- a/packages/youtube/index.js
+++ b/packages/youtube/index.js
@@ -2,6 +2,7 @@ const pattern = require('./lib/pattern.js');
 const embed = require('./lib/embed.js');
 const { defaults } = require('./lib/defaults.js');
 const deepmerge = require('deepmerge');
+const replace = require('string-replace-async');
 
 module.exports = function (eleventyConfig, options = {}) {
   const config = deepmerge(defaults, options);
@@ -10,6 +11,6 @@ module.exports = function (eleventyConfig, options = {}) {
       return content;
     }
     let index = 0;
-    return content.replace(pattern, (...match) => embed(match, config, index++));
+    return await replace(content, pattern, async (...match) => embed(match, config, index++));
   });
 };

--- a/packages/youtube/lib/defaults.js
+++ b/packages/youtube/lib/defaults.js
@@ -9,6 +9,10 @@
  * @property {boolean} [modestBranding] - Whether modest branding is enabled.
  * @property {boolean} [noCookie] - Whether cookies are disabled.
  * @property {boolean} [recommendSelfOnly] - Whether to only recommend self videos.
+ * @property {string} [title] - The title of the video.
+ * @property {Object} [titleOptions] - Options for the video title.
+ * @property {boolean} [titleOptions.download] - Whether to download the title.
+ * @property {string} [titleOptions.cacheDuration] - The cache duration for the title.
  */
 const defaults = {
   allowAttrs: 'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture',
@@ -20,6 +24,11 @@ const defaults = {
   modestBranding: false,
   noCookie: true,
   recommendSelfOnly: false,
+  title: 'Embedded YouTube video',
+  titleOptions:{
+    download: false,
+    cacheDuration: '5m',
+  },
 };
 
 /**

--- a/packages/youtube/lib/embed.js
+++ b/packages/youtube/lib/embed.js
@@ -200,5 +200,7 @@ async function getVideoTitle(id, options) {
 }
 
 // Exported for testing purposes
+module.exports.defaultEmbed = defaultEmbed;
+module.exports.liteEmbed = liteEmbed;
 module.exports.validateThumbnailSize = validateThumbnailSize;
 module.exports.getVideoTitle = getVideoTitle;

--- a/packages/youtube/package.json
+++ b/packages/youtube/package.json
@@ -35,7 +35,12 @@
   },
   "bugs": "https://github.com/gfscott/eleventy-plugin-embed-everything/issues",
   "dependencies": {
+    "@11ty/eleventy-fetch": "^4.0.0",
     "deepmerge": "^4.3.1",
-    "lite-youtube-embed": "^0.3.0"
+    "lite-youtube-embed": "^0.3.0",
+    "string-replace-async": "2.0.0"
+  },
+  "devDependencies": {
+    "delay": "5.0.0"
   }
 }

--- a/packages/youtube/test/embed.default.test.js
+++ b/packages/youtube/test/embed.default.test.js
@@ -25,81 +25,81 @@ const override = (obj) => merge(defaults, obj);
 
 const testString = '<p>https://www.youtube.com/watch?v=hIs5StN8J-0</p>';
 
-test(`Build embed default mode, default settings`, t => {
-  t.is(embed(extract(testString), defaults),
+test(`Build embed default mode, default settings`, async t => {
+  t.is(await embed(extract(testString), defaults),
     '<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/hIs5StN8J-0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>'
   );
 });
 
-test(`Build embed default mode, override nothing`, t => {
+test(`Build embed default mode, override nothing`, async t => {
   t.is(
-    (embed(extract(testString), defaults)),
+    (await embed(extract(testString), defaults)),
     '<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/hIs5StN8J-0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>'
   );
 });
 
-test(`Build embed default mode, override allowAttrs`, t => {
-  t.is(embed(extract(testString), override({allowAttrs: 'foo'})),
+test(`Build embed default mode, override allowAttrs`, async t => {
+  t.is(await embed(extract(testString), override({allowAttrs: 'foo'})),
     '<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/hIs5StN8J-0" allow="foo" allowfullscreen></iframe></div>'
   );
 });
 
-test(`Build embed default mode, override allowFullscreen`, t => {
-  t.is(embed(extract(testString), override({allowFullscreen: false})),
+test(`Build embed default mode, override allowFullscreen`, async t => {
+  t.is(await embed(extract(testString), override({allowFullscreen: false})),
     '<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/hIs5StN8J-0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"></iframe></div>'
   );
 });
 
-test(`Build embed default mode, override allowAutoplay`, t => {
-  t.is(embed(extract(testString), override({allowAutoplay: true})),
+test(`Build embed default mode, override allowAutoplay`, async t => {
+  t.is(await embed(extract(testString), override({allowAutoplay: true})),
     '<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/hIs5StN8J-0?autoplay=1" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>'
   );
 });
 
-test(`Build embed default mode, override embedClass`, t => {
-  t.is(embed(extract(testString), override({embedClass: 'foo'})),
+test(`Build embed default mode, override embedClass`, async t => {
+  t.is(await embed(extract(testString), override({embedClass: 'foo'})),
     '<div id="hIs5StN8J-0" class="foo" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/hIs5StN8J-0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>'
   );
 });
 
-test(`Build embed default mode, override lazy`, t => {
-  t.is(embed(extract(testString), override({lazy: true})),
+test(`Build embed default mode, override lazy`, async t => {
+  t.is(await embed(extract(testString), override({lazy: true})),
     '<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/hIs5StN8J-0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe></div>'
   );
 });
 
-test(`Build embed default mode, override noCookie`, t => {
-  t.is(embed(extract(testString), override({noCookie: false})),
+test(`Build embed default mode, override noCookie`, async t => {
+  t.is(await embed(extract(testString), override({noCookie: false})),
     '<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube.com/embed/hIs5StN8J-0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>'
   );
 });
 
-test(`Build embed default mode, override modestBranding`, t => {
-  t.is(embed(extract(testString), override({modestBranding: true})),
+test(`Build embed default mode, override modestBranding`, async t => {
+  t.is(await embed(extract(testString), override({modestBranding: true})),
     '<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/hIs5StN8J-0?modestbranding=1" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>'
   );
 });
 
-test(`Build embed default mode, override recommendSelfOnly`, t => {
-  t.is(embed(extract(testString), override({recommendSelfOnly: true})),
+test(`Build embed default mode, override recommendSelfOnly`, async t => {
+  t.is(await embed(extract(testString), override({recommendSelfOnly: true})),
     '<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/hIs5StN8J-0?rel=0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>'
   );
 });
 
-test(`Build embed default mode, override start time`, t => {
-  t.is(embed(extract(testString), override({startTime: 30})),
+test(`Build embed default mode, override start time`, async t => {
+  t.is(await embed(extract(testString), override({startTime: 30})),
     '<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/hIs5StN8J-0?start=30" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>'
   );
 });
 
-test(`Build embed default mode, override start time via URL`, t => {
-  t.is(embed(extract('<p>https://www.youtube.com/watch?v=hIs5StN8J-0&t=30s</p>'), override({})),
+test(`Build embed default mode, override start time via URL`, async t => {
+  t.is(await embed(extract('<p>https://www.youtube.com/watch?v=hIs5StN8J-0&t=30s</p>'), override({})),
     '<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/hIs5StN8J-0?start=30" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>'
   );
 });
 
-test(`Build embed default mode, short link with override start time via URL`, t => {
-  t.is(embed(extract('<p>https://youtu.be/hIs5StN8J-0?t=30</p>'), override({})),
+test(`Build embed default mode, short link with override start time via URL`, async t => {
+  t.is(await embed(extract('<p>https://youtu.be/hIs5StN8J-0?t=30</p>'), override({})),
     '<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/hIs5StN8J-0?start=30" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>'
   );
 });

--- a/packages/youtube/test/embed.default.test.js
+++ b/packages/youtube/test/embed.default.test.js
@@ -1,7 +1,7 @@
 const test = require('ava');
 const merge = require('deepmerge');
 const pattern = require('../lib/pattern.js');
-const embed = require('../lib/embed.js');
+const {defaultEmbed: embed} = require('../lib/embed.js');
 const {defaults} = require('../lib/defaults.js');
 
 /**
@@ -23,89 +23,97 @@ const extract = (str) => {
  */
 const override = (obj) => merge(defaults, obj);
 
-const testString = '<p>https://www.youtube.com/watch?v=hIs5StN8J-0</p>';
+const id = 'hIs5StN8J-0';
+const url = 'https://www.youtube.com/watch?v=hIs5StN8J-0';
 
 test(`Build embed default mode, default settings`, async t => {
-  t.is(await embed(extract(testString), defaults),
+  t.is(await embed({id, url}, defaults),
     '<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/hIs5StN8J-0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>'
   );
 });
 
 test(`Build embed default mode, override nothing`, async t => {
   t.is(
-    (await embed(extract(testString), defaults)),
+    (await embed({id, url}, defaults)),
     '<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/hIs5StN8J-0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>'
   );
 });
 
 test(`Build embed default mode, override allowAttrs`, async t => {
-  t.is(await embed(extract(testString), override({allowAttrs: 'foo'})),
+  t.is(await embed({id, url}, override({allowAttrs: 'foo'})),
     '<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/hIs5StN8J-0" allow="foo" allowfullscreen></iframe></div>'
   );
 });
 
 test(`Build embed default mode, override allowFullscreen`, async t => {
-  t.is(await embed(extract(testString), override({allowFullscreen: false})),
+  t.is(await embed({id, url}, override({allowFullscreen: false})),
     '<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/hIs5StN8J-0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"></iframe></div>'
   );
 });
 
 test(`Build embed default mode, override allowAutoplay`, async t => {
-  t.is(await embed(extract(testString), override({allowAutoplay: true})),
+  t.is(await embed({id, url}, override({allowAutoplay: true})),
     '<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/hIs5StN8J-0?autoplay=1" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>'
   );
 });
 
 test(`Build embed default mode, override embedClass`, async t => {
-  t.is(await embed(extract(testString), override({embedClass: 'foo'})),
+  t.is(await embed({id, url}, override({embedClass: 'foo'})),
     '<div id="hIs5StN8J-0" class="foo" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/hIs5StN8J-0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>'
   );
 });
 
 test(`Build embed default mode, override lazy`, async t => {
-  t.is(await embed(extract(testString), override({lazy: true})),
+  t.is(await embed({id, url}, override({lazy: true})),
     '<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/hIs5StN8J-0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe></div>'
   );
 });
 
 test(`Build embed default mode, override noCookie`, async t => {
-  t.is(await embed(extract(testString), override({noCookie: false})),
+  t.is(await embed({id, url}, override({noCookie: false})),
     '<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube.com/embed/hIs5StN8J-0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>'
   );
 });
 
 test(`Build embed default mode, override modestBranding`, async t => {
-  t.is(await embed(extract(testString), override({modestBranding: true})),
+  t.is(await embed({id, url}, override({modestBranding: true})),
     '<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/hIs5StN8J-0?modestbranding=1" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>'
   );
 });
 
 test(`Build embed default mode, override recommendSelfOnly`, async t => {
-  t.is(await embed(extract(testString), override({recommendSelfOnly: true})),
+  t.is(await embed({id, url}, override({recommendSelfOnly: true})),
     '<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/hIs5StN8J-0?rel=0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>'
   );
 });
 
 test(`Build embed default mode, override start time`, async t => {
-  t.is(await embed(extract(testString), override({startTime: 30})),
+  t.is(await embed({id, url}, override({startTime: 30})),
     '<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/hIs5StN8J-0?start=30" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>'
   );
 });
 
 test(`Build embed default mode, override start time via URL`, async t => {
-  t.is(await embed(extract('<p>https://www.youtube.com/watch?v=hIs5StN8J-0&t=30s</p>'), override({})),
+  t.is(await embed({id: 'hIs5StN8J-0', url: 'https://www.youtube.com/watch?v=hIs5StN8J-0&t=30s'}, override({})),
     '<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/hIs5StN8J-0?start=30" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>'
   );
 });
 
 test(`Build embed default mode, short link with override start time via URL`, async t => {
-  t.is(await embed(extract('<p>https://youtu.be/hIs5StN8J-0?t=30</p>'), override({})),
+  t.is(await embed({id: 'hIs5StN8J-0', url: 'https://youtu.be/hIs5StN8J-0?t=30'}, override({})),
     '<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/hIs5StN8J-0?start=30" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>'
   );
 });
 
 test(`Build embed default mode, downloading video title`, async t => {
-  t.is(await embed(extract(testString), override({titleOptions: {download: true}})),
+  t.is(await embed({id, url}, override({titleOptions: {download: true}})),
     '<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Animotion - Obsession (Official Music Video)" src="https://www.youtube-nocookie.com/embed/hIs5StN8J-0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>'
+  );
+});
+
+// Video id doesn't exist, so oEmbed fetch will fail, returning the default title instead
+test(`Build embed default mode, downloading video title with error state`, async t => {
+  t.is(await embed({id: '00000000000', url: 'https://www.youtube.com/watch?v=00000000000'}, override({titleOptions: {download: true}})),
+    '<div id="00000000000" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/00000000000" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>'
   );
 });

--- a/packages/youtube/test/embed.default.test.js
+++ b/packages/youtube/test/embed.default.test.js
@@ -103,3 +103,9 @@ test(`Build embed default mode, short link with override start time via URL`, as
     '<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/hIs5StN8J-0?start=30" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>'
   );
 });
+
+test(`Build embed default mode, downloading video title`, async t => {
+  t.is(await embed(extract(testString), override({titleOptions: {download: true}})),
+    '<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Animotion - Obsession (Official Music Video)" src="https://www.youtube-nocookie.com/embed/hIs5StN8J-0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>'
+  );
+});

--- a/packages/youtube/test/embed.lite.test.js
+++ b/packages/youtube/test/embed.lite.test.js
@@ -36,68 +36,68 @@ const override = (obj) => merge(defaults, obj);
 /**
  * Lite mode, zero index (first instance on page includes script and CSS)
  */
-test(`Build embed lite mode, zero index, lite defaults`, t => {
-  t.is(embed(extract(testString), override({lite: true}), 0),
+test(`Build embed lite mode, zero index, lite defaults`, async t => {
+  t.is(await embed(extract(testString), override({lite: true}), 0),
   `<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.0/src/lite-yt-embed.min.css">\n<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.0/src/lite-yt-embed.min.js"></script>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
   );
 });
-test(`Build embed lite mode, zero index, valid thumbnail quality override`, t => {
-  t.is(embed(extract(testString), override({lite: { thumbnailQuality: 'maxresdefault'}}), 0),
+test(`Build embed lite mode, zero index, valid thumbnail quality override`, async t => {
+  t.is(await embed(extract(testString), override({lite: { thumbnailQuality: 'maxresdefault'}}), 0),
   `<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.0/src/lite-yt-embed.min.css">\n<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.0/src/lite-yt-embed.min.js"></script>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/maxresdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
   );
 });
-test(`Build embed lite mode, zero index, invalid thumbnail quality override`, t => {
-  t.is(embed(extract(testString), override({lite: { thumbnailQuality: 'nope'}}), 0),
+test(`Build embed lite mode, zero index, invalid thumbnail quality override`, async t => {
+  t.is(await embed(extract(testString), override({lite: { thumbnailQuality: 'nope'}}), 0),
   `<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.0/src/lite-yt-embed.min.css">\n<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.0/src/lite-yt-embed.min.js"></script>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
   );
 });
-test(`Build embed lite mode, zero index, lite defaults with URL start time param`, t => {
-  t.is(embed(extract('<p>https://www.youtube.com/watch?v=hIs5StN8J-0&t=30s</p>'), override({lite: true}), 0),
+test(`Build embed lite mode, zero index, lite defaults with URL start time param`, async t => {
+  t.is(await embed(extract('<p>https://www.youtube.com/watch?v=hIs5StN8J-0&t=30s</p>'), override({lite: true}), 0),
   `<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.0/src/lite-yt-embed.min.css">\n<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.0/src/lite-yt-embed.min.js"></script>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');" params="start=30"><div class="lty-playbtn"></div></lite-youtube></div>`
   );
 });
-test(`Build embed lite mode, zero index, css disabled`, t => {
-  t.is(embed(extract(testString), override({lite:{css:{enabled: false}}}), 0),
+test(`Build embed lite mode, zero index, css disabled`, async t => {
+  t.is(await embed(extract(testString), override({lite:{css:{enabled: false}}}), 0),
   `<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.0/src/lite-yt-embed.min.js"></script>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
   );
 });
-test(`Build embed lite mode, zero index, css inline`, t => {
-  t.is(embed(extract(testString), override({lite:{css:{inline: true}}}), 0),
+test(`Build embed lite mode, zero index, css inline`, async t => {
+  t.is(await embed(extract(testString), override({lite:{css:{inline: true}}}), 0),
   `<style>${inlineCss}</style>\n<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.0/src/lite-yt-embed.min.js"></script>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
   );
 });
-test(`Build embed lite mode, zero index, css path override`, t => {
-  t.is(embed(extract(testString), override({lite:{css:{path: 'foo'}}}), 0),
+test(`Build embed lite mode, zero index, css path override`, async t => {
+  t.is(await embed(extract(testString), override({lite:{css:{path: 'foo'}}}), 0),
   `<link rel="stylesheet" href="foo">\n<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.0/src/lite-yt-embed.min.js"></script>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
   );
 });
-test(`Build embed lite mode, zero index, js disabled`, t => {
-  t.is(embed(extract(testString), override({lite:{js:{enabled: false}}}), 0),
+test(`Build embed lite mode, zero index, js disabled`, async t => {
+  t.is(await embed(extract(testString), override({lite:{js:{enabled: false}}}), 0),
   `<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.0/src/lite-yt-embed.min.css">\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
   );
 });
-test(`Build embed lite mode, zero index, js inline`, t => {
-  t.is(embed(extract(testString), override({lite:{js:{inline: true}}}), 0),
+test(`Build embed lite mode, zero index, js inline`, async t => {
+  t.is(await embed(extract(testString), override({lite:{js:{inline: true}}}), 0),
   `<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.0/src/lite-yt-embed.min.css">\n<script>${inlineJs}</script>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
   );
 });
-test(`Build embed lite mode, zero index, css AND js disabled`, t => {
-  t.is(embed(extract(testString), override({lite:{css:{enabled:false},js:{enabled:false}}}), 0),
+test(`Build embed lite mode, zero index, css AND js disabled`, async t => {
+  t.is(await embed(extract(testString), override({lite:{css:{enabled:false},js:{enabled:false}}}), 0),
   `<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
   );
 });
-test(`Build embed lite mode, zero index, css AND js path override`, t => {
-  t.is(embed(extract(testString), override({lite:{css:{path: 'foo'},js:{path: 'foo'}}}), 0),
+test(`Build embed lite mode, zero index, css AND js path override`, async t => {
+  t.is(await embed(extract(testString), override({lite:{css:{path: 'foo'},js:{path: 'foo'}}}), 0),
   `<link rel="stylesheet" href="foo">\n<script defer="defer" src="foo"></script>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
   );
 });
-test(`Build embed lite mode, zero index, css AND js inline`, t => {
-  t.is(embed(extract(testString), override({lite:{css:{inline: true},js:{inline: true}}}), 0),
+test(`Build embed lite mode, zero index, css AND js inline`, async t => {
+  t.is(await embed(extract(testString), override({lite:{css:{inline: true},js:{inline: true}}}), 0),
   `<style>${inlineCss}</style>\n<script>${inlineJs}</script>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
   );
 });
-test(`Build embed lite mode, zero index, responsive true`, t => {
-  t.is(embed(extract(testString), override({lite: { responsive: true }}), 0),
+test(`Build embed lite mode, zero index, responsive true`, async t => {
+  t.is(await embed(extract(testString), override({lite: { responsive: true }}), 0),
   `<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.0/src/lite-yt-embed.min.css">\n<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.0/src/lite-yt-embed.min.js"></script>\n<style>.eleventy-plugin-youtube-embed lite-youtube {max-width:100%}</style>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
   );
 });
@@ -106,43 +106,43 @@ test(`Build embed lite mode, zero index, responsive true`, t => {
 /**
  * Lite mode, 1+ index (no style or script on subsequent outputs)
  */
-test(`Build embed lite mode, 1+ index, lite defaults`, t => {
-  t.is(embed(extract(testString), override({lite: true}), 1),
+test(`Build embed lite mode, 1+ index, lite defaults`, async t => {
+  t.is(await embed(extract(testString), override({lite: true}), 1),
   `<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
   );
 });
-test(`Build embed lite mode, 1+ index, lite defaults with URL start time param`, t => {
-  t.is(embed(extract('<p>https://www.youtube.com/watch?v=hIs5StN8J-0&t=30s</p>'), override({lite: true}), 1),
+test(`Build embed lite mode, 1+ index, lite defaults with URL start time param`, async t => {
+  t.is(await embed(extract('<p>https://www.youtube.com/watch?v=hIs5StN8J-0&t=30s</p>'), override({lite: true}), 1),
   `<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');" params="start=30"><div class="lty-playbtn"></div></lite-youtube></div>`
   );
 });
-test(`Build embed lite mode, 1+ index, css disabled`, t => {
-  t.is(embed(extract(testString), override({lite:{css:{enabled: false}}}), 1),
+test(`Build embed lite mode, 1+ index, css disabled`, async t => {
+  t.is(await embed(extract(testString), override({lite:{css:{enabled: false}}}), 1),
   `<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
   );
 });
-test(`Build embed lite mode, 1+ index, css inline`, t => {
-  t.is(embed(extract(testString), override({lite:{css:{inline: true}}}), 1),
+test(`Build embed lite mode, 1+ index, css inline`, async t => {
+  t.is(await embed(extract(testString), override({lite:{css:{inline: true}}}), 1),
   `<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
   );
 });
-test(`Build embed lite mode, 1+ index, css path override`, t => {
-  t.is(embed(extract(testString), override({lite:{css:{path: 'foo'}}}), 1),
+test(`Build embed lite mode, 1+ index, css path override`, async t => {
+  t.is(await embed(extract(testString), override({lite:{css:{path: 'foo'}}}), 1),
   `<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
   );
 });
-test(`Build embed lite mode, 1+ index, js disabled`, t => {
-  t.is(embed(extract(testString), override({lite:{js:{enabled: false}}}), 1),
+test(`Build embed lite mode, 1+ index, js disabled`, async t => {
+  t.is(await embed(extract(testString), override({lite:{js:{enabled: false}}}), 1),
   `<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
   );
 });
-test(`Build embed lite mode, 1+ index, js inline`, t => {
-  t.is(embed(extract(testString), override({lite:{js:{inline: true}}}), 1),
+test(`Build embed lite mode, 1+ index, js inline`, async t => {
+  t.is(await embed(extract(testString), override({lite:{js:{inline: true}}}), 1),
   `<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
   );
 });
-test(`Build embed lite mode, 1+ index, responsive true`, t => {
-  t.is(embed(extract(testString), override({lite: { responive: true }}), 1),
+test(`Build embed lite mode, 1+ index, responsive true`, async t => {
+  t.is(await embed(extract(testString), override({lite: { responive: true }}), 1),
   `<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
   );
 });
@@ -150,17 +150,17 @@ test(`Build embed lite mode, 1+ index, responsive true`, t => {
 /**
  * In lite mode, test that the thumbnail size validator returns the expected values.
 */
-test(`Thumbnail validator returns default value in response to empty parameter`, t => {
+test(`Thumbnail validator returns default value in response to empty parameter`, async t => {
   t.is(validateThumbnailSize(), 'hqdefault');
 });
-test(`Thumbnail validator returns default value in response to incorrect parameter types`, t => {
+test(`Thumbnail validator returns default value in response to incorrect parameter types`, async t => {
   t.is(validateThumbnailSize(1), 'hqdefault');
   t.is(validateThumbnailSize(true), 'hqdefault');
 });
-test(`Thumbnail validator returns default value in response to invalid string`, t => {
+test(`Thumbnail validator returns default value in response to invalid string`, async t => {
   t.is(validateThumbnailSize('foo'), 'hqdefault');
 });
-test(`Thumbnail validator returns expected strings when passed expected strings`, t => {
+test(`Thumbnail validator returns expected strings when passed expected strings`, async t => {
   t.is(validateThumbnailSize('default'), 'default');
   t.is(validateThumbnailSize('hqdefault'), 'hqdefault');
   t.is(validateThumbnailSize('mqdefault'), 'mqdefault');

--- a/packages/youtube/test/index.test.js
+++ b/packages/youtube/test/index.test.js
@@ -1,31 +1,100 @@
 const test = require('ava');
+const delay = require('delay');
+const replaceAsync = require('string-replace-async');
+
+  const content = 'foo bar foo bar';
+  const expected = 'foo baz foo bar';
+  const pattern = /bar/g;
 
 /**
- * This test mocks the behavior of how the plugin index file works.
- * The purpose is to test that the index of the replacement is passed
- * correctly to the embed function. This is important because the index
- * is used to determine whether to use the lite embed or the default embed.
- * The lite embed needs to know whether it is the first embed in the content
- * so that it can determine whether to include additional markup, such as
- * style and script tags. The default embed doesn't need to be aware of its
- * index.
+ * These tests compare the results of the sync and async replacement functions.
+ * The purpose is to ensure that the async function produces the same results
+ * as the sync function. This is important because the async function comes
+ * from a third-party library, and it's important to know that it behaves the
+ * same way as the native Javascript replace function.
+ * 
+ * The string-replace-async library seems solid but we're pinning an older
+ * CJS version and so we want be doubly sure that it works as expected.
  */
-test('Index of replacements inside content works as expected', (t) => {
-  // `bar` appears twice in the test string.
-  const content = 'foo bar foo bar';
-  // We expect *only* the first `bar` to be replaced with `baz`.
-  const expected = 'foo baz foo bar';
-  // The pattern is global, so it will match all instances of `bar`.
-  const pattern = /bar/g;
-  // This function mocks the way the index file handles content replacement.
-  // the match and config arguments aren't used in this test.
-  const mockEmbed = (match, config, i) => {
-    return i === 0 ? 'baz' : 'bar';
+
+const bar = async () => {
+  await delay(100);
+  return 'bar'
+};
+
+const baz = async () => {
+  await delay(100);
+  return 'baz'
+};
+
+const syncReplace = (_content, _pattern, index) => {
+  if(index === 0) {
+    return 'baz';
+  }
+  return 'bar';
+};
+
+const asyncReplace = async (_content, _pattern, index) => {
+  if(index === 0) {
+    return await baz();
+  }
+  return await bar();
+};
+
+test('Async replace produces identical results to sync replace', async (t) => {
+  
+  // With index 0, result is "foo baz foo bar"
+  const syncResult = syncReplace(content, pattern, 0);
+  const asyncResult = await asyncReplace(content, pattern, 0);
+  
+  // With index 1, result is "foo bar foo bar"
+  const syncResult_index1 = syncReplace(content, pattern, 1);
+  const asyncResult_index1 = await asyncReplace(content, pattern, 1);
+  
+  t.is(syncResult, asyncResult);
+  t.is(syncResult_index1, asyncResult_index1);
+
+});
+
+/**
+ * This test replicates the behavior of how the plugin index file works.
+ * The purpose is to test that the index variable is incremented correctly,
+ * and that the resulting string is correct. It tests both that the mock
+ * embed function finds the matches as expected, and that it returns the 
+ * expected output string as a result.
+ */
+test('Index of replacements inside content works as expected', async (t) => {
+
+  // The callback function should find two matches with these exact indexes.
+  const expectedMatches = [
+    ['bar', 4, 'foo bar foo bar'],
+    ['bar', 12, 'foo bar foo bar'],
+  ]
+  const actualMatches = [];
+
+  // Note: config is not used in this test but we pass it anyway.
+  const embed_mock = async (match, _config, index) => {
+    
+    // For each match found, push the regex match array to the "actualMatches" array.
+    actualMatches.push(match);
+
+    // If the index is 0, return "baz". Otherwise, return "bar".
+    if (index === 0) {
+      await delay(100)
+      return await baz();
+    }
+    await delay(100)
+    return await bar();
   };
+  
   // Start the index at 0.
   let index = 0;
-  // Call mockEmbed for each match, passing the index and then incrementing it.
-  const result = content.replace(pattern, (...match) => mockEmbed(match, {}, index++));
-  // The resulting string should only replace the first instance of `bar`.
+  // Call embed_mock for each match, passing the index and then incrementing it.
+  // Testing this ensures that the incrementing of the index inside the callback
+  // works as expected.
+  const result = await replaceAsync(content, pattern, async (...match) => await embed_mock(match, {}, index++));  
+  
   t.is(result, expected)
-})
+  t.deepEqual(actualMatches, expectedMatches)
+});
+

--- a/packages/youtube/test/title.test.js
+++ b/packages/youtube/test/title.test.js
@@ -1,0 +1,16 @@
+const test = require('ava');
+const merge = require('deepmerge');
+const {defaults: options} = require('../lib/defaults.js');
+const {getVideoTitle} = require('../lib/embed.js');
+
+test('getVideoTitle returns the default title when the API call fails', async t => {
+  const title = await getVideoTitle('not_valid', options);
+  t.is(title, options.title);
+});
+
+test('getVideoTitle returns expected title via oEmbed', async t => {
+  const expectedTitle = 'Animotion - Obsession (Official Music Video)';
+  const enableDownloadOption = merge(options, {titleOptions: {download: true}});
+  const title = await getVideoTitle('hIs5StN8J-0', enableDownloadOption);
+  t.is(title, expectedTitle);
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,12 +100,22 @@ importers:
 
   packages/youtube:
     dependencies:
+      '@11ty/eleventy-fetch':
+        specifier: ^4.0.0
+        version: 4.0.0
       deepmerge:
         specifier: ^4.3.1
         version: 4.3.1
       lite-youtube-embed:
         specifier: ^0.3.0
         version: 0.3.0
+      string-replace-async:
+        specifier: 2.0.0
+        version: 2.0.0
+    devDependencies:
+      delay:
+        specifier: 5.0.0
+        version: 5.0.0
 
 packages:
 
@@ -1563,6 +1573,11 @@ packages:
       has-property-descriptors: 1.0.0
       object-keys: 1.1.1
     dev: false
+
+  /delay@5.0.0:
+    resolution: {integrity: sha512-ReEBKkIfe4ya47wlPYf/gu5ib6yUG0/Aez0JQZQz94kiWtRQvZIQbTiehsnwHvLSWJnQdhVeqYue7Id1dKr0qw==}
+    engines: {node: '>=10'}
+    dev: true
 
   /delegates@1.0.0:
     resolution: {integrity: sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==}
@@ -3878,6 +3893,11 @@ packages:
     resolution: {integrity: sha512-9GHUiM5hMiCi6Y03jD2ARC1ettBXkQBoQAe7nJsPknnI0ow10aXjTnew8QtYQmLjzn974BnmWEAJgCY6ZP1DeQ==}
     dependencies:
       mixme: 0.5.9
+    dev: false
+
+  /string-replace-async@2.0.0:
+    resolution: {integrity: sha512-AHMupZscUiDh07F1QziX7PLoB1DQ/pzu19vc8Xa8LwZcgnOXaw7yCgBuSYrxVEfaM2d8scc3Gtp+i+QJZV+spw==}
+    engines: {node: '>=0.12'}
     dev: false
 
   /string-width@4.2.3:


### PR DESCRIPTION
Close #205 

This PR adds several options related to YouTube embed titles:

- The default iframe `title` attribute is now configurable as an option. The default value remains the same.
- You can now opt to automatically download the actual title of the video from YouTube. This can be an accessibility win, since the iframe will better reflect the real content of the video. Note that activating this feature will cause network calls to YouTube for each embedded video — on large sites this could result in slow builds, or rate-limiting by YouTube, or both. If there's any failure in fetching the title, it will fall back to the default value.

## How to use it

This simplified example shows the new title options in action:

```js
eleventyConfig.addPlugin(embedYouTube, {
  title: "Custom iframe title wooooo",    // All YouTube iframes get this title by default
  titleOptions: {
    download: true,                       // Download the titles from YouTube
    cacheDuration: '1h'                   // Cache titles for one hour
  }
});
```

## Notes on implementation

- Javascript’s native `.replace` prototype is synchronous, which makes `await`ing the title impossible, so we now use the [string-replace-async](https://www.npmjs.com/package/string-replace-async) package instead.
  - Currently it has to be pinned to v2.0.0 because that's the most recent version that supports CJS modules. We can update later when Eleventy 3 ships.
  - I do prefer using native JS whenever possible but this library has decent usage and all tests continue to pass.
- The nature of this update makes it kind of an all-or-nothing change; the plugin is asynchronous for everyone as of this release, whether they turn on `titleOptions.download` or not. I worry a smidge about backward compatibility as a result, but hey, that's what semantic versioning is for, I guess.
- One nice effect is that making the pattern-replacements async is that they can also be made concurrent, so that could be a performance win.
- I've added some [new tests](https://github.com/gfscott/eleventy-plugin-embed-everything/blob/95a48d7333eb1ec5dfa604e113a7153fc2a5cf63/packages/youtube/test/index.test.js) just to really convince myself that the new behavior is truly equivalent to `.replace()`. It seems to be at parity.
