### PR TITLE
Add private utility package to permute arrays for URL testing purposes

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@svitejs/changesets-changelog-github-compact": "^1.1.0",
     "ava": "^6.1.2",
     "nyc": "^15.1.0",
+    "permute-arrays": "workspace:^",
     "turbo": "^1.12.5"
   },
   "dependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,9 @@ importers:
       nyc:
         specifier: ^15.1.0
         version: 15.1.0
+      permute-arrays:
+        specifier: workspace:^
+        version: link:utils/permute-arrays
       turbo:
         specifier: ^1.12.5
         version: 1.12.5
@@ -112,6 +115,8 @@ importers:
       string-replace-async:
         specifier: ^3.0.2
         version: 3.0.2
+
+  utils/permute-arrays: {}
 
 packages:
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,5 @@
 packages:
   - "packages/*"
   - "demo"
+  - "utils/*"
+  

--- a/utils/permute-arrays/index.js
+++ b/utils/permute-arrays/index.js
@@ -1,0 +1,54 @@
+/**
+ * Permutes the given term by prepending each prefix and appending each suffix.
+ *
+ * @param {string} term - The term to permute.
+ * @param {string[]} prefixes - The prefixes to prepend to the term.
+ * @param {string[]} suffixes - The suffixes to append to the term.
+ * @returns {string[]} - The permuted array of terms.
+ */
+export default function(term, prefixes = [], suffixes = []) {
+  const termWithPrefixes = prependEach(term, prefixes);
+  const termWithSuffixes = appendEach(term, suffixes);
+  const termWithPrefixesAndSuffixes = appendEach(termWithPrefixes, suffixes);
+  return [...termWithPrefixes, ...termWithSuffixes, ...termWithPrefixesAndSuffixes];
+}
+
+/**
+ * Prepends each element of the term array with each prefix in the prefixes array.
+ * @param {string | string[]} term - The term array.
+ * @param {string[]} prefixes - The prefixes array.
+ * @returns {string[]} - The resulting array with each element prepended with each prefix.
+ */
+export const prependEach = (term, prefixes) => {  
+  let arr = coerceToArray(term);
+  return arr.map(t => prefixes.map(p => p + t)).flat();
+}
+
+/**
+ * Appends each suffix to every term in the array.
+ *
+ * @param {string | string[]} term - The term to append suffixes to.
+ * @param {string[]} suffixes - The array of suffixes to append.
+ * @returns {string[]} - The array of terms with suffixes appended.
+ */
+export const appendEach = (term, suffixes) => {
+  let arr = coerceToArray(term);
+  return arr.map(t => suffixes.map(s => t + s)).flat();
+}
+
+
+/**
+ * Coerces the given value to an array.
+ *
+ * @param {any} mysteryObject - The value to be coerced to an array.
+ * @returns {string[]} - The coerced array.
+ */
+export const coerceToArray = (mysteryObject) => {
+  if ( Array.isArray(mysteryObject) ) {
+    return mysteryObject;
+  }
+  if ( typeof mysteryObject === 'string' ) {
+    return [].concat(mysteryObject);
+  }
+  return undefined;
+}

--- a/utils/permute-arrays/index.test.js
+++ b/utils/permute-arrays/index.test.js
@@ -1,0 +1,141 @@
+import test from 'ava';
+import { coerceToArray, appendEach, prependEach } from './index.js';
+import permuteArrays from './index.js';
+
+test('coerceToArray - should return the input array if it is already an array', (t) => {
+  const input = [1, 2, 3];
+  const result = coerceToArray(input);
+  t.deepEqual(result, input);
+});
+
+test('coerceToArray - should convert a string to an array with the string as the only element', (t) => {
+  const input = 'hello';
+  const result = coerceToArray(input);
+  t.deepEqual(result, ['hello']);
+});
+
+test('coerceToArray - should return undefined for any other input type', (t) => {
+  const input = { key: 'value' };
+  const result = coerceToArray(input);
+  t.is(result, undefined);
+});
+
+test('appendEach - should append each suffix to each term in the array', (t) => {
+  const term = ['fast', 'slow'];
+  const suffixes = ['er', 'est'];
+  const result = appendEach(term, suffixes);
+  t.deepEqual(result, ['faster', 'fastest', 'slower', 'slowest']);
+});
+
+test('appendEach - should return an empty array if the term is an empty array', (t) => {
+  const term = [];
+  const suffixes = ['s', 'es'];
+  const result = appendEach(term, suffixes);
+  t.deepEqual(result, []);
+});
+
+test('appendEach - should return an empty array if the suffixes array is empty', (t) => {
+  const term = ['apple', 'banana'];
+  const suffixes = [];
+  const result = appendEach(term, suffixes);
+  t.deepEqual(result, []);
+});
+
+test('appendEach - should return an empty array if both the term and suffixes arrays are empty', (t) => {
+  const term = [];
+  const suffixes = [];
+  const result = appendEach(term, suffixes);
+  t.deepEqual(result, []);
+});
+
+test('prependEach - should prepend each prefix to each term in the array', (t) => {
+  const term = ['fast', 'slow'];
+  const prefixes = ['super', 'ultra'];
+  const result = prependEach(term, prefixes);
+  t.deepEqual(result, ['superfast', 'ultrafast', 'superslow', 'ultraslow']);
+});
+
+test('prependEach - should return an empty array if the term is an empty array', (t) => {
+  const term = [];
+  const prefixes = ['big', 'small'];
+  const result = prependEach(term, prefixes);
+  t.deepEqual(result, []);
+});
+
+test('prependEach - should return an empty array if the prefixes array is empty', (t) => {
+  const term = ['apple', 'banana'];
+  const prefixes = [];
+  const result = prependEach(term, prefixes);
+  t.deepEqual(result, []);
+});
+
+test('prependEach - should return an empty array if both the term and prefixes arrays are empty', (t) => {
+  const term = [];
+  const prefixes = [];
+  const result = prependEach(term, prefixes);
+  t.deepEqual(result, []);
+});
+
+test('permuteArrays - should prepend each prefix and append each suffix to each term in the array', (t) => {
+  const term = ['a'];
+  const prefixes = ['d', 'r'];
+  const suffixes = ['d', 'm'];
+  const result = permuteArrays(term, prefixes, suffixes);
+  t.deepEqual(result, ['da', 'ra', 'ad', 'am', 'dad', 'dam', 'rad', 'ram']);
+});
+
+test('permuteArrays - should return an empty array if the term is an empty array', (t) => {
+  const term = [];
+  const prefixes = ['big', 'small'];
+  const suffixes = ['s', 'es'];
+  const result = permuteArrays(term, prefixes, suffixes);
+  t.deepEqual(result, []);
+});
+
+test('permuteArrays - should return term with suffixes if the prefixes array is empty', (t) => {
+  const term = ['high', 'low'];
+  const prefixes = [];
+  const suffixes = ['ly', 'est'];
+  const result = permuteArrays(term, prefixes, suffixes);
+  t.deepEqual(result, ['highly', 'highest', 'lowly', 'lowest']);
+});
+
+test('permuteArrays - should return an empty array if the suffixes array is empty', (t) => {
+  const term = ['way', 'line'];
+  const prefixes = ['high', 'by'];
+  const suffixes = [];
+  const result = permuteArrays(term, prefixes, suffixes);
+  t.deepEqual(result, ['highway', 'byway', 'highline', 'byline']);
+});
+
+test('permuteArrays - should return an empty array if both the term and prefixes arrays are empty', (t) => {
+  const term = [];
+  const prefixes = [];
+  const suffixes = ['s', 'es'];
+  const result = permuteArrays(term, prefixes, suffixes);
+  t.deepEqual(result, []);
+});
+
+test('permuteArrays - should return an empty array if both the term and suffixes arrays are empty', (t) => {
+  const term = [];
+  const prefixes = ['big', 'small'];
+  const suffixes = [];
+  const result = permuteArrays(term, prefixes, suffixes);
+  t.deepEqual(result, []);
+});
+
+test('permuteArrays - should return an empty array if both the prefixes and suffixes arrays are empty', (t) => {
+  const term = ['apple', 'banana'];
+  const prefixes = [];
+  const suffixes = [];
+  const result = permuteArrays(term, prefixes, suffixes);
+  t.deepEqual(result, []);
+});
+
+test('permuteArrays - should return an empty array if all arrays (term, prefixes, suffixes) are empty', (t) => {
+  const term = [];
+  const prefixes = [];
+  const suffixes = [];
+  const result = permuteArrays(term, prefixes, suffixes);
+  t.deepEqual(result, []);
+});

--- a/utils/permute-arrays/package.json
+++ b/utils/permute-arrays/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "permute-arrays",
+  "version": "0.1.0",
+  "description": "A utility to generate all possible permutations of an array of arrays.",
+  "main": "index.js",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "test": "npx ava",
+    "coverage": "nyc --reporter=lcov ava"
+  },
+  "files": [
+    "index.js"
+  ],
+  "keywords": [],
+  "author": {
+    "name": "Graham F. Scott",
+    "email": "gfscott@gmail.com",
+    "url": "https://gfscott.com"
+  },
+  "license": "MIT"
+}


### PR DESCRIPTION
This PR adds a private utility package, `permute-arrays`, which is useful for constructing large arrays of URL variants for testing. Something like it is already duplicated across several existing packages so I'm extracting it into a reusable thing here. I don't think it makes sense to release it publicly. It'll only be available in the local workspace for testing purposes and isn't included as a dependency in any of the plugin packages.