### PR TITLE
Add lite-mode options for thumbnail format and YouTube Player API access

### DIFF
--- a/.changeset/old-dragons-float.md
+++ b/.changeset/old-dragons-float.md
@@ -1,0 +1,5 @@
+---
+"eleventy-plugin-youtube-embed": minor
+---
+
+Add lite-mode options for thumbnail format and YouTube JS API access

--- a/packages/youtube/README.md
+++ b/packages/youtube/README.md
@@ -251,6 +251,12 @@ eleventyConfig.addPlugin(embedYouTube, {
       <td>Pass a custom URL to load the necessary JavaScript from the source of your choice.</td>
     </tr>
     <tr>
+      <td><code>lite.jsApi</code><br>✨ <b>New in v1.11.0!</b></td>
+      <td>Boolean</td>
+      <td><code>false</code></td>
+      <td>If you change this to true, then the plugin adds a `js-api` parameter to the custom element that enables access to YouTube's IFrame Player API. See <a href="https://github.com/paulirish/lite-youtube-embed?tab=readme-ov-file#access-the-youtube-iframe-player-api">usage example</a> and <a href="https://paulirish.github.io/lite-youtube-embed/variants/js-api.html">demo</a>.</td>
+    </tr>
+    <tr>
       <td><code>lite.responsive</code><br>✨ <b>New in v1.10.0!</b></td>
       <td>Boolean</td>
       <td><code>false</code></td>

--- a/packages/youtube/README.md
+++ b/packages/youtube/README.md
@@ -257,6 +257,12 @@ eleventyConfig.addPlugin(embedYouTube, {
       <td>If you change this to <code>true</code>, then the plugin adds a CSS rule to override the default max-width of <code>&lt;lite-youtube&gt;</code> elements, which are <a href="https://github.com/paulirish/lite-youtube-embed/blob/f9fc3a2475ade166d0cf7bb3e3caa3ec236ee74e/src/lite-yt-embed.css#L9">hard coded</a> to a maximum of 720 pixels.</td>
     </tr>
     <tr>
+      <td><code>lite.thumbnailFormat</code><br>✨ <b>New in v1.11.0!</b></td>
+      <td>String</td>
+      <td><code>jpg</code></td>
+      <td>If you change this to <code>webp</code>, then the plugin will load the YouTube thumbnail image in WebP format instead of JPEG.</td>
+    </tr>
+    <tr>
       <td><code>lite.thumbnailQuality</code></td>
       <td>String</td>
       <td><code>hqdefault</code></td>

--- a/packages/youtube/lib/defaults.js
+++ b/packages/youtube/lib/defaults.js
@@ -35,10 +35,14 @@ const defaults = {
  * @typedef {Object} Thumbnails
  * @property {string[]} validSizes - An array of valid sizes.
  * @property {string} defaultSize - The default size.
+ * @property {string[]} validFormats - An array of valid formats.
+ * @property {string} defaultFormat - The default format.
  */
 const thumbnails = {
   validSizes: ["default", "hqdefault", "mqdefault", "sddefault", "maxresdefault"],
-  defaultSize: "hqdefault"
+  defaultSize: "hqdefault",
+  validFormats: ["jpg", "webp"],
+  defaultFormat: "jpg",
 }
 
 /**
@@ -58,15 +62,16 @@ const liteDefaults = {
   css: {
     enabled: true,
     inline: false,
-    path: 'https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.0/src/lite-yt-embed.min.css'
+    path: 'https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.2/src/lite-yt-embed.min.css'
   },
   js: {
     enabled: true,
     inline: false,
-    path: 'https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.0/src/lite-yt-embed.min.js'
+    path: 'https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.2/src/lite-yt-embed.min.js'
   },
   responsive: false,
   thumbnailQuality: thumbnails.defaultSize,
+  thumbnailFormat: thumbnails.defaultFormat,
 };
   
 module.exports.thumbnails = thumbnails;

--- a/packages/youtube/lib/defaults.js
+++ b/packages/youtube/lib/defaults.js
@@ -55,6 +55,7 @@ const thumbnails = {
  * @property {boolean} [js.enabled] - Whether JS is enabled.
  * @property {boolean} [js.inline] - Whether JS is inline.
  * @property {string} [js.path] - The path to the JS file.
+ * 
  * @property {boolean} [responsive] - Whether the layout is responsive.
  * @property {string} [thumbnailQuality] - The quality of the thumbnail.
  */
@@ -69,6 +70,7 @@ const liteDefaults = {
     inline: false,
     path: 'https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.2/src/lite-yt-embed.min.js'
   },
+  jsApi: false,
   responsive: false,
   thumbnailQuality: thumbnails.defaultSize,
   thumbnailFormat: thumbnails.defaultFormat,

--- a/packages/youtube/lib/embed.js
+++ b/packages/youtube/lib/embed.js
@@ -73,8 +73,15 @@ function liteEmbed({id, url}, options, index) {
   options = merge(options, getInputUrlParams(url))
   const liteOpt = liteConfig(options);
         liteOpt.thumbnailQuality = validateThumbnailSize(liteOpt.thumbnailQuality);
+        liteOpt.thumbnailFormat = validateThumbnailFormat(liteOpt.thumbnailFormat);
   const params = stringifyUrlParams(options);
   
+  const thumbnailUrl = () => {
+    const fileTypePath = liteOpt.thumbnailFormat === 'webp' ? 'vi_webp' : 'vi';
+    const fileName = `${liteOpt.thumbnailQuality}.${liteOpt.thumbnailFormat}`;
+    return `https://i.ytimg.com/${fileTypePath}/${id}/${fileName}`;
+  }
+
   // Access the file system to read the lite embed CSS and JS
   const fs = require('fs');
   const path = require('path');
@@ -96,7 +103,7 @@ function liteEmbed({id, url}, options, index) {
   out += index === 0 && liteOpt.responsive ? `<style>.${options.embedClass} lite-youtube {max-width:100%}</style>\n` : '';
   
   out += `<div id="${id}" class="${options.embedClass}">`;
-  out += `<lite-youtube videoid="${id}" style="background-image: url('https://i.ytimg.com/vi/${id}/${liteOpt.thumbnailQuality}.jpg');"${params ? ` params="${params}"` : ''}>`;
+  out += `<lite-youtube videoid="${id}" style="background-image: url('${thumbnailUrl()}');"${params ? ` params="${params}"` : ''}>`;
   out += '<div class="lty-playbtn"></div></lite-youtube></div>';
   return out;
 }
@@ -198,5 +205,20 @@ async function getYouTubeTitleViaOembed(id, options) {
   }
 }
 
+/**
+ * Validates the thumbnail format and returns the format if it is valid, otherwise returns the default format.
+ *
+ * @param {string} format - The thumbnail format to validate.
+ * @param {object} options - The options object containing the valid thumbnail formats.
+ * @returns {string} - The validated thumbnail format.
+ */
+function validateThumbnailFormat(format) {
+  if ( !thumbnails.validFormats.includes(format) ) {
+    return thumbnails.defaultFormat
+  }
+  return format;
+}
+
 module.exports.validateThumbnailSize = validateThumbnailSize;
+module.exports.validateThumbnailFormat = validateThumbnailFormat;
 module.exports.getYouTubeTitleViaOembed = getYouTubeTitleViaOembed;

--- a/packages/youtube/lib/embed.js
+++ b/packages/youtube/lib/embed.js
@@ -103,7 +103,7 @@ function liteEmbed({id, url}, options, index) {
   out += index === 0 && liteOpt.responsive ? `<style>.${options.embedClass} lite-youtube {max-width:100%}</style>\n` : '';
   
   out += `<div id="${id}" class="${options.embedClass}">`;
-  out += `<lite-youtube videoid="${id}" style="background-image: url('${thumbnailUrl()}');"${params ? ` params="${params}"` : ''}>`;
+  out += `<lite-youtube videoid="${id}" style="background-image: url('${thumbnailUrl()}');"${params ? ` params="${params}"` : ''}${liteOpt.jsApi ? ' js-api' : ''}>`;
   out += '<div class="lty-playbtn"></div></lite-youtube></div>';
   return out;
 }

--- a/packages/youtube/test/embed.lite.test.js
+++ b/packages/youtube/test/embed.lite.test.js
@@ -41,6 +41,11 @@ test(`Build embed lite mode, zero index, lite defaults`, t => {
   `<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.2/src/lite-yt-embed.min.css">\n<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.2/src/lite-yt-embed.min.js"></script>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
   );
 });
+test(`Build embed lite mode, zero index, JS API enabled`, t => {
+  t.is(embed(extract(testString), override({lite: {jsApi: true}}), 0),
+  `<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.2/src/lite-yt-embed.min.css">\n<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.2/src/lite-yt-embed.min.js"></script>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');" js-api><div class="lty-playbtn"></div></lite-youtube></div>`
+  );
+});
 test(`Build embed lite mode, zero index, valid thumbnail format override`, t => {
   t.is(embed(extract(testString), override({lite: {thumbnailFormat: 'webp'}}), 0),
   `<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.2/src/lite-yt-embed.min.css">\n<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.2/src/lite-yt-embed.min.js"></script>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi_webp/hIs5StN8J-0/hqdefault.webp');"><div class="lty-playbtn"></div></lite-youtube></div>`
@@ -119,6 +124,11 @@ test(`Build embed lite mode, zero index, responsive true`, t => {
 test(`Build embed lite mode, 1+ index, lite defaults`, t => {
   t.is(embed(extract(testString), override({lite: true}), 1),
   `<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+  );
+});
+test(`Build embed lite mode, 1+ index, JS API enabled`, t => {
+  t.is(embed(extract(testString), override({lite: {jsApi: true}}), 1),
+  `<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');" js-api><div class="lty-playbtn"></div></lite-youtube></div>`
   );
 });
 test(`Build embed lite mode, 1+ index, valid thumbnail quality override`, t => {

--- a/packages/youtube/test/embed.lite.test.js
+++ b/packages/youtube/test/embed.lite.test.js
@@ -3,7 +3,7 @@ const merge = require('deepmerge');
 const pattern = require('../lib/pattern.js');
 const embed = require('../lib/embed.js');
 const {defaults} = require('../lib/defaults.js');
-const { validateThumbnailSize } = require('../lib/embed.js');
+const { validateThumbnailSize, validateThumbnailFormat } = require('../lib/embed.js');
 
 const fs = require('fs');
 const path = require('path');
@@ -38,47 +38,57 @@ const override = (obj) => merge(defaults, obj);
  */
 test(`Build embed lite mode, zero index, lite defaults`, t => {
   t.is(embed(extract(testString), override({lite: true}), 0),
-  `<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.0/src/lite-yt-embed.min.css">\n<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.0/src/lite-yt-embed.min.js"></script>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+  `<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.2/src/lite-yt-embed.min.css">\n<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.2/src/lite-yt-embed.min.js"></script>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+  );
+});
+test(`Build embed lite mode, zero index, valid thumbnail format override`, t => {
+  t.is(embed(extract(testString), override({lite: {thumbnailFormat: 'webp'}}), 0),
+  `<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.2/src/lite-yt-embed.min.css">\n<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.2/src/lite-yt-embed.min.js"></script>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi_webp/hIs5StN8J-0/hqdefault.webp');"><div class="lty-playbtn"></div></lite-youtube></div>`
+  );
+});
+test(`Build embed lite mode, zero index, invalid thumbnail format override`, t => {
+  t.is(embed(extract(testString), override({lite: {thumbnailFormat: 'no'}}), 0),
+  `<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.2/src/lite-yt-embed.min.css">\n<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.2/src/lite-yt-embed.min.js"></script>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
   );
 });
 test(`Build embed lite mode, zero index, valid thumbnail quality override`, t => {
   t.is(embed(extract(testString), override({lite: { thumbnailQuality: 'maxresdefault'}}), 0),
-  `<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.0/src/lite-yt-embed.min.css">\n<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.0/src/lite-yt-embed.min.js"></script>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/maxresdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+  `<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.2/src/lite-yt-embed.min.css">\n<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.2/src/lite-yt-embed.min.js"></script>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/maxresdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
   );
 });
 test(`Build embed lite mode, zero index, invalid thumbnail quality override`, t => {
   t.is(embed(extract(testString), override({lite: { thumbnailQuality: 'nope'}}), 0),
-  `<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.0/src/lite-yt-embed.min.css">\n<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.0/src/lite-yt-embed.min.js"></script>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+  `<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.2/src/lite-yt-embed.min.css">\n<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.2/src/lite-yt-embed.min.js"></script>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
   );
 });
 test(`Build embed lite mode, zero index, lite defaults with URL start time param`, t => {
   t.is(embed(extract('<p>https://www.youtube.com/watch?v=hIs5StN8J-0&t=30s</p>'), override({lite: true}), 0),
-  `<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.0/src/lite-yt-embed.min.css">\n<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.0/src/lite-yt-embed.min.js"></script>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');" params="start=30"><div class="lty-playbtn"></div></lite-youtube></div>`
+  `<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.2/src/lite-yt-embed.min.css">\n<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.2/src/lite-yt-embed.min.js"></script>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');" params="start=30"><div class="lty-playbtn"></div></lite-youtube></div>`
   );
 });
 test(`Build embed lite mode, zero index, css disabled`, t => {
   t.is(embed(extract(testString), override({lite:{css:{enabled: false}}}), 0),
-  `<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.0/src/lite-yt-embed.min.js"></script>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+  `<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.2/src/lite-yt-embed.min.js"></script>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
   );
 });
 test(`Build embed lite mode, zero index, css inline`, t => {
   t.is(embed(extract(testString), override({lite:{css:{inline: true}}}), 0),
-  `<style>${inlineCss}</style>\n<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.0/src/lite-yt-embed.min.js"></script>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+  `<style>${inlineCss}</style>\n<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.2/src/lite-yt-embed.min.js"></script>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
   );
 });
 test(`Build embed lite mode, zero index, css path override`, t => {
   t.is(embed(extract(testString), override({lite:{css:{path: 'foo'}}}), 0),
-  `<link rel="stylesheet" href="foo">\n<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.0/src/lite-yt-embed.min.js"></script>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+  `<link rel="stylesheet" href="foo">\n<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.2/src/lite-yt-embed.min.js"></script>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
   );
 });
 test(`Build embed lite mode, zero index, js disabled`, t => {
   t.is(embed(extract(testString), override({lite:{js:{enabled: false}}}), 0),
-  `<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.0/src/lite-yt-embed.min.css">\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+  `<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.2/src/lite-yt-embed.min.css">\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
   );
 });
 test(`Build embed lite mode, zero index, js inline`, t => {
   t.is(embed(extract(testString), override({lite:{js:{inline: true}}}), 0),
-  `<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.0/src/lite-yt-embed.min.css">\n<script>${inlineJs}</script>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+  `<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.2/src/lite-yt-embed.min.css">\n<script>${inlineJs}</script>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
   );
 });
 test(`Build embed lite mode, zero index, css AND js disabled`, t => {
@@ -98,7 +108,7 @@ test(`Build embed lite mode, zero index, css AND js inline`, t => {
 });
 test(`Build embed lite mode, zero index, responsive true`, t => {
   t.is(embed(extract(testString), override({lite: { responsive: true }}), 0),
-  `<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.0/src/lite-yt-embed.min.css">\n<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.0/src/lite-yt-embed.min.js"></script>\n<style>.eleventy-plugin-youtube-embed lite-youtube {max-width:100%}</style>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+  `<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.2/src/lite-yt-embed.min.css">\n<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.2/src/lite-yt-embed.min.js"></script>\n<style>.eleventy-plugin-youtube-embed lite-youtube {max-width:100%}</style>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
   );
 });
 
@@ -108,6 +118,26 @@ test(`Build embed lite mode, zero index, responsive true`, t => {
  */
 test(`Build embed lite mode, 1+ index, lite defaults`, t => {
   t.is(embed(extract(testString), override({lite: true}), 1),
+  `<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+  );
+});
+test(`Build embed lite mode, 1+ index, valid thumbnail quality override`, t => {
+  t.is(embed(extract(testString), override({lite: { thumbnailQuality: 'maxresdefault'}}), 1),
+  `<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/maxresdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+  );
+});
+test(`Build embed lite mode, 1+ index, invalid thumbnail quality override`, t => {
+  t.is(embed(extract(testString), override({lite: { thumbnailQuality: 'nope'}}), 1),
+  `<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+  );
+});
+test(`Build embed lite mode, 1+ index, valid thumbnail format override`, t => {
+  t.is(embed(extract(testString), override({lite: {thumbnailFormat: 'webp'}}), 1),
+  `<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi_webp/hIs5StN8J-0/hqdefault.webp');"><div class="lty-playbtn"></div></lite-youtube></div>`
+  );
+});
+test(`Build embed lite mode, 1+ index, invalid thumbnail format override`, t => {
+  t.is(embed(extract(testString), override({lite: {thumbnailFormat: 'foo'}}), 1),
   `<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
   );
 });
@@ -148,22 +178,37 @@ test(`Build embed lite mode, 1+ index, responsive true`, t => {
 });
 
 /**
- * In lite mode, test that the thumbnail size validator returns the expected values.
+ * In lite mode, test that the thumbnail validators return the expected values.
 */
-test(`Thumbnail validator returns default value in response to empty parameter`, t => {
+test(`Thumbnail size validator returns default value in response to empty parameter`, t => {
   t.is(validateThumbnailSize(), 'hqdefault');
 });
-test(`Thumbnail validator returns default value in response to incorrect parameter types`, t => {
+test(`Thumbnail size validator returns default value in response to incorrect parameter types`, t => {
   t.is(validateThumbnailSize(1), 'hqdefault');
   t.is(validateThumbnailSize(true), 'hqdefault');
 });
-test(`Thumbnail validator returns default value in response to invalid string`, t => {
+test(`Thumbnail size validator returns default value in response to invalid string`, t => {
   t.is(validateThumbnailSize('foo'), 'hqdefault');
 });
-test(`Thumbnail validator returns expected strings when passed expected strings`, t => {
+test(`Thumbnail size validator returns expected strings when passed expected strings`, t => {
   t.is(validateThumbnailSize('default'), 'default');
   t.is(validateThumbnailSize('hqdefault'), 'hqdefault');
   t.is(validateThumbnailSize('mqdefault'), 'mqdefault');
   t.is(validateThumbnailSize('sddefault'), 'sddefault');
   t.is(validateThumbnailSize('maxresdefault'), 'maxresdefault');
+});
+
+test(`Thumbnail format validator returns default value in response to empty parameter`, t => {
+  t.is(validateThumbnailFormat(), 'jpg');
+})
+test(`Thumbnail format validator returns default value in response to incorrect parameter types`, t => {
+  t.is(validateThumbnailFormat(1), 'jpg');
+  t.is(validateThumbnailFormat(true), 'jpg');
+});
+test(`Thumbnail format validator returns default value in response to invalid string`, t => {
+  t.is(validateThumbnailFormat('avif'), 'jpg');
+});
+test(`Thumbnail format validator returns expected strings when passed expected strings`, t => {
+  t.is(validateThumbnailFormat('jpg'), 'jpg');
+  t.is(validateThumbnailFormat('webp'), 'webp');
 });


### PR DESCRIPTION
Lite YouTube Embed was recently bumped to v0.3.2 with #244, and it added a few new options. This PR matches that dependency update and adds some options that align its functionality with the upstream package:

1. Lite YouTube Embed recently [improved its support](https://github.com/paulirish/lite-youtube-embed/pull/167) for WebP images. You can now opt-in to WebP instead of the default JPG format by passing the `thumbnailFormat: 'webp'` option.
2. The library also recently [added support](https://github.com/paulirish/lite-youtube-embed/pull/164) for a `js-api` parameter, which enables access to the [YouTube IFrame Player API](https://developers.google.com/youtube/iframe_api_reference). You can enable this by passing the `jsApi: true` option.