### PR TITLE
Add support for embedding playlists

### DIFF
--- a/.changeset/lazy-crews-fry.md
+++ b/.changeset/lazy-crews-fry.md
@@ -1,0 +1,6 @@
+---
+"eleventy-plugin-youtube-embed": minor
+"eleventy-plugin-embed-everything-demo": patch
+---
+
+Add support for embedding playlists

--- a/demo/src/youtube.md
+++ b/demo/src/youtube.md
@@ -2,4 +2,20 @@
 title: YouTube
 ---
 
+## Single video
+
+`https://www.youtube.com/watch?v=hIs5StN8J-0`
+
 https://www.youtube.com/watch?v=hIs5StN8J-0
+
+## Playlist
+
+`https://www.youtube.com/playlist?list=PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW`
+
+https://www.youtube.com/playlist?list=PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW
+
+## Any given video from within a playlist
+
+`https://www.youtube.com/watch?v=Jy6l92bFxtQ&list=PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW`
+
+https://www.youtube.com/watch?v=Jy6l92bFxtQ&list=PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW

--- a/packages/youtube/lib/pattern.js
+++ b/packages/youtube/lib/pattern.js
@@ -23,4 +23,4 @@
  * 6. Arbitrary whitespace 
  */
 
-module.exports = /<p>(?=(\s*))\1(?:<a [^>]*?>)??(?=(\s*))\2(?:https?:\/\/)??((?:w{3}\.)??(?:youtube\.com|youtu\.be)\/(?:watch\?v=|embed\/)??([A-Za-z0-9-_]{11})(?:[^\s<>]*))(?=(\s*))\5(?:<\/a>)??(?=(\s*))\6<\/p>/g;
+module.exports = /<p>(?=(\s*))\1(?:<a [^>]*?>)??(?=(\s*))\2(?:https?:\/\/)??((?:w{3}\.)??(?:youtube\.com|youtu\.be)\/(?:watch\?v=|embed\/|playlist\?list=)??([A-Za-z0-9-_]{11})(?:[^\s<>]*))(?=(\s*))\5(?:<\/a>)??(?=(\s*))\6<\/p>/g;

--- a/packages/youtube/test/_urls.mjs
+++ b/packages/youtube/test/_urls.mjs
@@ -15,6 +15,8 @@ const validUrls_params = [
   'youtube.com/watch?v=hIs5StN8J-0',
   // This isn't actually a valid YouTube url, but accepted by the plugin regex
   'youtu.be/watch?v=hIs5StN8J-0',
+  // Playlist URL
+  'youtube.com/playlist?list=PLv0jwu7G_DFVP0SGNlBiBtFVkV5LZ7SOU',
 ]
 const validUrls_noparams = [
   'youtu.be/hIs5StN8J-0',
@@ -48,6 +50,4 @@ export const invalid = [
   'https://www.youtube.com/watch?v=hIs5St',
   // Invalid protocol
   'ftp://www.youtube.com/watch?v=hIs5StN8J-0',
-  // Playlist URL
-  'https://www.youtube.com/playlist?list=PLv0jwu7G_DFVP0SGNlBiBtFVkV5LZ7SOU',
 ]

--- a/packages/youtube/test/embed.default.playlist.test.js
+++ b/packages/youtube/test/embed.default.playlist.test.js
@@ -1,0 +1,80 @@
+const test = require('ava');
+const merge = require('deepmerge');
+const pattern = require('../lib/pattern.js');
+const embed = require('../lib/embed.js');
+const {defaults} = require('../lib/defaults.js');
+
+/**
+ * Extract matches from the string
+ * @param {string} str 
+ * @returns {Array} An array of matches
+ */
+const extract = (str) => {
+  // You have to reset the lastIndex property of the regex
+  // object before calling exec again, or it returns null
+  pattern.lastIndex = 0;
+  return pattern.exec(str)
+};
+
+/**
+ * Override plugin default settings
+ * @param {object} Object with user-configurable settings
+ * @returns {object}
+ */
+const override = (obj) => merge(defaults, obj);
+
+const testString = '<p>https://www.youtube.com/playlist?list=PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW</p>';
+
+test(`Playlist embed default mode, default settings`, async t => {
+  t.is(await embed(extract(testString), defaults),
+    '<div id="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/videoseries?list=PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>'
+  );
+});
+
+test(`Playlist embed default mode, override allowAttrs`, async t => {
+  t.is(await embed(extract(testString), override({allowAttrs: 'foo'})),
+    '<div id="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/videoseries?list=PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" allow="foo" allowfullscreen></iframe></div>'
+  );
+});
+
+test(`Playlist embed default mode, override allowFullscreen`, async t => {
+  t.is(await embed(extract(testString), override({allowFullscreen: false})),
+    '<div id="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/videoseries?list=PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"></iframe></div>'
+  );
+});
+
+test(`Playlist embed default mode, override allowAutoplay`, async t => {
+  t.is(await embed(extract(testString), override({allowAutoplay: true})),
+    '<div id="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/videoseries?list=PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW&autoplay=1" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>'
+  );
+});
+
+test(`Playlist embed default mode, override embed class`, async t => {
+  t.is(await embed(extract(testString), override({embedClass: 'foo'})),
+    '<div id="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" class="foo" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/videoseries?list=PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>'
+  );
+});
+
+test(`Playlist embed default mode, override lazy loading`, async t => {
+  t.is(await embed(extract(testString), override({lazy: true})),
+    '<div id="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/videoseries?list=PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen loading="lazy"></iframe></div>'
+  );
+});
+
+test(`Playlist embed default mode, override noCookie`, async t => {
+  t.is(await embed(extract(testString), override({noCookie: false})),
+    '<div id="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube.com/embed/videoseries?list=PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>'
+  );
+});
+
+test(`Playlist embed default mode, override modestBranding`, async t => {
+  t.is(await embed(extract(testString), override({modestBranding: true})),
+    '<div id="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/videoseries?list=PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW&modestbranding=1" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>'
+  );
+});
+
+test(`Playlist embed default mode, override recommendSelfOnly`, async t => {
+  t.is(await embed(extract(testString), override({recommendSelfOnly: true})),
+    '<div id="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/videoseries?list=PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW&rel=1" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>'
+  );
+});

--- a/packages/youtube/test/embed.default.test.js
+++ b/packages/youtube/test/embed.default.test.js
@@ -82,7 +82,7 @@ test(`Build embed default mode, override modestBranding`, async t => {
 
 test(`Build embed default mode, override recommendSelfOnly`, async t => {
   t.is(await embed(extract(testString), override({recommendSelfOnly: true})),
-    '<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/hIs5StN8J-0?rel=0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>'
+    '<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/hIs5StN8J-0?rel=1" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>'
   );
 });
 

--- a/packages/youtube/test/embed.lite.playlist.test.js
+++ b/packages/youtube/test/embed.lite.playlist.test.js
@@ -16,7 +16,7 @@ const testString = '<p>https://www.youtube.com/playlist?list=PLCbA9r6ecYWU6SVyvb
 
 /**
  * Extract matches from the string
- * @param {string} str 
+ * @param {string} str
  * @returns {Array} An array of matches
  */
 const extract = (str) => {
@@ -37,84 +37,54 @@ const override = (obj) => merge(defaults, obj);
  * Lite mode, zero index (first instance on page includes script and CSS)
  */
 test(`Build embed lite mode, zero index, lite defaults`, t => {
-  t.is(embed(extract(testString), override({lite: true}), 0),
-  `<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.css">\n<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.js"></script>\n<div id="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" style="background-image: url('https://i.ytimg.com/vi/PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
-  );
+  t.is(embed(extract(testString), override({lite: true}), 0), testString);
 });
 test(`Build embed lite mode, zero index, JS API enabled`, t => {
-  t.is(embed(extract(testString), override({lite: {jsApi: true}}), 0),
-  `<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.css">\n<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.js"></script>\n<div id="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" style="background-image: url('https://i.ytimg.com/vi/PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW/hqdefault.jpg');" js-api><div class="lty-playbtn"></div></lite-youtube></div>`
-  );
+  t.is(embed(extract(testString), override({lite: {jsApi: true}}), 0), testString);
 });
 test(`Build embed lite mode, zero index, valid thumbnail format override`, t => {
-  t.is(embed(extract(testString), override({lite: {thumbnailFormat: 'webp'}}), 0),
-  `<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.css">\n<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.js"></script>\n<div id="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" style="background-image: url('https://i.ytimg.com/vi_webp/PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW/hqdefault.webp');"><div class="lty-playbtn"></div></lite-youtube></div>`
-  );
+  t.is(embed(extract(testString), override({lite: {thumbnailFormat: 'webp'}}), 0), testString);
 });
 test(`Build embed lite mode, zero index, invalid thumbnail format override`, t => {
-  t.is(embed(extract(testString), override({lite: {thumbnailFormat: 'no'}}), 0),
-  `<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.css">\n<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.js"></script>\n<div id="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" style="background-image: url('https://i.ytimg.com/vi/PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
-  );
+  t.is(embed(extract(testString), override({lite: {thumbnailFormat: 'no'}}), 0), testString);
 });
 test(`Build embed lite mode, zero index, valid thumbnail quality override`, t => {
-  t.is(embed(extract(testString), override({lite: { thumbnailQuality: 'maxresdefault'}}), 0),
-  `<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.css">\n<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.js"></script>\n<div id="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" style="background-image: url('https://i.ytimg.com/vi/PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW/maxresdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
-  );
+  t.is(embed(extract(testString), override({lite: { thumbnailQuality: 'maxresdefault'}}), 0), testString);
 });
 test(`Build embed lite mode, zero index, invalid thumbnail quality override`, t => {
-  t.is(embed(extract(testString), override({lite: { thumbnailQuality: 'nope'}}), 0),
-  `<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.css">\n<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.js"></script>\n<div id="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" style="background-image: url('https://i.ytimg.com/vi/PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
-  );
+  t.is(embed(extract(testString), override({lite: { thumbnailQuality: 'nope'}}), 0), testString);
 });
 test(`Build embed lite mode, zero index, lite defaults with URL start time param`, t => {
-  t.is(embed(extract('<p>https://www.youtube.com/watch?v=PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW&t=30s</p>'), override({lite: true}), 0),
-  `<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.css">\n<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.js"></script>\n<div id="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" style="background-image: url('https://i.ytimg.com/vi/PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW/hqdefault.jpg');" params="start=30"><div class="lty-playbtn"></div></lite-youtube></div>`
-  );
+  t.is(embed(extract('<p>https://www.youtube.com/playlist?list=PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW&t=30s</p>'), override({lite: true}), 0),
+	'<p>https://www.youtube.com/playlist?list=PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW&t=30s</p>'
+	);
 });
 test(`Build embed lite mode, zero index, css disabled`, t => {
-  t.is(embed(extract(testString), override({lite:{css:{enabled: false}}}), 0),
-  `<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.js"></script>\n<div id="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" style="background-image: url('https://i.ytimg.com/vi/PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
-  );
+  t.is(embed(extract(testString), override({lite:{css:{enabled: false}}}), 0), testString);
 });
 test(`Build embed lite mode, zero index, css inline`, t => {
-  t.is(embed(extract(testString), override({lite:{css:{inline: true}}}), 0),
-  `<style>${inlineCss}</style>\n<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.js"></script>\n<div id="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" style="background-image: url('https://i.ytimg.com/vi/PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
-  );
+  t.is(embed(extract(testString), override({lite:{css:{inline: true}}}), 0), testString);
 });
 test(`Build embed lite mode, zero index, css path override`, t => {
-  t.is(embed(extract(testString), override({lite:{css:{path: 'foo'}}}), 0),
-  `<link rel="stylesheet" href="foo">\n<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.js"></script>\n<div id="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" style="background-image: url('https://i.ytimg.com/vi/PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
-  );
+  t.is(embed(extract(testString), override({lite:{css:{path: 'foo'}}}), 0), testString);
 });
 test(`Build embed lite mode, zero index, js disabled`, t => {
-  t.is(embed(extract(testString), override({lite:{js:{enabled: false}}}), 0),
-  `<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.css">\n<div id="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" style="background-image: url('https://i.ytimg.com/vi/PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
-  );
+  t.is(embed(extract(testString), override({lite:{js:{enabled: false}}}), 0), testString);
 });
 test(`Build embed lite mode, zero index, js inline`, t => {
-  t.is(embed(extract(testString), override({lite:{js:{inline: true}}}), 0),
-  `<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.css">\n<script>${inlineJs}</script>\n<div id="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" style="background-image: url('https://i.ytimg.com/vi/PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
-  );
+  t.is(embed(extract(testString), override({lite:{js:{inline: true}}}), 0), testString);
 });
 test(`Build embed lite mode, zero index, css AND js disabled`, t => {
-  t.is(embed(extract(testString), override({lite:{css:{enabled:false},js:{enabled:false}}}), 0),
-  `<div id="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" style="background-image: url('https://i.ytimg.com/vi/PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
-  );
+  t.is(embed(extract(testString), override({lite:{css:{enabled:false},js:{enabled:false}}}), 0), testString);
 });
 test(`Build embed lite mode, zero index, css AND js path override`, t => {
-  t.is(embed(extract(testString), override({lite:{css:{path: 'foo'},js:{path: 'foo'}}}), 0),
-  `<link rel="stylesheet" href="foo">\n<script defer="defer" src="foo"></script>\n<div id="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" style="background-image: url('https://i.ytimg.com/vi/PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
-  );
+  t.is(embed(extract(testString), override({lite:{css:{path: 'foo'},js:{path: 'foo'}}}), 0), testString);
 });
 test(`Build embed lite mode, zero index, css AND js inline`, t => {
-  t.is(embed(extract(testString), override({lite:{css:{inline: true},js:{inline: true}}}), 0),
-  `<style>${inlineCss}</style>\n<script>${inlineJs}</script>\n<div id="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" style="background-image: url('https://i.ytimg.com/vi/PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
-  );
+  t.is(embed(extract(testString), override({lite:{css:{inline: true},js:{inline: true}}}), 0), testString);
 });
 test(`Build embed lite mode, zero index, responsive true`, t => {
-  t.is(embed(extract(testString), override({lite: { responsive: true }}), 0),
-  `<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.css">\n<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.js"></script>\n<style>.eleventy-plugin-youtube-embed lite-youtube {max-width:100%}</style>\n<div id="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" style="background-image: url('https://i.ytimg.com/vi/PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
-  );
+  t.is(embed(extract(testString), override({lite: { responsive: true }}), 0), testString);
 });
 
 
@@ -122,69 +92,45 @@ test(`Build embed lite mode, zero index, responsive true`, t => {
  * Lite mode, 1+ index (no style or script on subsequent outputs)
  */
 test(`Build embed lite mode, 1+ index, lite defaults`, t => {
-  t.is(embed(extract(testString), override({lite: true}), 1),
-  `<div id="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" style="background-image: url('https://i.ytimg.com/vi/PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
-  );
+  t.is(embed(extract(testString), override({lite: true}), 1), testString);
 });
 test(`Build embed lite mode, 1+ index, JS API enabled`, t => {
-  t.is(embed(extract(testString), override({lite: {jsApi: true}}), 1),
-  `<div id="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" style="background-image: url('https://i.ytimg.com/vi/PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW/hqdefault.jpg');" js-api><div class="lty-playbtn"></div></lite-youtube></div>`
-  );
+  t.is(embed(extract(testString), override({lite: {jsApi: true}}), 1), testString);
 });
 test(`Build embed lite mode, 1+ index, valid thumbnail quality override`, t => {
-  t.is(embed(extract(testString), override({lite: { thumbnailQuality: 'maxresdefault'}}), 1),
-  `<div id="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" style="background-image: url('https://i.ytimg.com/vi/PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW/maxresdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
-  );
+  t.is(embed(extract(testString), override({lite: { thumbnailQuality: 'maxresdefault'}}), 1), testString);
 });
 test(`Build embed lite mode, 1+ index, invalid thumbnail quality override`, t => {
-  t.is(embed(extract(testString), override({lite: { thumbnailQuality: 'nope'}}), 1),
-  `<div id="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" style="background-image: url('https://i.ytimg.com/vi/PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
-  );
+  t.is(embed(extract(testString), override({lite: { thumbnailQuality: 'nope'}}), 1), testString);
 });
 test(`Build embed lite mode, 1+ index, valid thumbnail format override`, t => {
-  t.is(embed(extract(testString), override({lite: {thumbnailFormat: 'webp'}}), 1),
-  `<div id="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" style="background-image: url('https://i.ytimg.com/vi_webp/PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW/hqdefault.webp');"><div class="lty-playbtn"></div></lite-youtube></div>`
-  );
+  t.is(embed(extract(testString), override({lite: {thumbnailFormat: 'webp'}}), 1), testString);
 });
 test(`Build embed lite mode, 1+ index, invalid thumbnail format override`, t => {
-  t.is(embed(extract(testString), override({lite: {thumbnailFormat: 'foo'}}), 1),
-  `<div id="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" style="background-image: url('https://i.ytimg.com/vi/PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
-  );
+  t.is(embed(extract(testString), override({lite: {thumbnailFormat: 'foo'}}), 1), testString);
 });
 test(`Build embed lite mode, 1+ index, lite defaults with URL start time param`, t => {
-  t.is(embed(extract('<p>https://www.youtube.com/watch?v=PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW&t=30s</p>'), override({lite: true}), 1),
-  `<div id="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" style="background-image: url('https://i.ytimg.com/vi/PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW/hqdefault.jpg');" params="start=30"><div class="lty-playbtn"></div></lite-youtube></div>`
-  );
+  t.is(embed(extract('<p>https://www.youtube.com/playlist?list=PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW&t=30s</p>'), override({lite: true}), 1),
+	'<p>https://www.youtube.com/playlist?list=PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW&t=30s</p>'
+	);
 });
 test(`Build embed lite mode, 1+ index, css disabled`, t => {
-  t.is(embed(extract(testString), override({lite:{css:{enabled: false}}}), 1),
-  `<div id="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" style="background-image: url('https://i.ytimg.com/vi/PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
-  );
+  t.is(embed(extract(testString), override({lite:{css:{enabled: false}}}), 1), testString);
 });
 test(`Build embed lite mode, 1+ index, css inline`, t => {
-  t.is(embed(extract(testString), override({lite:{css:{inline: true}}}), 1),
-  `<div id="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" style="background-image: url('https://i.ytimg.com/vi/PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
-  );
+  t.is(embed(extract(testString), override({lite:{css:{inline: true}}}), 1), testString);
 });
 test(`Build embed lite mode, 1+ index, css path override`, t => {
-  t.is(embed(extract(testString), override({lite:{css:{path: 'foo'}}}), 1),
-  `<div id="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" style="background-image: url('https://i.ytimg.com/vi/PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
-  );
+  t.is(embed(extract(testString), override({lite:{css:{path: 'foo'}}}), 1), testString);
 });
 test(`Build embed lite mode, 1+ index, js disabled`, t => {
-  t.is(embed(extract(testString), override({lite:{js:{enabled: false}}}), 1),
-  `<div id="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" style="background-image: url('https://i.ytimg.com/vi/PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
-  );
+  t.is(embed(extract(testString), override({lite:{js:{enabled: false}}}), 1), testString);
 });
 test(`Build embed lite mode, 1+ index, js inline`, t => {
-  t.is(embed(extract(testString), override({lite:{js:{inline: true}}}), 1),
-  `<div id="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" style="background-image: url('https://i.ytimg.com/vi/PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
-  );
+  t.is(embed(extract(testString), override({lite:{js:{inline: true}}}), 1), testString);
 });
 test(`Build embed lite mode, 1+ index, responsive true`, t => {
-  t.is(embed(extract(testString), override({lite: { responsive: true }}), 1),
-  `<div id="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" style="background-image: url('https://i.ytimg.com/vi/PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
-  );
+  t.is(embed(extract(testString), override({lite: { responsive: true }}), 1), testString);
 });
 
 /**

--- a/packages/youtube/test/embed.lite.playlist.test.js
+++ b/packages/youtube/test/embed.lite.playlist.test.js
@@ -182,7 +182,7 @@ test(`Build embed lite mode, 1+ index, js inline`, t => {
   );
 });
 test(`Build embed lite mode, 1+ index, responsive true`, t => {
-  t.is(embed(extract(testString), override({lite: { responive: true }}), 1),
+  t.is(embed(extract(testString), override({lite: { responsive: true }}), 1),
   `<div id="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" style="background-image: url('https://i.ytimg.com/vi/PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
   );
 });

--- a/packages/youtube/test/embed.lite.playlist.test.js
+++ b/packages/youtube/test/embed.lite.playlist.test.js
@@ -1,0 +1,224 @@
+const test = require('ava');
+const merge = require('deepmerge');
+const pattern = require('../lib/pattern.js');
+const embed = require('../lib/embed.js');
+const {defaults} = require('../lib/defaults.js');
+const { validateThumbnailSize, validateThumbnailFormat } = require('../lib/embed.js');
+
+const fs = require('fs');
+const path = require('path');
+const liteCssFilePath = path.resolve(__dirname, '../node_modules/lite-youtube-embed/src/lite-yt-embed.css');
+const liteJsFilePath = path.resolve(__dirname, '../node_modules/lite-youtube-embed/src/lite-yt-embed.js');
+const inlineCss = fs.readFileSync(liteCssFilePath, 'utf-8');
+const inlineJs = fs.readFileSync(liteJsFilePath, 'utf-8');
+
+const testString = '<p>https://www.youtube.com/playlist?list=PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW</p>';
+
+/**
+ * Extract matches from the string
+ * @param {string} str 
+ * @returns {Array} An array of matches
+ */
+const extract = (str) => {
+  // You have to reset the lastIndex property of the regex
+  // object before calling exec again, or it returns null
+  pattern.lastIndex = 0;
+  return pattern.exec(str)
+};
+
+/**
+ * Override plugin default settings
+ * @param {object} Object with user-configurable settings
+ * @returns {object}
+ */
+const override = (obj) => merge(defaults, obj);
+
+/**
+ * Lite mode, zero index (first instance on page includes script and CSS)
+ */
+test(`Build embed lite mode, zero index, lite defaults`, t => {
+  t.is(embed(extract(testString), override({lite: true}), 0),
+  `<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.css">\n<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.js"></script>\n<div id="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" style="background-image: url('https://i.ytimg.com/vi/PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+  );
+});
+test(`Build embed lite mode, zero index, JS API enabled`, t => {
+  t.is(embed(extract(testString), override({lite: {jsApi: true}}), 0),
+  `<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.css">\n<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.js"></script>\n<div id="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" style="background-image: url('https://i.ytimg.com/vi/PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW/hqdefault.jpg');" js-api><div class="lty-playbtn"></div></lite-youtube></div>`
+  );
+});
+test(`Build embed lite mode, zero index, valid thumbnail format override`, t => {
+  t.is(embed(extract(testString), override({lite: {thumbnailFormat: 'webp'}}), 0),
+  `<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.css">\n<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.js"></script>\n<div id="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" style="background-image: url('https://i.ytimg.com/vi_webp/PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW/hqdefault.webp');"><div class="lty-playbtn"></div></lite-youtube></div>`
+  );
+});
+test(`Build embed lite mode, zero index, invalid thumbnail format override`, t => {
+  t.is(embed(extract(testString), override({lite: {thumbnailFormat: 'no'}}), 0),
+  `<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.css">\n<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.js"></script>\n<div id="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" style="background-image: url('https://i.ytimg.com/vi/PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+  );
+});
+test(`Build embed lite mode, zero index, valid thumbnail quality override`, t => {
+  t.is(embed(extract(testString), override({lite: { thumbnailQuality: 'maxresdefault'}}), 0),
+  `<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.css">\n<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.js"></script>\n<div id="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" style="background-image: url('https://i.ytimg.com/vi/PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW/maxresdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+  );
+});
+test(`Build embed lite mode, zero index, invalid thumbnail quality override`, t => {
+  t.is(embed(extract(testString), override({lite: { thumbnailQuality: 'nope'}}), 0),
+  `<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.css">\n<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.js"></script>\n<div id="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" style="background-image: url('https://i.ytimg.com/vi/PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+  );
+});
+test(`Build embed lite mode, zero index, lite defaults with URL start time param`, t => {
+  t.is(embed(extract('<p>https://www.youtube.com/watch?v=PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW&t=30s</p>'), override({lite: true}), 0),
+  `<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.css">\n<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.js"></script>\n<div id="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" style="background-image: url('https://i.ytimg.com/vi/PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW/hqdefault.jpg');" params="start=30"><div class="lty-playbtn"></div></lite-youtube></div>`
+  );
+});
+test(`Build embed lite mode, zero index, css disabled`, t => {
+  t.is(embed(extract(testString), override({lite:{css:{enabled: false}}}), 0),
+  `<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.js"></script>\n<div id="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" style="background-image: url('https://i.ytimg.com/vi/PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+  );
+});
+test(`Build embed lite mode, zero index, css inline`, t => {
+  t.is(embed(extract(testString), override({lite:{css:{inline: true}}}), 0),
+  `<style>${inlineCss}</style>\n<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.js"></script>\n<div id="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" style="background-image: url('https://i.ytimg.com/vi/PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+  );
+});
+test(`Build embed lite mode, zero index, css path override`, t => {
+  t.is(embed(extract(testString), override({lite:{css:{path: 'foo'}}}), 0),
+  `<link rel="stylesheet" href="foo">\n<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.js"></script>\n<div id="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" style="background-image: url('https://i.ytimg.com/vi/PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+  );
+});
+test(`Build embed lite mode, zero index, js disabled`, t => {
+  t.is(embed(extract(testString), override({lite:{js:{enabled: false}}}), 0),
+  `<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.css">\n<div id="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" style="background-image: url('https://i.ytimg.com/vi/PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+  );
+});
+test(`Build embed lite mode, zero index, js inline`, t => {
+  t.is(embed(extract(testString), override({lite:{js:{inline: true}}}), 0),
+  `<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.css">\n<script>${inlineJs}</script>\n<div id="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" style="background-image: url('https://i.ytimg.com/vi/PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+  );
+});
+test(`Build embed lite mode, zero index, css AND js disabled`, t => {
+  t.is(embed(extract(testString), override({lite:{css:{enabled:false},js:{enabled:false}}}), 0),
+  `<div id="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" style="background-image: url('https://i.ytimg.com/vi/PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+  );
+});
+test(`Build embed lite mode, zero index, css AND js path override`, t => {
+  t.is(embed(extract(testString), override({lite:{css:{path: 'foo'},js:{path: 'foo'}}}), 0),
+  `<link rel="stylesheet" href="foo">\n<script defer="defer" src="foo"></script>\n<div id="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" style="background-image: url('https://i.ytimg.com/vi/PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+  );
+});
+test(`Build embed lite mode, zero index, css AND js inline`, t => {
+  t.is(embed(extract(testString), override({lite:{css:{inline: true},js:{inline: true}}}), 0),
+  `<style>${inlineCss}</style>\n<script>${inlineJs}</script>\n<div id="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" style="background-image: url('https://i.ytimg.com/vi/PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+  );
+});
+test(`Build embed lite mode, zero index, responsive true`, t => {
+  t.is(embed(extract(testString), override({lite: { responsive: true }}), 0),
+  `<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.css">\n<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.js"></script>\n<style>.eleventy-plugin-youtube-embed lite-youtube {max-width:100%}</style>\n<div id="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" style="background-image: url('https://i.ytimg.com/vi/PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+  );
+});
+
+
+/**
+ * Lite mode, 1+ index (no style or script on subsequent outputs)
+ */
+test(`Build embed lite mode, 1+ index, lite defaults`, t => {
+  t.is(embed(extract(testString), override({lite: true}), 1),
+  `<div id="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" style="background-image: url('https://i.ytimg.com/vi/PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+  );
+});
+test(`Build embed lite mode, 1+ index, JS API enabled`, t => {
+  t.is(embed(extract(testString), override({lite: {jsApi: true}}), 1),
+  `<div id="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" style="background-image: url('https://i.ytimg.com/vi/PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW/hqdefault.jpg');" js-api><div class="lty-playbtn"></div></lite-youtube></div>`
+  );
+});
+test(`Build embed lite mode, 1+ index, valid thumbnail quality override`, t => {
+  t.is(embed(extract(testString), override({lite: { thumbnailQuality: 'maxresdefault'}}), 1),
+  `<div id="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" style="background-image: url('https://i.ytimg.com/vi/PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW/maxresdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+  );
+});
+test(`Build embed lite mode, 1+ index, invalid thumbnail quality override`, t => {
+  t.is(embed(extract(testString), override({lite: { thumbnailQuality: 'nope'}}), 1),
+  `<div id="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" style="background-image: url('https://i.ytimg.com/vi/PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+  );
+});
+test(`Build embed lite mode, 1+ index, valid thumbnail format override`, t => {
+  t.is(embed(extract(testString), override({lite: {thumbnailFormat: 'webp'}}), 1),
+  `<div id="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" style="background-image: url('https://i.ytimg.com/vi_webp/PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW/hqdefault.webp');"><div class="lty-playbtn"></div></lite-youtube></div>`
+  );
+});
+test(`Build embed lite mode, 1+ index, invalid thumbnail format override`, t => {
+  t.is(embed(extract(testString), override({lite: {thumbnailFormat: 'foo'}}), 1),
+  `<div id="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" style="background-image: url('https://i.ytimg.com/vi/PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+  );
+});
+test(`Build embed lite mode, 1+ index, lite defaults with URL start time param`, t => {
+  t.is(embed(extract('<p>https://www.youtube.com/watch?v=PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW&t=30s</p>'), override({lite: true}), 1),
+  `<div id="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" style="background-image: url('https://i.ytimg.com/vi/PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW/hqdefault.jpg');" params="start=30"><div class="lty-playbtn"></div></lite-youtube></div>`
+  );
+});
+test(`Build embed lite mode, 1+ index, css disabled`, t => {
+  t.is(embed(extract(testString), override({lite:{css:{enabled: false}}}), 1),
+  `<div id="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" style="background-image: url('https://i.ytimg.com/vi/PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+  );
+});
+test(`Build embed lite mode, 1+ index, css inline`, t => {
+  t.is(embed(extract(testString), override({lite:{css:{inline: true}}}), 1),
+  `<div id="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" style="background-image: url('https://i.ytimg.com/vi/PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+  );
+});
+test(`Build embed lite mode, 1+ index, css path override`, t => {
+  t.is(embed(extract(testString), override({lite:{css:{path: 'foo'}}}), 1),
+  `<div id="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" style="background-image: url('https://i.ytimg.com/vi/PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+  );
+});
+test(`Build embed lite mode, 1+ index, js disabled`, t => {
+  t.is(embed(extract(testString), override({lite:{js:{enabled: false}}}), 1),
+  `<div id="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" style="background-image: url('https://i.ytimg.com/vi/PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+  );
+});
+test(`Build embed lite mode, 1+ index, js inline`, t => {
+  t.is(embed(extract(testString), override({lite:{js:{inline: true}}}), 1),
+  `<div id="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" style="background-image: url('https://i.ytimg.com/vi/PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+  );
+});
+test(`Build embed lite mode, 1+ index, responsive true`, t => {
+  t.is(embed(extract(testString), override({lite: { responive: true }}), 1),
+  `<div id="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" style="background-image: url('https://i.ytimg.com/vi/PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+  );
+});
+
+/**
+ * In lite mode, test that the thumbnail validators return the expected values.
+*/
+test(`Thumbnail size validator returns default value in response to empty parameter`, t => {
+  t.is(validateThumbnailSize(), 'hqdefault');
+});
+test(`Thumbnail size validator returns default value in response to incorrect parameter types`, t => {
+  t.is(validateThumbnailSize(1), 'hqdefault');
+  t.is(validateThumbnailSize(true), 'hqdefault');
+});
+test(`Thumbnail size validator returns default value in response to invalid string`, t => {
+  t.is(validateThumbnailSize('foo'), 'hqdefault');
+});
+test(`Thumbnail size validator returns expected strings when passed expected strings`, t => {
+  t.is(validateThumbnailSize('default'), 'default');
+  t.is(validateThumbnailSize('hqdefault'), 'hqdefault');
+  t.is(validateThumbnailSize('mqdefault'), 'mqdefault');
+  t.is(validateThumbnailSize('sddefault'), 'sddefault');
+  t.is(validateThumbnailSize('maxresdefault'), 'maxresdefault');
+});
+
+test(`Thumbnail format validator returns default value in response to empty parameter`, t => {
+  t.is(validateThumbnailFormat(), 'jpg');
+})
+test(`Thumbnail format validator returns default value in response to incorrect parameter types`, t => {
+  t.is(validateThumbnailFormat(1), 'jpg');
+  t.is(validateThumbnailFormat(true), 'jpg');
+});
+test(`Thumbnail format validator returns default value in response to invalid string`, t => {
+  t.is(validateThumbnailFormat('avif'), 'jpg');
+});
+test(`Thumbnail format validator returns expected strings when passed expected strings`, t => {
+  t.is(validateThumbnailFormat('jpg'), 'jpg');
+  t.is(validateThumbnailFormat('webp'), 'webp');
+});


### PR DESCRIPTION
Closes #149 

At long last, this PR adds support for YouTube playlists. There are two use cases:

## Standalone playlists

These are YouTube playlist URLs that **don't** specify an individual video ID:
`https://www.youtube.com/playlist?list=PLFtSvldL7Mh4ismj4BgH33pBR9hbtBkxz`

For standalone playlists, the plugin embeds the player and starts playing from the first video in the list.

⚠️ In lite mode, the plugin simply returns the original URL. Playlists aren't supported by the `lite-youtube-embed` package.

## Videos with associated playlists

These are YouTube URLs that include **both** a video ID _and_ a playlist ID:
`https://www.youtube.com/watch?v=C04JZsoqs1A&list=PLFtSvldL7Mh4ismj4BgH33pBR9hbtBkxz`

For this type of URL, the plugin embeds the player and starts playing from the specified video, wherever it is in the playlist numbering. 

ℹ️ In lite mode, only the individual video will be embedded. Playlists aren't supported by the `lite-youtube-embed` package.