### PR TITLE
Add testing with Node 22

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        node: ["18", "20"]
+        node: ["18", "20", "22"]
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3


### PR DESCRIPTION
Node 22 was released on May 15, so adding it as a testing runtime.