### PR TITLE
Enable option to download video title in Lite mode

### DIFF
--- a/.changeset/breezy-rings-leave.md
+++ b/.changeset/breezy-rings-leave.md
@@ -1,0 +1,6 @@
+---
+"eleventy-plugin-youtube-embed": minor
+"eleventy-plugin-embed-everything": patch
+---
+
+Add option to display a video title in Lite mode

--- a/packages/youtube/README.md
+++ b/packages/youtube/README.md
@@ -142,16 +142,16 @@ The plugin’s default settings reside in [lib/defaults.js](lib/defaults.js). Al
       <td>Setting this to <code>true</code> will add a <code>rel=0</code> attribute to the embed url. This will tell YouTube to <a href="https://developers.google.com/youtube/player_parameters#rel">recommend videos from the same channel.</a></td>
     </tr>
     <tr>
-      <td><code>title</code><br>✨ <b>New in v1.10.0!</b></td>
+      <td><code>title</code></td>
       <td>String</td>
       <td><code>Embedded YouTube video</code></td>
       <td>Edit this value to change the default <code>title</code> attribute for the embedded iframe.</td>
     </tr>
     <tr>
-      <td colspan="4"><code>titleOptions</code>✨ <b>New in v1.10.0!</b></td>
+      <td colspan="4"><code>titleOptions</code></td>
     </tr>
     <tr>
-      <td><code>titleOptions.download</code></td>
+      <td><code>titleOptions.download</code><br>✨ <b>Works in Lite mode <a href="#showing-titles-in-lite-mode">as of v1.13.0</a>!</b></td>
       <td>Boolean</td>
       <td><code>false</code></td>
       <td>Setting this to true will download and cache the title of the video from YouTube, then override the default value of <code>title</code>. <b>Note:</b> Turning this feature on will cause a network call to YouTube’s servers.</td>
@@ -180,7 +180,7 @@ In addition, using the Lite version will cause several of the plugin’s setting
 - `allowFullscreen`
 - `lazy`
 - `noCookie`
-- `title` and `titleOptions`
+- `title` (but [`titleOptions.download` works](#showing-titles-in-lite-mode))
 
 #### Lite embed options
 
@@ -191,6 +191,23 @@ eleventyConfig.addPlugin(embedYouTube, {
   lite: true
 });
 ```
+
+#### Showing titles in Lite mode
+
+✨ **Added in 1.13.0**
+
+By default, Lite embeds don't display a title. As of v1.13.0, you can opt to download the video title from YouTube in Lite mode:
+
+```javascript
+eleventyConfig.addPlugin(embedYouTube, {
+  lite: true,
+	titleOptions: {
+		download: true
+	}
+});
+```
+
+This option works basically the same way it does for the default mode, with one exception: Lite mode always ignores the default `title` value, since using it would result in every embed having the same title. If fetching the title data from YouTube fails for any reason, the title is omitted.
 
 #### Configuring lite embed options
 
@@ -251,19 +268,19 @@ eleventyConfig.addPlugin(embedYouTube, {
       <td>Pass a custom URL to load the necessary JavaScript from the source of your choice.</td>
     </tr>
     <tr>
-      <td><code>lite.jsApi</code><br>✨ <b>New in v1.11.0!</b></td>
+      <td><code>lite.jsApi</code></td>
       <td>Boolean</td>
       <td><code>false</code></td>
       <td>If you change this to true, then the plugin adds a `js-api` parameter to the custom element that enables access to YouTube's IFrame Player API. See <a href="https://github.com/paulirish/lite-youtube-embed?tab=readme-ov-file#access-the-youtube-iframe-player-api">usage example</a> and <a href="https://paulirish.github.io/lite-youtube-embed/variants/js-api.html">demo</a>.</td>
     </tr>
     <tr>
-      <td><code>lite.responsive</code><br>✨ <b>New in v1.10.0!</b></td>
+      <td><code>lite.responsive</code></td>
       <td>Boolean</td>
       <td><code>false</code></td>
       <td>If you change this to <code>true</code>, then the plugin adds a CSS rule to override the default max-width of <code>&lt;lite-youtube&gt;</code> elements, which are <a href="https://github.com/paulirish/lite-youtube-embed/blob/f9fc3a2475ade166d0cf7bb3e3caa3ec236ee74e/src/lite-yt-embed.css#L9">hard coded</a> to a maximum of 720 pixels.</td>
     </tr>
     <tr>
-      <td><code>lite.thumbnailFormat</code><br>✨ <b>New in v1.11.0!</b></td>
+      <td><code>lite.thumbnailFormat</code></td>
       <td>String</td>
       <td><code>jpg</code></td>
       <td>If you change this to <code>webp</code>, then the plugin will load the YouTube thumbnail image in WebP format instead of JPEG.</td>

--- a/packages/youtube/test/embed.lite.playlist.test.js
+++ b/packages/youtube/test/embed.lite.playlist.test.js
@@ -36,101 +36,101 @@ const override = (obj) => merge(defaults, obj);
 /**
  * Lite mode, zero index (first instance on page includes script and CSS)
  */
-test(`Build embed lite mode, zero index, lite defaults`, t => {
-  t.is(embed(extract(testString), override({lite: true}), 0), testString);
+test(`Build embed lite mode, zero index, lite defaults`, async t => {
+	t.is(await embed(extract(testString), override({lite: true}), 0), testString);
 });
-test(`Build embed lite mode, zero index, JS API enabled`, t => {
-  t.is(embed(extract(testString), override({lite: {jsApi: true}}), 0), testString);
+test(`Build embed lite mode, zero index, JS API enabled`, async t => {
+	t.is(await embed(extract(testString), override({lite: {jsApi: true}}), 0), testString);
 });
-test(`Build embed lite mode, zero index, valid thumbnail format override`, t => {
-  t.is(embed(extract(testString), override({lite: {thumbnailFormat: 'webp'}}), 0), testString);
+test(`Build embed lite mode, zero index, valid thumbnail format override`, async t => {
+	t.is(await embed(extract(testString), override({lite: {thumbnailFormat: 'webp'}}), 0), testString);
 });
-test(`Build embed lite mode, zero index, invalid thumbnail format override`, t => {
-  t.is(embed(extract(testString), override({lite: {thumbnailFormat: 'no'}}), 0), testString);
+test(`Build embed lite mode, zero index, invalid thumbnail format override`, async t => {
+	t.is(await embed(extract(testString), override({lite: {thumbnailFormat: 'no'}}), 0), testString);
 });
-test(`Build embed lite mode, zero index, valid thumbnail quality override`, t => {
-  t.is(embed(extract(testString), override({lite: { thumbnailQuality: 'maxresdefault'}}), 0), testString);
+test(`Build embed lite mode, zero index, valid thumbnail quality override`, async t => {
+	t.is(await embed(extract(testString), override({lite: { thumbnailQuality: 'maxresdefault'}}), 0), testString);
 });
-test(`Build embed lite mode, zero index, invalid thumbnail quality override`, t => {
-  t.is(embed(extract(testString), override({lite: { thumbnailQuality: 'nope'}}), 0), testString);
+test(`Build embed lite mode, zero index, invalid thumbnail quality override`, async t => {
+	t.is(await embed(extract(testString), override({lite: { thumbnailQuality: 'nope'}}), 0), testString);
 });
-test(`Build embed lite mode, zero index, lite defaults with URL start time param`, t => {
-  t.is(embed(extract('<p>https://www.youtube.com/playlist?list=PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW&t=30s</p>'), override({lite: true}), 0),
+test(`Build embed lite mode, zero index, lite defaults with URL start time param`, async t => {
+	t.is(await embed(extract('<p>https://www.youtube.com/playlist?list=PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW&t=30s</p>'), override({lite: true}), 0),
 	'<p>https://www.youtube.com/playlist?list=PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW&t=30s</p>'
 	);
 });
-test(`Build embed lite mode, zero index, css disabled`, t => {
-  t.is(embed(extract(testString), override({lite:{css:{enabled: false}}}), 0), testString);
+test(`Build embed lite mode, zero index, css disabled`, async t => {
+	t.is(await embed(extract(testString), override({lite:{css:{enabled: false}}}), 0), testString);
 });
-test(`Build embed lite mode, zero index, css inline`, t => {
-  t.is(embed(extract(testString), override({lite:{css:{inline: true}}}), 0), testString);
+test(`Build embed lite mode, zero index, css inline`, async t => {
+	t.is(await embed(extract(testString), override({lite:{css:{inline: true}}}), 0), testString);
 });
-test(`Build embed lite mode, zero index, css path override`, t => {
-  t.is(embed(extract(testString), override({lite:{css:{path: 'foo'}}}), 0), testString);
+test(`Build embed lite mode, zero index, css path override`, async t => {
+	t.is(await embed(extract(testString), override({lite:{css:{path: 'foo'}}}), 0), testString);
 });
-test(`Build embed lite mode, zero index, js disabled`, t => {
-  t.is(embed(extract(testString), override({lite:{js:{enabled: false}}}), 0), testString);
+test(`Build embed lite mode, zero index, js disabled`, async t => {
+	t.is(await embed(extract(testString), override({lite:{js:{enabled: false}}}), 0), testString);
 });
-test(`Build embed lite mode, zero index, js inline`, t => {
-  t.is(embed(extract(testString), override({lite:{js:{inline: true}}}), 0), testString);
+test(`Build embed lite mode, zero index, js inline`, async t => {
+	t.is(await embed(extract(testString), override({lite:{js:{inline: true}}}), 0), testString);
 });
-test(`Build embed lite mode, zero index, css AND js disabled`, t => {
-  t.is(embed(extract(testString), override({lite:{css:{enabled:false},js:{enabled:false}}}), 0), testString);
+test(`Build embed lite mode, zero index, css AND js disabled`, async t => {
+	t.is(await embed(extract(testString), override({lite:{css:{enabled:false},js:{enabled:false}}}), 0), testString);
 });
-test(`Build embed lite mode, zero index, css AND js path override`, t => {
-  t.is(embed(extract(testString), override({lite:{css:{path: 'foo'},js:{path: 'foo'}}}), 0), testString);
+test(`Build embed lite mode, zero index, css AND js path override`, async t => {
+	t.is(await embed(extract(testString), override({lite:{css:{path: 'foo'},js:{path: 'foo'}}}), 0), testString);
 });
-test(`Build embed lite mode, zero index, css AND js inline`, t => {
-  t.is(embed(extract(testString), override({lite:{css:{inline: true},js:{inline: true}}}), 0), testString);
+test(`Build embed lite mode, zero index, css AND js inline`, async t => {
+	t.is(await embed(extract(testString), override({lite:{css:{inline: true},js:{inline: true}}}), 0), testString);
 });
-test(`Build embed lite mode, zero index, responsive true`, t => {
-  t.is(embed(extract(testString), override({lite: { responsive: true }}), 0), testString);
+test(`Build embed lite mode, zero index, responsive true`, async t => {
+	t.is(await embed(extract(testString), override({lite: { responsive: true }}), 0), testString);
 });
 
 
 /**
  * Lite mode, 1+ index (no style or script on subsequent outputs)
  */
-test(`Build embed lite mode, 1+ index, lite defaults`, t => {
-  t.is(embed(extract(testString), override({lite: true}), 1), testString);
+test(`Build embed lite mode, 1+ index, lite defaults`, async t => {
+	t.is(await embed(extract(testString), override({lite: true}), 1), testString);
 });
-test(`Build embed lite mode, 1+ index, JS API enabled`, t => {
-  t.is(embed(extract(testString), override({lite: {jsApi: true}}), 1), testString);
+test(`Build embed lite mode, 1+ index, JS API enabled`, async t => {
+	t.is(await embed(extract(testString), override({lite: {jsApi: true}}), 1), testString);
 });
-test(`Build embed lite mode, 1+ index, valid thumbnail quality override`, t => {
-  t.is(embed(extract(testString), override({lite: { thumbnailQuality: 'maxresdefault'}}), 1), testString);
+test(`Build embed lite mode, 1+ index, valid thumbnail quality override`, async t => {
+	t.is(await embed(extract(testString), override({lite: { thumbnailQuality: 'maxresdefault'}}), 1), testString);
 });
-test(`Build embed lite mode, 1+ index, invalid thumbnail quality override`, t => {
-  t.is(embed(extract(testString), override({lite: { thumbnailQuality: 'nope'}}), 1), testString);
+test(`Build embed lite mode, 1+ index, invalid thumbnail quality override`, async t => {
+	t.is(await embed(extract(testString), override({lite: { thumbnailQuality: 'nope'}}), 1), testString);
 });
-test(`Build embed lite mode, 1+ index, valid thumbnail format override`, t => {
-  t.is(embed(extract(testString), override({lite: {thumbnailFormat: 'webp'}}), 1), testString);
+test(`Build embed lite mode, 1+ index, valid thumbnail format override`, async t => {
+	t.is(await embed(extract(testString), override({lite: {thumbnailFormat: 'webp'}}), 1), testString);
 });
-test(`Build embed lite mode, 1+ index, invalid thumbnail format override`, t => {
-  t.is(embed(extract(testString), override({lite: {thumbnailFormat: 'foo'}}), 1), testString);
+test(`Build embed lite mode, 1+ index, invalid thumbnail format override`, async t => {
+	t.is(await embed(extract(testString), override({lite: {thumbnailFormat: 'foo'}}), 1), testString);
 });
-test(`Build embed lite mode, 1+ index, lite defaults with URL start time param`, t => {
-  t.is(embed(extract('<p>https://www.youtube.com/playlist?list=PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW&t=30s</p>'), override({lite: true}), 1),
+test(`Build embed lite mode, 1+ index, lite defaults with URL start time param`, async t => {
+	t.is(await embed(extract('<p>https://www.youtube.com/playlist?list=PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW&t=30s</p>'), override({lite: true}), 1),
 	'<p>https://www.youtube.com/playlist?list=PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW&t=30s</p>'
 	);
 });
-test(`Build embed lite mode, 1+ index, css disabled`, t => {
-  t.is(embed(extract(testString), override({lite:{css:{enabled: false}}}), 1), testString);
+test(`Build embed lite mode, 1+ index, css disabled`, async t => {
+	t.is(await embed(extract(testString), override({lite:{css:{enabled: false}}}), 1), testString);
 });
-test(`Build embed lite mode, 1+ index, css inline`, t => {
-  t.is(embed(extract(testString), override({lite:{css:{inline: true}}}), 1), testString);
+test(`Build embed lite mode, 1+ index, css inline`, async t => {
+	t.is(await embed(extract(testString), override({lite:{css:{inline: true}}}), 1), testString);
 });
-test(`Build embed lite mode, 1+ index, css path override`, t => {
-  t.is(embed(extract(testString), override({lite:{css:{path: 'foo'}}}), 1), testString);
+test(`Build embed lite mode, 1+ index, css path override`, async t => {
+	t.is(await embed(extract(testString), override({lite:{css:{path: 'foo'}}}), 1), testString);
 });
-test(`Build embed lite mode, 1+ index, js disabled`, t => {
-  t.is(embed(extract(testString), override({lite:{js:{enabled: false}}}), 1), testString);
+test(`Build embed lite mode, 1+ index, js disabled`, async t => {
+	t.is(await embed(extract(testString), override({lite:{js:{enabled: false}}}), 1), testString);
 });
-test(`Build embed lite mode, 1+ index, js inline`, t => {
-  t.is(embed(extract(testString), override({lite:{js:{inline: true}}}), 1), testString);
+test(`Build embed lite mode, 1+ index, js inline`, async t => {
+	t.is(await embed(extract(testString), override({lite:{js:{inline: true}}}), 1), testString);
 });
-test(`Build embed lite mode, 1+ index, responsive true`, t => {
-  t.is(embed(extract(testString), override({lite: { responsive: true }}), 1), testString);
+test(`Build embed lite mode, 1+ index, responsive true`, async t => {
+	t.is(await embed(extract(testString), override({lite: { responsive: true }}), 1), testString);
 });
 
 /**

--- a/packages/youtube/test/embed.lite.test.js
+++ b/packages/youtube/test/embed.lite.test.js
@@ -192,7 +192,7 @@ test(`Build embed lite mode, 1+ index, js inline`, async t => {
 	);
 });
 test(`Build embed lite mode, 1+ index, responsive true`, async t => {
-	t.is(await embed(extract(testString), override({lite: { responive: true }}), 1),
+	t.is(await embed(extract(testString), override({lite: { responsive: true }}), 1),
 	`<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
 	);
 });

--- a/packages/youtube/test/embed.lite.test.js
+++ b/packages/youtube/test/embed.lite.test.js
@@ -36,155 +36,175 @@ const override = (obj) => merge(defaults, obj);
 /**
  * Lite mode, zero index (first instance on page includes script and CSS)
  */
-test(`Build embed lite mode, zero index, lite defaults`, t => {
-  t.is(embed(extract(testString), override({lite: true}), 0),
-  `<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.css">\n<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.js"></script>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
-  );
+test(`Build embed lite mode, zero index, lite defaults`, async t => {
+	t.is(await embed(extract(testString), override({lite: true}), 0),
+	`<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.css">\n<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.js"></script>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+	);
 });
-test(`Build embed lite mode, zero index, JS API enabled`, t => {
-  t.is(embed(extract(testString), override({lite: {jsApi: true}}), 0),
-  `<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.css">\n<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.js"></script>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');" js-api><div class="lty-playbtn"></div></lite-youtube></div>`
-  );
+test(`Build embed lite mode, zero index, JS API enabled`, async t => {
+	t.is(await embed(extract(testString), override({lite: {jsApi: true}}), 0),
+	`<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.css">\n<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.js"></script>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');" js-api><div class="lty-playbtn"></div></lite-youtube></div>`
+	);
 });
-test(`Build embed lite mode, zero index, valid thumbnail format override`, t => {
-  t.is(embed(extract(testString), override({lite: {thumbnailFormat: 'webp'}}), 0),
-  `<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.css">\n<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.js"></script>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi_webp/hIs5StN8J-0/hqdefault.webp');"><div class="lty-playbtn"></div></lite-youtube></div>`
-  );
+test(`Build embed lite mode, zero index, valid thumbnail format override`, async t => {
+	t.is(await embed(extract(testString), override({lite: {thumbnailFormat: 'webp'}}), 0),
+	`<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.css">\n<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.js"></script>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi_webp/hIs5StN8J-0/hqdefault.webp');"><div class="lty-playbtn"></div></lite-youtube></div>`
+	);
 });
-test(`Build embed lite mode, zero index, invalid thumbnail format override`, t => {
-  t.is(embed(extract(testString), override({lite: {thumbnailFormat: 'no'}}), 0),
-  `<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.css">\n<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.js"></script>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
-  );
+test(`Build embed lite mode, zero index, invalid thumbnail format override`, async t => {
+	t.is(await embed(extract(testString), override({lite: {thumbnailFormat: 'no'}}), 0),
+	`<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.css">\n<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.js"></script>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+	);
 });
-test(`Build embed lite mode, zero index, valid thumbnail quality override`, t => {
-  t.is(embed(extract(testString), override({lite: { thumbnailQuality: 'maxresdefault'}}), 0),
-  `<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.css">\n<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.js"></script>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/maxresdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
-  );
+test(`Build embed lite mode, zero index, valid thumbnail quality override`, async t => {
+	t.is(await embed(extract(testString), override({lite: { thumbnailQuality: 'maxresdefault'}}), 0),
+	`<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.css">\n<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.js"></script>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/maxresdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+	);
 });
-test(`Build embed lite mode, zero index, invalid thumbnail quality override`, t => {
-  t.is(embed(extract(testString), override({lite: { thumbnailQuality: 'nope'}}), 0),
-  `<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.css">\n<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.js"></script>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
-  );
+test(`Build embed lite mode, zero index, invalid thumbnail quality override`, async t => {
+	t.is(await embed(extract(testString), override({lite: { thumbnailQuality: 'nope'}}), 0),
+	`<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.css">\n<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.js"></script>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+	);
 });
-test(`Build embed lite mode, zero index, lite defaults with URL start time param`, t => {
-  t.is(embed(extract('<p>https://www.youtube.com/watch?v=hIs5StN8J-0&t=30s</p>'), override({lite: true}), 0),
-  `<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.css">\n<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.js"></script>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');" params="start=30"><div class="lty-playbtn"></div></lite-youtube></div>`
-  );
+test(`Build embed lite mode, zero index, lite defaults with URL start time param`, async t => {
+	t.is(await embed(extract('<p>https://www.youtube.com/watch?v=hIs5StN8J-0&t=30s</p>'), override({lite: true}), 0),
+	`<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.css">\n<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.js"></script>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');" params="start=30"><div class="lty-playbtn"></div></lite-youtube></div>`
+	);
 });
-test(`Build embed lite mode, zero index, css disabled`, t => {
-  t.is(embed(extract(testString), override({lite:{css:{enabled: false}}}), 0),
-  `<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.js"></script>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
-  );
+test(`Build embed lite mode, zero index, css disabled`, async t => {
+	t.is(await embed(extract(testString), override({lite:{css:{enabled: false}}}), 0),
+	`<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.js"></script>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+	);
 });
-test(`Build embed lite mode, zero index, css inline`, t => {
-  t.is(embed(extract(testString), override({lite:{css:{inline: true}}}), 0),
-  `<style>${inlineCss}</style>\n<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.js"></script>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
-  );
+test(`Build embed lite mode, zero index, css inline`, async t => {
+	t.is(await embed(extract(testString), override({lite:{css:{inline: true}}}), 0),
+	`<style>${inlineCss}</style>\n<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.js"></script>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+	);
 });
-test(`Build embed lite mode, zero index, css path override`, t => {
-  t.is(embed(extract(testString), override({lite:{css:{path: 'foo'}}}), 0),
-  `<link rel="stylesheet" href="foo">\n<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.js"></script>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
-  );
+test(`Build embed lite mode, zero index, css path override`, async t => {
+	t.is(await embed(extract(testString), override({lite:{css:{path: 'foo'}}}), 0),
+	`<link rel="stylesheet" href="foo">\n<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.js"></script>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+	);
 });
-test(`Build embed lite mode, zero index, js disabled`, t => {
-  t.is(embed(extract(testString), override({lite:{js:{enabled: false}}}), 0),
-  `<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.css">\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
-  );
+test(`Build embed lite mode, zero index, js disabled`, async t => {
+	t.is(await embed(extract(testString), override({lite:{js:{enabled: false}}}), 0),
+	`<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.css">\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+	);
 });
-test(`Build embed lite mode, zero index, js inline`, t => {
-  t.is(embed(extract(testString), override({lite:{js:{inline: true}}}), 0),
-  `<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.css">\n<script>${inlineJs}</script>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
-  );
+test(`Build embed lite mode, zero index, js inline`, async t => {
+	t.is(await embed(extract(testString), override({lite:{js:{inline: true}}}), 0),
+	`<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.css">\n<script>${inlineJs}</script>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+	);
 });
-test(`Build embed lite mode, zero index, css AND js disabled`, t => {
-  t.is(embed(extract(testString), override({lite:{css:{enabled:false},js:{enabled:false}}}), 0),
-  `<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
-  );
+test(`Build embed lite mode, zero index, css AND js disabled`, async t => {
+	t.is(await embed(extract(testString), override({lite:{css:{enabled:false},js:{enabled:false}}}), 0),
+	`<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+	);
 });
-test(`Build embed lite mode, zero index, css AND js path override`, t => {
-  t.is(embed(extract(testString), override({lite:{css:{path: 'foo'},js:{path: 'foo'}}}), 0),
-  `<link rel="stylesheet" href="foo">\n<script defer="defer" src="foo"></script>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
-  );
+test(`Build embed lite mode, zero index, css AND js path override`, async t => {
+	t.is(await embed(extract(testString), override({lite:{css:{path: 'foo'},js:{path: 'foo'}}}), 0),
+	`<link rel="stylesheet" href="foo">\n<script defer="defer" src="foo"></script>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+	);
 });
-test(`Build embed lite mode, zero index, css AND js inline`, t => {
-  t.is(embed(extract(testString), override({lite:{css:{inline: true},js:{inline: true}}}), 0),
-  `<style>${inlineCss}</style>\n<script>${inlineJs}</script>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
-  );
+test(`Build embed lite mode, zero index, css AND js inline`, async t => {
+	t.is(await embed(extract(testString), override({lite:{css:{inline: true},js:{inline: true}}}), 0),
+	`<style>${inlineCss}</style>\n<script>${inlineJs}</script>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+	);
 });
-test(`Build embed lite mode, zero index, responsive true`, t => {
-  t.is(embed(extract(testString), override({lite: { responsive: true }}), 0),
-  `<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.css">\n<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.js"></script>\n<style>.eleventy-plugin-youtube-embed lite-youtube {max-width:100%}</style>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
-  );
+test(`Build embed lite mode, zero index, responsive true`, async t => {
+	t.is(await embed(extract(testString), override({lite: { responsive: true }}), 0),
+	`<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.css">\n<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.js"></script>\n<style>.eleventy-plugin-youtube-embed lite-youtube {max-width:100%}</style>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+	);
+});
+test(`Build embed lite mode, zero index, fetch title via oembed`, async t => {
+	t.is(await embed(extract(testString), override({lite: { responsive: true }, titleOptions: {download: true}}), 0),
+	`<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.css">\n<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.js"></script>\n<style>.eleventy-plugin-youtube-embed lite-youtube {max-width:100%}</style>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');" title="Animotion - Obsession (Official Music Video)"><div class="lty-playbtn"></div></lite-youtube></div>`
+	);
+});
+test(`Build embed lite mode, zero index, default title set but should be ignored`, async t => {
+	t.is(await embed(extract(testString), override({lite: { responsive: true }, title: "Foo"}), 0),
+	`<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.css">\n<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.js"></script>\n<style>.eleventy-plugin-youtube-embed lite-youtube {max-width:100%}</style>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+	);
 });
 
 
 /**
  * Lite mode, 1+ index (no style or script on subsequent outputs)
  */
-test(`Build embed lite mode, 1+ index, lite defaults`, t => {
-  t.is(embed(extract(testString), override({lite: true}), 1),
-  `<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
-  );
+test(`Build embed lite mode, 1+ index, lite defaults`, async t => {
+	t.is(await embed(extract(testString), override({lite: true}), 1),
+	`<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+	);
 });
-test(`Build embed lite mode, 1+ index, JS API enabled`, t => {
-  t.is(embed(extract(testString), override({lite: {jsApi: true}}), 1),
-  `<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');" js-api><div class="lty-playbtn"></div></lite-youtube></div>`
-  );
+test(`Build embed lite mode, 1+ index, JS API enabled`, async t => {
+	t.is(await embed(extract(testString), override({lite: {jsApi: true}}), 1),
+	`<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');" js-api><div class="lty-playbtn"></div></lite-youtube></div>`
+	);
 });
-test(`Build embed lite mode, 1+ index, valid thumbnail quality override`, t => {
-  t.is(embed(extract(testString), override({lite: { thumbnailQuality: 'maxresdefault'}}), 1),
-  `<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/maxresdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
-  );
+test(`Build embed lite mode, 1+ index, valid thumbnail quality override`, async t => {
+	t.is(await embed(extract(testString), override({lite: { thumbnailQuality: 'maxresdefault'}}), 1),
+	`<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/maxresdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+	);
 });
-test(`Build embed lite mode, 1+ index, invalid thumbnail quality override`, t => {
-  t.is(embed(extract(testString), override({lite: { thumbnailQuality: 'nope'}}), 1),
-  `<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
-  );
+test(`Build embed lite mode, 1+ index, invalid thumbnail quality override`, async t => {
+	t.is(await embed(extract(testString), override({lite: { thumbnailQuality: 'nope'}}), 1),
+	`<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+	);
 });
-test(`Build embed lite mode, 1+ index, valid thumbnail format override`, t => {
-  t.is(embed(extract(testString), override({lite: {thumbnailFormat: 'webp'}}), 1),
-  `<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi_webp/hIs5StN8J-0/hqdefault.webp');"><div class="lty-playbtn"></div></lite-youtube></div>`
-  );
+test(`Build embed lite mode, 1+ index, valid thumbnail format override`, async t => {
+	t.is(await embed(extract(testString), override({lite: {thumbnailFormat: 'webp'}}), 1),
+	`<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi_webp/hIs5StN8J-0/hqdefault.webp');"><div class="lty-playbtn"></div></lite-youtube></div>`
+	);
 });
-test(`Build embed lite mode, 1+ index, invalid thumbnail format override`, t => {
-  t.is(embed(extract(testString), override({lite: {thumbnailFormat: 'foo'}}), 1),
-  `<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
-  );
+test(`Build embed lite mode, 1+ index, invalid thumbnail format override`, async t => {
+	t.is(await embed(extract(testString), override({lite: {thumbnailFormat: 'foo'}}), 1),
+	`<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+	);
 });
-test(`Build embed lite mode, 1+ index, lite defaults with URL start time param`, t => {
-  t.is(embed(extract('<p>https://www.youtube.com/watch?v=hIs5StN8J-0&t=30s</p>'), override({lite: true}), 1),
-  `<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');" params="start=30"><div class="lty-playbtn"></div></lite-youtube></div>`
-  );
+test(`Build embed lite mode, 1+ index, lite defaults with URL start time param`, async t => {
+	t.is(await embed(extract('<p>https://www.youtube.com/watch?v=hIs5StN8J-0&t=30s</p>'), override({lite: true}), 1),
+	`<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');" params="start=30"><div class="lty-playbtn"></div></lite-youtube></div>`
+	);
 });
-test(`Build embed lite mode, 1+ index, css disabled`, t => {
-  t.is(embed(extract(testString), override({lite:{css:{enabled: false}}}), 1),
-  `<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
-  );
+test(`Build embed lite mode, 1+ index, css disabled`, async t => {
+	t.is(await embed(extract(testString), override({lite:{css:{enabled: false}}}), 1),
+	`<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+	);
 });
-test(`Build embed lite mode, 1+ index, css inline`, t => {
-  t.is(embed(extract(testString), override({lite:{css:{inline: true}}}), 1),
-  `<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
-  );
+test(`Build embed lite mode, 1+ index, css inline`, async t => {
+	t.is(await embed(extract(testString), override({lite:{css:{inline: true}}}), 1),
+	`<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+	);
 });
-test(`Build embed lite mode, 1+ index, css path override`, t => {
-  t.is(embed(extract(testString), override({lite:{css:{path: 'foo'}}}), 1),
-  `<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
-  );
+test(`Build embed lite mode, 1+ index, css path override`, async t => {
+	t.is(await embed(extract(testString), override({lite:{css:{path: 'foo'}}}), 1),
+	`<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+	);
 });
-test(`Build embed lite mode, 1+ index, js disabled`, t => {
-  t.is(embed(extract(testString), override({lite:{js:{enabled: false}}}), 1),
-  `<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
-  );
+test(`Build embed lite mode, 1+ index, js disabled`, async t => {
+	t.is(await embed(extract(testString), override({lite:{js:{enabled: false}}}), 1),
+	`<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+	);
 });
-test(`Build embed lite mode, 1+ index, js inline`, t => {
-  t.is(embed(extract(testString), override({lite:{js:{inline: true}}}), 1),
-  `<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
-  );
+test(`Build embed lite mode, 1+ index, js inline`, async t => {
+	t.is(await embed(extract(testString), override({lite:{js:{inline: true}}}), 1),
+	`<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+	);
 });
-test(`Build embed lite mode, 1+ index, responsive true`, t => {
-  t.is(embed(extract(testString), override({lite: { responive: true }}), 1),
-  `<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
-  );
+test(`Build embed lite mode, 1+ index, responsive true`, async t => {
+	t.is(await embed(extract(testString), override({lite: { responive: true }}), 1),
+	`<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+	);
+});
+test(`Build embed lite mode, 1+ index, fetch title via oembed`, async t => {
+	t.is(await embed(extract(testString), override({lite: { responsive: true }, titleOptions: {download: true}}), 1),
+	`<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');" title="Animotion - Obsession (Official Music Video)"><div class="lty-playbtn"></div></lite-youtube></div>`
+	);
+});
+test(`Build embed lite mode, 1+ index, default title set but should be ignored`, async t => {
+	t.is(await embed(extract(testString), override({lite: { responsive: true }, title: "Foo"}), 1),
+	`<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
+	);
 });
 
 /**


### PR DESCRIPTION
Closes #314 

This PR enables the option to download and display the video title when using Lite mode, which previously wasn't possible:

```javascript
eleventyConfig.addPlugin(embedYouTube, {
  lite: true,
  titleOptions: {
    download: true
  }
});
```

I've opted to always ignore the fallback/default value of `title` in Lite mode, because using it could result in every Lite embed having the same title. I think in cases where some error prevents fetching the title from YouTube, it's better to display nothing, rather than hard-code the default title for all affected videos. If you feel differently, please file an issue and let's discuss.

In addition, there's probably no noticeable effect, but it's worth noting for the record: since this requires (potentially) awaiting a network call to YouTube, Lite mode now runs asynchronously, same as default mode. (This is why all the tests had to be updated to async).
