### PR TITLE
Fix missing mastodon dependency

### DIFF
--- a/packages/everything/package.json
+++ b/packages/everything/package.json
@@ -18,7 +18,9 @@
     "embeds",
     "embedding",
     "instagram",
+    "mastodon",
     "media",
+    "openstreetmap",
     "soundcloud",
     "spotify",
     "tiktok",
@@ -31,6 +33,7 @@
   "dependencies": {
     "deepmerge": "^4.3.1",
     "eleventy-plugin-embed-instagram": "workspace:^",
+    "eleventy-plugin-embed-mastodon": "workspace:^",
     "eleventy-plugin-embed-openstreetmap": "workspace:^",
     "eleventy-plugin-embed-soundcloud": "workspace:^",
     "eleventy-plugin-embed-spotify": "workspace:^",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,13 +17,13 @@ importers:
         version: 1.2.0
       '@vitest/coverage-istanbul':
         specifier: ^3.0.5
-        version: 3.0.5(vitest@3.0.5(@types/node@22.13.4)(msw@2.7.0(@types/node@22.13.4)))
+        version: 3.0.5(vitest@3.0.5(@types/node@12.20.55)(msw@2.7.0(@types/node@12.20.55)))
       ava:
         specifier: ^6.2.0
         version: 6.2.0(rollup@4.34.7)
       msw:
         specifier: ^2.7.0
-        version: 2.7.0(@types/node@22.13.4)
+        version: 2.7.0(@types/node@12.20.55)
       nyc:
         specifier: ^17.1.0
         version: 17.1.0
@@ -35,7 +35,7 @@ importers:
         version: 2.4.2
       vitest:
         specifier: ^3.0.5
-        version: 3.0.5(@types/node@22.13.4)(msw@2.7.0(@types/node@22.13.4))
+        version: 3.0.5(@types/node@12.20.55)(msw@2.7.0(@types/node@12.20.55))
 
   demo:
     devDependencies:
@@ -57,6 +57,9 @@ importers:
       eleventy-plugin-embed-instagram:
         specifier: workspace:^
         version: link:../instagram
+      eleventy-plugin-embed-mastodon:
+        specifier: workspace:^
+        version: link:../mastodon
       eleventy-plugin-embed-openstreetmap:
         specifier: workspace:^
         version: link:../openstreetmap
@@ -716,9 +719,6 @@ packages:
 
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
-
-  '@types/node@22.13.4':
-    resolution: {integrity: sha512-ywP2X0DYtX3y08eFVx5fNIw7/uIv8hYUKgXoK8oayJlLnKcRfEYCxWMVE1XagUdVtCJlZT1AU4LXEABW+L1Peg==}
 
   '@types/statuses@2.0.5':
     resolution: {integrity: sha512-jmIUGWrAiwu3dZpxntxieC+1n/5c3mjrImkmOSQ2NC5uP6cYO4aAZDdSmRcI5C1oiTmqlZGHC+/NmJrKogbP5A==}
@@ -2485,9 +2485,6 @@ packages:
   uc.micro@2.1.0:
     resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
 
-  undici-types@6.20.0:
-    resolution: {integrity: sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==}
-
   unicorn-magic@0.3.0:
     resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
     engines: {node: '>=18'}
@@ -3150,17 +3147,17 @@ snapshots:
   '@esbuild/win32-x64@0.24.2':
     optional: true
 
-  '@inquirer/confirm@5.1.6(@types/node@22.13.4)':
+  '@inquirer/confirm@5.1.6(@types/node@12.20.55)':
     dependencies:
-      '@inquirer/core': 10.1.7(@types/node@22.13.4)
-      '@inquirer/type': 3.0.4(@types/node@22.13.4)
+      '@inquirer/core': 10.1.7(@types/node@12.20.55)
+      '@inquirer/type': 3.0.4(@types/node@12.20.55)
     optionalDependencies:
-      '@types/node': 22.13.4
+      '@types/node': 12.20.55
 
-  '@inquirer/core@10.1.7(@types/node@22.13.4)':
+  '@inquirer/core@10.1.7(@types/node@12.20.55)':
     dependencies:
       '@inquirer/figures': 1.0.10
-      '@inquirer/type': 3.0.4(@types/node@22.13.4)
+      '@inquirer/type': 3.0.4(@types/node@12.20.55)
       ansi-escapes: 4.3.2
       cli-width: 4.1.0
       mute-stream: 2.0.0
@@ -3168,13 +3165,13 @@ snapshots:
       wrap-ansi: 6.2.0
       yoctocolors-cjs: 2.1.2
     optionalDependencies:
-      '@types/node': 22.13.4
+      '@types/node': 12.20.55
 
   '@inquirer/figures@1.0.10': {}
 
-  '@inquirer/type@3.0.4(@types/node@22.13.4)':
+  '@inquirer/type@3.0.4(@types/node@12.20.55)':
     optionalDependencies:
-      '@types/node': 22.13.4
+      '@types/node': 12.20.55
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -3367,11 +3364,6 @@ snapshots:
 
   '@types/node@12.20.55': {}
 
-  '@types/node@22.13.4':
-    dependencies:
-      undici-types: 6.20.0
-    optional: true
-
   '@types/statuses@2.0.5': {}
 
   '@types/tough-cookie@4.0.5': {}
@@ -3395,7 +3387,7 @@ snapshots:
       - rollup
       - supports-color
 
-  '@vitest/coverage-istanbul@3.0.5(vitest@3.0.5(@types/node@22.13.4)(msw@2.7.0(@types/node@22.13.4)))':
+  '@vitest/coverage-istanbul@3.0.5(vitest@3.0.5(@types/node@12.20.55)(msw@2.7.0(@types/node@12.20.55)))':
     dependencies:
       '@istanbuljs/schema': 0.1.3
       debug: 4.4.0
@@ -3407,7 +3399,7 @@ snapshots:
       magicast: 0.3.5
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.0.5(@types/node@22.13.4)(msw@2.7.0(@types/node@22.13.4))
+      vitest: 3.0.5(@types/node@12.20.55)(msw@2.7.0(@types/node@12.20.55))
     transitivePeerDependencies:
       - supports-color
 
@@ -3418,14 +3410,14 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.0.5(msw@2.7.0(@types/node@22.13.4))(vite@6.1.0(@types/node@22.13.4))':
+  '@vitest/mocker@3.0.5(msw@2.7.0(@types/node@12.20.55))(vite@6.1.0(@types/node@12.20.55))':
     dependencies:
       '@vitest/spy': 3.0.5
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      msw: 2.7.0(@types/node@22.13.4)
-      vite: 6.1.0(@types/node@22.13.4)
+      msw: 2.7.0(@types/node@12.20.55)
+      vite: 6.1.0(@types/node@12.20.55)
 
   '@vitest/pretty-format@3.0.5':
     dependencies:
@@ -4474,12 +4466,12 @@ snapshots:
 
   ms@2.1.3: {}
 
-  msw@2.7.0(@types/node@22.13.4):
+  msw@2.7.0(@types/node@12.20.55):
     dependencies:
       '@bundled-es-modules/cookie': 2.0.1
       '@bundled-es-modules/statuses': 1.0.1
       '@bundled-es-modules/tough-cookie': 0.1.6
-      '@inquirer/confirm': 5.1.6(@types/node@22.13.4)
+      '@inquirer/confirm': 5.1.6(@types/node@12.20.55)
       '@mswjs/interceptors': 0.37.6
       '@open-draft/deferred-promise': 2.2.0
       '@open-draft/until': 2.1.0
@@ -5071,9 +5063,6 @@ snapshots:
 
   uc.micro@2.1.0: {}
 
-  undici-types@6.20.0:
-    optional: true
-
   unicorn-magic@0.3.0: {}
 
   universalify@0.1.2: {}
@@ -5097,13 +5086,13 @@ snapshots:
 
   uuid@8.3.2: {}
 
-  vite-node@3.0.5(@types/node@22.13.4):
+  vite-node@3.0.5(@types/node@12.20.55):
     dependencies:
       cac: 6.7.14
       debug: 4.4.0
       es-module-lexer: 1.6.0
       pathe: 2.0.3
-      vite: 6.1.0(@types/node@22.13.4)
+      vite: 6.1.0(@types/node@12.20.55)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -5118,19 +5107,19 @@ snapshots:
       - tsx
       - yaml
 
-  vite@6.1.0(@types/node@22.13.4):
+  vite@6.1.0(@types/node@12.20.55):
     dependencies:
       esbuild: 0.24.2
       postcss: 8.5.2
       rollup: 4.34.7
     optionalDependencies:
-      '@types/node': 22.13.4
+      '@types/node': 12.20.55
       fsevents: 2.3.3
 
-  vitest@3.0.5(@types/node@22.13.4)(msw@2.7.0(@types/node@22.13.4)):
+  vitest@3.0.5(@types/node@12.20.55)(msw@2.7.0(@types/node@12.20.55)):
     dependencies:
       '@vitest/expect': 3.0.5
-      '@vitest/mocker': 3.0.5(msw@2.7.0(@types/node@22.13.4))(vite@6.1.0(@types/node@22.13.4))
+      '@vitest/mocker': 3.0.5(msw@2.7.0(@types/node@12.20.55))(vite@6.1.0(@types/node@12.20.55))
       '@vitest/pretty-format': 3.0.5
       '@vitest/runner': 3.0.5
       '@vitest/snapshot': 3.0.5
@@ -5146,11 +5135,11 @@ snapshots:
       tinyexec: 0.3.2
       tinypool: 1.0.2
       tinyrainbow: 2.0.0
-      vite: 6.1.0(@types/node@22.13.4)
-      vite-node: 3.0.5(@types/node@22.13.4)
+      vite: 6.1.0(@types/node@12.20.55)
+      vite-node: 3.0.5(@types/node@12.20.55)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 22.13.4
+      '@types/node': 12.20.55
     transitivePeerDependencies:
       - jiti
       - less


### PR DESCRIPTION
Mastodon was missing from the Everything package dependency list so while it worked locally, it wouldn't install properly. No changeset, this is just fixing something already covered by existing entries.