### PR TITLE
Add `includeMarker` option for OpenStreetMap

### DIFF
--- a/.changeset/tidy-webs-punch.md
+++ b/.changeset/tidy-webs-punch.md
@@ -1,0 +1,6 @@
+---
+"eleventy-plugin-embed-openstreetmap": minor
+"eleventy-plugin-embed-everything": patch
+---
+
+Add `includeMarker` option in OpenStreetMap

--- a/packages/openstreetmap/README.md
+++ b/packages/openstreetmap/README.md
@@ -66,6 +66,7 @@ The plugin’s default settings reside in [lib/defaults.js](lib/defaults.js). Al
 Option | Type | Default | Notes
 ---|---|---|---
 `embedClass` | String | `"eleventy-plugin-embed-openstreetmap"` | CSS class applied to the container `<div>` that wraps the embedded map.
+`includeMarker` | Boolean | `false` | Whether to include a map marker in the embedded map.
 `layer` | String | `mapnik` | Selected [tile layer](https://wiki.openstreetmap.org/wiki/Featured_tile_layers) style applied to the map.
 `wrapperStyle` | String | `aspect-ratio: 16/9` | Inline CSS `style` parameter applied to the container `div`.
 

--- a/packages/openstreetmap/lib/defaults.js
+++ b/packages/openstreetmap/lib/defaults.js
@@ -1,5 +1,6 @@
 module.exports = {
   embedClass: "eleventy-plugin-embed-openstreetmap",
+	includeMarker: false,
   layer: "mapnik",
-  wrapperStyle: "aspect-ratio: 16/9"
+  wrapperStyle: "aspect-ratio: 16/9",
 }

--- a/packages/openstreetmap/lib/replace.js
+++ b/packages/openstreetmap/lib/replace.js
@@ -4,15 +4,19 @@ const merge = require('deepmerge');
 module.exports = function(match, options = {}) {
 
   const config = merge(defaults, options);
-  
+
   const {long, lat, zoom} = match.pop();
   const {long_s, lat_e, long_e, lat_s} = getBoundingBox(long, lat, zoom, 425, 350);
   const bbox = encodeURIComponent(`${long_s},${lat_e},${long_e},${lat_s}`);
-  
+
+	// `marker` parameter isn't active by default in the embed code provided by OSM.
+	// https://wiki.openstreetmap.org/wiki/Export#Embeddable_HTML_with_an_added_Marker
+	const marker = options.includeMarker ? '&marker=' + encodeURIComponent(`${lat},${long}`) : '';
+
   let out = `<div class="${config.embedClass}" style="${config.wrapperStyle}">`;
-  out += `<iframe width="100%" height="100%" frameborder="0" src="https://www.openstreetmap.org/export/embed.html?bbox=${bbox}&layer=${config.layer}"></iframe>`;
+  out += `<iframe width="100%" height="100%" frameborder="0" src="https://www.openstreetmap.org/export/embed.html?bbox=${bbox}&layer=${config.layer}${marker}"></iframe>`;
   out += `</div>`;
-  
+
   return out;
 }
 
@@ -46,9 +50,9 @@ function getTileNumber(long, lat, zoom) {
   return [xtile, ytile];
 }
 
-function getBoundingBox(long, lat, zoom, width, height) {  
+function getBoundingBox(long, lat, zoom, width, height) {
   const [xtile, ytile] = getTileNumber(parseFloat(long), parseFloat(lat), zoom);
-  
+
   const tileSize = 256;
 
 	const xtile_s = (xtile * tileSize - width) / tileSize;
@@ -58,7 +62,7 @@ function getBoundingBox(long, lat, zoom, width, height) {
 
 	const [long_s, lat_s] = getLongLat(xtile_s, ytile_s, zoom);
 	const [long_e, lat_e] = getLongLat(xtile_e, ytile_e, zoom);
-  
+
   return {
     long_s,
     lat_e,

--- a/packages/openstreetmap/test/pattern.test.mjs
+++ b/packages/openstreetmap/test/pattern.test.mjs
@@ -7,7 +7,8 @@ const prefixes = ['', '//', 'www.', '//www.', 'https://', 'http://', 'https://ww
 const suffixes = [
   '/#map=8/46.195/-81.362',
   '/way/1147323572#map=8/46.195/-81.362',
-  '/search?whereami=1&query=52.147%2C104.106#map=8/46.195/-81.362'
+  '/search?whereami=1&query=52.147%2C104.106#map=8/46.195/-81.362',
+  '/?mlat=46.195&mlon=-81.362#map=8/46.195/-81.362'
 ];
 // Use set to remove duplicates; slice to remove URLs without paths
 const validUrls = new Set(permuteArrays(base, prefixes, suffixes).slice(prefixes.length))

--- a/packages/openstreetmap/test/replace.test.mjs
+++ b/packages/openstreetmap/test/replace.test.mjs
@@ -4,7 +4,7 @@ import replace from '../lib/replace.js';
 import { getBoundingBox } from '../lib/replace.js';
 
 test('Custom bounding box calculation is within acceptable variance from OSM', t => {
-  
+
   // These are values produced by the OSM embed service
   const expected = {
     long_s: -7.451734542846681,
@@ -12,7 +12,7 @@ test('Custom bounding box calculation is within acceptable variance from OSM', t
     long_e: -7.426950931549073,
     lat_s: 62.117492893935236,
   }
-  
+
   const str = '<p>https://www.openstreetmap.org/#map=16/62.1103/-7.4393</p>';
   const { groups: { zoom, lat, long } } = pattern.exec(str);
 
@@ -22,14 +22,14 @@ test('Custom bounding box calculation is within acceptable variance from OSM', t
   // Even with these bounding box size values, you can set the iframe width
   // and height to 100% and the map still looks OK.
   const {long_s, lat_e, long_e, lat_s} = getBoundingBox(long, lat, zoom, 425, 350);
-  
+
   // The values produced by our calculations and OSM's are close, but not
-  // _exactly_ the same. In practice this isn't an issue as long as the 
+  // _exactly_ the same. In practice this isn't an issue as long as the
   // difference is small enough. This is kind of a magic number.
   // TODO: See if we can align more closely how OSM calculates its bounding boxes?
   // https://github.com/openstreetmap/openstreetmap-website/blob/master/lib/bounding_box.rb
   const acceptableDrift = 0.01;
-  
+
   t.is(Math.abs(long_s - expected.long_s) < acceptableDrift, true);
   t.is(Math.abs(lat_e - expected.lat_e) < acceptableDrift, true);
   t.is(Math.abs(long_e - expected.long_e) < acceptableDrift, true);
@@ -62,5 +62,12 @@ test('Input produces expected output with custom map layer', t => {
   const input = '<p>https://www.openstreetmap.org/#map=11/47.9012/106.8911</p>';
   const output = input.replace(pattern, (...match) => replace(match, {layer: 'cycle'}));
   const expected = '<div class="eleventy-plugin-embed-openstreetmap" style="aspect-ratio: 16/9"><iframe width="100%" height="100%" frameborder="0" src="https://www.openstreetmap.org/export/embed.html?bbox=106.59927565917968%2C47.73983206904563%2C107.1829243408203%2C48.06206649357146&layer=cycle"></iframe></div>';
+  t.is(output, expected);
+});
+
+test('Input produces expected output with marker option active', t => {
+  const input = '<p>https://www.openstreetmap.org/#map=11/47.9012/106.8911</p>';
+  const output = input.replace(pattern, (...match) => replace(match, {includeMarker: true}));
+  const expected = '<div class="eleventy-plugin-embed-openstreetmap" style="aspect-ratio: 16/9"><iframe width="100%" height="100%" frameborder="0" src="https://www.openstreetmap.org/export/embed.html?bbox=106.59927565917968%2C47.73983206904563%2C107.1829243408203%2C48.06206649357146&layer=mapnik&marker=47.9012%2C106.8911"></iframe></div>';
   t.is(output, expected);
 });


### PR DESCRIPTION
Closes #313 

This PR adds a new `includeMarker` option to the OpenStreetMap plugin, which allows you to opt in to displaying a map marker in your embeds. It's off by default because that's how OSM does it; when manually copying the embed code from OSM, you need to check the **Include marker** box in order to get it to show up. So I'm keeping the equivalent opt-in behavior here.