### PR TITLE
Restore YouTube options for custom iframe title and title download option

### DIFF
--- a/.changeset/four-mice-stare.md
+++ b/.changeset/four-mice-stare.md
@@ -1,0 +1,6 @@
+---
+"eleventy-plugin-youtube-embed": patch
+"eleventy-plugin-embed-everything": patch
+---
+
+Restore option to download and cache video title from YouTube

--- a/demo/.eleventy.js
+++ b/demo/.eleventy.js
@@ -16,6 +16,13 @@ module.exports = function(eleventyConfig) {
       options: {
         parent: ['localhost']
       }
+    },
+    youtube: {
+      options: {
+        titleOptions: {
+          download: true
+        }
+      }
     }
   });
 

--- a/demo/.eleventy.js
+++ b/demo/.eleventy.js
@@ -17,13 +17,6 @@ module.exports = function(eleventyConfig) {
         parent: ['localhost']
       }
     },
-    youtube: {
-      options: {
-        titleOptions: {
-          download: true
-        }
-      }
-    }
   });
 
   return {

--- a/demo/src/youtube.md
+++ b/demo/src/youtube.md
@@ -3,5 +3,3 @@ title: YouTube
 ---
 
 https://www.youtube.com/watch?v=hIs5StN8J-0
-
-https://www.youtube.com/watch?v=u6j6Zk945ZY

--- a/demo/src/youtube.md
+++ b/demo/src/youtube.md
@@ -3,3 +3,5 @@ title: YouTube
 ---
 
 https://www.youtube.com/watch?v=hIs5StN8J-0
+
+https://www.youtube.com/watch?v=u6j6Zk945ZY

--- a/packages/youtube/README.md
+++ b/packages/youtube/README.md
@@ -75,7 +75,7 @@ eleventyConfig.addPlugin(embedYouTube, {
 
 ### Plugin default options
 
-The plugin’s default settings reside in [lib/pluginDefaults.js](lib/pluginDefaults.js). All of these values can be changed with an options object passed to the plugin.
+The plugin’s default settings reside in [lib/defaults.js](lib/defaults.js). All of these values can be changed with an options object passed to the plugin.
 
 <table style="width: 100%;">
   <thead>
@@ -141,6 +141,27 @@ The plugin’s default settings reside in [lib/pluginDefaults.js](lib/pluginDefa
       <td><code>false</code></td>
       <td>Setting this to <code>true</code> will add a <code>rel=0</code> attribute to the embed url. This will tell YouTube to <a href="https://developers.google.com/youtube/player_parameters#rel">recommend videos from the same channel.</a></td>
     </tr>
+    <tr>
+      <td><code>title</code><br>✨ <b>New in v1.10.0!</b></td>
+      <td>String</td>
+      <td><code>Embedded YouTube video</code></td>
+      <td>Edit this value to change the default <code>title</code> attribute for the embedded iframe.</td>
+    </tr>
+    <tr>
+      <td colspan="4"><code>titleOptions</code>✨ <b>New in v1.10.0!</b></td>
+    </tr>
+    <tr>
+      <td><code>titleOptions.download</code></td>
+      <td>Boolean</td>
+      <td><code>false</code></td>
+      <td>Setting this to true will download and cache the title of the video from YouTube, then override the default value of <code>title</code>. <b>Note:</b> Turning this feature on will cause a network call to YouTube’s servers.</td>
+    </tr>
+    <tr>
+      <td><code>titleOptions.cacheDuration</code></td>
+      <td>String</td>
+      <td><code>5m</code></td>
+      <td>The length of time to cache the data from YouTube when <code>titleOptions.download</code> is set to true. Use the cache duration syntax from <a href="https://www.11ty.dev/docs/plugins/fetch/#change-the-cache-duration">@11ty/eleventy-fetch</a> to set this value.</td>
+    </tr>
   </tbody>
 </table>
 
@@ -159,6 +180,7 @@ In addition, using the Lite version will cause several of the plugin’s setting
 - `allowFullscreen`
 - `lazy`
 - `noCookie`
+- `title` and `titleOptions`
 
 #### Lite embed options
 
@@ -229,7 +251,7 @@ eleventyConfig.addPlugin(embedYouTube, {
       <td>Pass a custom URL to load the necessary JavaScript from the source of your choice.</td>
     </tr>
     <tr>
-      <td>✨ <b>New in v1.10.0!</b><br><code>lite.responsive</code></td>
+      <td><code>lite.responsive</code><br>✨ <b>New in v1.10.0!</b></td>
       <td>Boolean</td>
       <td><code>false</code></td>
       <td>If you change this to <code>true</code>, then the plugin adds a CSS rule to override the default max-width of <code>&lt;lite-youtube&gt;</code> elements, which are <a href="https://github.com/paulirish/lite-youtube-embed/blob/f9fc3a2475ade166d0cf7bb3e3caa3ec236ee74e/src/lite-yt-embed.css#L9">hard coded</a> to a maximum of 720 pixels.</td>

--- a/packages/youtube/index.js
+++ b/packages/youtube/index.js
@@ -9,7 +9,10 @@ module.exports = function (eleventyConfig, options = {}) {
     if ( !outputPath || !outputPath.endsWith(".html")) {
       return content;
     }
+    const {default: asyncReplace} = await import('string-replace-async');
     let index = 0;
-    return content.replace(pattern, (...match) => embed(match, config, index++));
+    return await asyncReplace(content, pattern, async (...match) => {
+      return await embed(match, config, index++)
+    });
   });
 };

--- a/packages/youtube/lib/defaults.js
+++ b/packages/youtube/lib/defaults.js
@@ -9,6 +9,10 @@
  * @property {boolean} [modestBranding] - Whether modest branding is enabled.
  * @property {boolean} [noCookie] - Whether cookies are disabled.
  * @property {boolean} [recommendSelfOnly] - Whether to only recommend self videos.
+ * @property {string} [title] - The default title for the embed iframe.
+ * @property {Object} [titleOptions] - Title options.
+ * @property {boolean} [titleOptions.download] - Whether to download the video title from YouTube.
+ * @property {string} [titleOptions.cacheDuration] - How long to cache the video title.
  */
 const defaults = {
   allowAttrs: 'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture',
@@ -20,6 +24,11 @@ const defaults = {
   modestBranding: false,
   noCookie: true,
   recommendSelfOnly: false,
+  title: 'Embedded YouTube video',
+  titleOptions: {
+    download: false,
+    cacheDuration: '5m',
+  }
 };
 
 /**

--- a/packages/youtube/package.json
+++ b/packages/youtube/package.json
@@ -35,7 +35,9 @@
   },
   "bugs": "https://github.com/gfscott/eleventy-plugin-embed-everything/issues",
   "dependencies": {
+    "@11ty/eleventy-fetch": "^4.0.0",
     "deepmerge": "^4.3.1",
-    "lite-youtube-embed": "^0.3.0"
+    "lite-youtube-embed": "^0.3.0",
+    "string-replace-async": "^3.0.2"
   }
 }

--- a/packages/youtube/test/embed.default.test.js
+++ b/packages/youtube/test/embed.default.test.js
@@ -25,81 +25,87 @@ const override = (obj) => merge(defaults, obj);
 
 const testString = '<p>https://www.youtube.com/watch?v=hIs5StN8J-0</p>';
 
-test(`Build embed default mode, default settings`, t => {
-  t.is(embed(extract(testString), defaults),
+test(`Build embed default mode, default settings`, async t => {
+  t.is(await embed(extract(testString), defaults),
     '<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/hIs5StN8J-0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>'
   );
 });
 
-test(`Build embed default mode, override nothing`, t => {
+test(`Build embed default mode, override nothing`, async t => {
   t.is(
-    (embed(extract(testString), defaults)),
+    (await embed(extract(testString), defaults)),
     '<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/hIs5StN8J-0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>'
   );
 });
 
-test(`Build embed default mode, override allowAttrs`, t => {
-  t.is(embed(extract(testString), override({allowAttrs: 'foo'})),
+test(`Build embed default mode, override allowAttrs`, async t => {
+  t.is(await embed(extract(testString), override({allowAttrs: 'foo'})),
     '<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/hIs5StN8J-0" allow="foo" allowfullscreen></iframe></div>'
   );
 });
 
-test(`Build embed default mode, override allowFullscreen`, t => {
-  t.is(embed(extract(testString), override({allowFullscreen: false})),
+test(`Build embed default mode, override allowFullscreen`, async t => {
+  t.is(await embed(extract(testString), override({allowFullscreen: false})),
     '<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/hIs5StN8J-0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"></iframe></div>'
   );
 });
 
-test(`Build embed default mode, override allowAutoplay`, t => {
-  t.is(embed(extract(testString), override({allowAutoplay: true})),
+test(`Build embed default mode, override allowAutoplay`, async t => {
+  t.is(await embed(extract(testString), override({allowAutoplay: true})),
     '<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/hIs5StN8J-0?autoplay=1" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>'
   );
 });
 
-test(`Build embed default mode, override embedClass`, t => {
-  t.is(embed(extract(testString), override({embedClass: 'foo'})),
+test(`Build embed default mode, override embedClass`, async t => {
+  t.is(await embed(extract(testString), override({embedClass: 'foo'})),
     '<div id="hIs5StN8J-0" class="foo" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/hIs5StN8J-0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>'
   );
 });
 
-test(`Build embed default mode, override lazy`, t => {
-  t.is(embed(extract(testString), override({lazy: true})),
+test(`Build embed default mode, override lazy`, async t => {
+  t.is(await embed(extract(testString), override({lazy: true})),
     '<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/hIs5StN8J-0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe></div>'
   );
 });
 
-test(`Build embed default mode, override noCookie`, t => {
-  t.is(embed(extract(testString), override({noCookie: false})),
+test(`Build embed default mode, override noCookie`, async t => {
+  t.is(await embed(extract(testString), override({noCookie: false})),
     '<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube.com/embed/hIs5StN8J-0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>'
   );
 });
 
-test(`Build embed default mode, override modestBranding`, t => {
-  t.is(embed(extract(testString), override({modestBranding: true})),
+test(`Build embed default mode, override modestBranding`, async t => {
+  t.is(await embed(extract(testString), override({modestBranding: true})),
     '<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/hIs5StN8J-0?modestbranding=1" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>'
   );
 });
 
-test(`Build embed default mode, override recommendSelfOnly`, t => {
-  t.is(embed(extract(testString), override({recommendSelfOnly: true})),
+test(`Build embed default mode, override recommendSelfOnly`, async t => {
+  t.is(await embed(extract(testString), override({recommendSelfOnly: true})),
     '<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/hIs5StN8J-0?rel=0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>'
   );
 });
 
-test(`Build embed default mode, override start time`, t => {
-  t.is(embed(extract(testString), override({startTime: 30})),
+test(`Build embed default mode, download YouTube title`, async t => {
+  t.is(await embed(extract(testString), override({titleOptions: { download: true }})), 
+  '<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Animotion - Obsession (Official Music Video)" src="https://www.youtube-nocookie.com/embed/hIs5StN8J-0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>'
+  );
+});
+
+test(`Build embed default mode, override start time`, async t => {
+  t.is(await embed(extract(testString), override({startTime: 30})),
     '<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/hIs5StN8J-0?start=30" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>'
   );
 });
 
-test(`Build embed default mode, override start time via URL`, t => {
-  t.is(embed(extract('<p>https://www.youtube.com/watch?v=hIs5StN8J-0&t=30s</p>'), override({})),
+test(`Build embed default mode, override start time via URL`, async t => {
+  t.is(await embed(extract('<p>https://www.youtube.com/watch?v=hIs5StN8J-0&t=30s</p>'), override({})),
     '<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/hIs5StN8J-0?start=30" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>'
   );
 });
 
-test(`Build embed default mode, short link with override start time via URL`, t => {
-  t.is(embed(extract('<p>https://youtu.be/hIs5StN8J-0?t=30</p>'), override({})),
+test(`Build embed default mode, short link with override start time via URL`, async t => {
+  t.is(await embed(extract('<p>https://youtu.be/hIs5StN8J-0?t=30</p>'), override({})),
     '<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/hIs5StN8J-0?start=30" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>'
   );
 });

--- a/packages/youtube/test/embed.multiple.test.js
+++ b/packages/youtube/test/embed.multiple.test.js
@@ -1,0 +1,22 @@
+const test = require('ava');
+const merge = require('deepmerge');
+const pattern = require('../lib/pattern.js');
+const embed = require('../lib/embed.js');
+const {defaults} = require('../lib/defaults.js');
+
+
+const multipleEmbeds = `<p>https://www.youtube.com/watch?v=hIs5StN8J-0</p><p>https://www.youtube.com/watch?v=4JS70KB9GS0</p>`;
+const expected = '<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/hIs5StN8J-0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div><div id="4JS70KB9GS0" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/4JS70KB9GS0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>'
+
+test(`Check that output doesn't produce duplicated embeds`, async t => {
+  const {default: asyncReplace} = await import('string-replace-async');
+  const content = multipleEmbeds;
+  const config = defaults;
+  let index = 0;
+  const result = await asyncReplace(content, pattern, async (...match) => {
+    return await embed(match, config, index++)
+  });
+  t.is(result, expected);
+
+});
+

--- a/packages/youtube/test/oembed.test.js
+++ b/packages/youtube/test/oembed.test.js
@@ -1,0 +1,19 @@
+const test = require('ava');
+const {defaults} = require('../lib/defaults.js');
+const {getYouTubeTitleViaOembed} = require('../lib/embed.js');
+
+
+test('getYouTubeTitleViaOembed returns a string', async (t) => {
+  const result = await getYouTubeTitleViaOembed('hIs5StN8J-0', defaults);
+  t.is(typeof result, 'string');
+});
+
+test('getYouTubeTitleViaOembed returns the correct title', async (t) => {
+  const result = await getYouTubeTitleViaOembed('hIs5StN8J-0', defaults);
+  t.is(result, 'Animotion - Obsession (Official Music Video)');
+});
+
+test('getYouTubeTitleViaOembed returns the default title on network error', async (t) => {
+  const result = await getYouTubeTitleViaOembed('00000000000', defaults);
+  t.is(result, defaults.title);
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,12 +100,18 @@ importers:
 
   packages/youtube:
     dependencies:
+      '@11ty/eleventy-fetch':
+        specifier: ^4.0.0
+        version: 4.0.0
       deepmerge:
         specifier: ^4.3.1
         version: 4.3.1
       lite-youtube-embed:
         specifier: ^0.3.0
         version: 0.3.0
+      string-replace-async:
+        specifier: ^3.0.2
+        version: 3.0.2
 
 packages:
 
@@ -3878,6 +3884,11 @@ packages:
     resolution: {integrity: sha512-9GHUiM5hMiCi6Y03jD2ARC1ettBXkQBoQAe7nJsPknnI0ow10aXjTnew8QtYQmLjzn974BnmWEAJgCY6ZP1DeQ==}
     dependencies:
       mixme: 0.5.9
+    dev: false
+
+  /string-replace-async@3.0.2:
+    resolution: {integrity: sha512-s6hDtXJ7FKyRap/amefqrOMpkEQvxUDueyvJygQeHxCK5Za90dOMgdibCCrPdfdAYAkr8imrZ1PPXW7DOf0RzQ==}
+    engines: {node: '>= 14.0.0'}
     dev: false
 
   /string-width@4.2.3:


### PR DESCRIPTION
Closes #205. Genuinely fixes #230 instead of just mitigating it. Supersedes #224.

This PR adds several options related to YouTube embed titles:

- The default iframe `title` attribute is now configurable as an option. The default value remains the same.
- You can now opt to automatically download the actual title of the video from YouTube. This can be an accessibility win, since the iframe will better reflect the real content of the video. Note that activating this feature will cause network calls to YouTube for each embedded video — on large sites this could result in slow builds, or rate-limiting by YouTube, or both. If there's any failure in fetching the title, it will fall back to the default value.

## How to use it

This simplified example shows the new title options in action:

```js
eleventyConfig.addPlugin(embedYouTube, {
  title: "Custom iframe title wooooo",    // Default/fallback iframe title value
  titleOptions: {
    download: true,                       // Download the titles from YouTube
    cacheDuration: '1h'                   // Cache titles for one hour
  }
});
```

## Notes on implementation

- Javascript’s native `.replace` prototype is synchronous, which makes `await`ing the title impossible, so we now use the [string-replace-async](https://www.npmjs.com/package/string-replace-async) package instead.
- The nature of this update makes it kind of an all-or-nothing change; the YouTube plugin is asynchronous for everyone as of this release, whether they turn on `titleOptions.download` or not. 
- One nice effect is that making the pattern-replacements async is that they can also be made concurrent, so that could be a performance win.
- I've added some [new tests](https://github.com/gfscott/eleventy-plugin-embed-everything/blob/95a48d7333eb1ec5dfa604e113a7153fc2a5cf63/packages/youtube/test/index.test.js) just to really convince myself that the new behavior is truly equivalent to `.replace()`. It seems to be at parity.
