### PR TITLE
Deduplicate active plugin list when using 'add' option

### DIFF
--- a/.changeset/green-cameras-invent.md
+++ b/.changeset/green-cameras-invent.md
@@ -1,0 +1,5 @@
+---
+"eleventy-plugin-embed-everything": patch
+---
+
+Deduplicate list of active plugins when using the 'add' option

--- a/packages/everything/lib/configOptions.js
+++ b/packages/everything/lib/configOptions.js
@@ -21,8 +21,9 @@ module.exports = function(options = {}) {
 function setActivePlugins(obj) {
 	let active = [...defaultPlugins]; // default
 	// Add to default plugin list
+	// The `Set` ensures there are no duplicates
 	if (obj.add) {
-		active = [...defaultPlugins, ...obj.add];
+		active = [...new Set([...defaultPlugins, ...obj.add])];
 	}
 	// Define custom plugin list from scratch.
 	// Will always override `add`

--- a/packages/everything/test/test-configOptions.js
+++ b/packages/everything/test/test-configOptions.js
@@ -71,6 +71,17 @@ test(
 );
 
 test(
+	`Config "add" option returns deduplicated output when adding plugins already included by default`,
+	(t) => {
+		let output = config({
+			// These are already active by default, so `add`ing should do nothing
+			add: ["youtube", "vimeo"],
+		});
+		t.deepEqual(output, defaultOptions);
+	},
+)
+
+test(
 	`Config returns expected output with valid "use" option`,
 	(t) => {
 		let output = config({


### PR DESCRIPTION
I spotted someone in the wild with a config object like this:

```js
eleventyConfig.addPlugin(embedEverything, {
  add: ['twitter', 'soundcloud', 'youtube']
});
```

The original intent behind the `add` option was to make it easier to activate _non-default_ plugins (of which there's currently only one, `soundcloud`). I tried it out and discovered that this usage results in `twitter` and `youtube` showing up twice in the active plugin list. The effect probably isn't noticeable to the end user but this PR ensures that the list of active plugins is always deduplicated.