### PR TITLE
Resolve pnpm version conflict in actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,9 +22,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: 8
+        uses: pnpm/action-setup@v4
       
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -87,9 +85,7 @@ jobs:
           ref: next
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: 8
+        uses: pnpm/action-setup@v4
       
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,9 +16,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
       - name: Install pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: 8
+        uses: pnpm/action-setup@v4
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -70,9 +68,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
       - name: Install pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: 8
+        uses: pnpm/action-setup@v4
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
[pnpm/action-setup](https://github.com/pnpm/action-setup) v4 now installs the version specified in the `packageManager` field of the package file and throws an error if a different version is passed in the action. Better to just remove those references and rely on the centralized version.