### PR TITLE
Correctly handle trailing anchor tags in Mastodon URLs

### DIFF
--- a/.changeset/odd-plants-punch.md
+++ b/.changeset/odd-plants-punch.md
@@ -1,0 +1,6 @@
+---
+"eleventy-plugin-embed-mastodon": patch
+"eleventy-plugin-embed-everything": patch
+---
+
+Correctly handle trailing </a> in urls

--- a/packages/mastodon/lib/pattern.js
+++ b/packages/mastodon/lib/pattern.js
@@ -14,8 +14,8 @@ module.exports = function(hostname) {
 		/@(?<user>\w+)
 		 @?(?<server>[\w\.]+)?
 		/(?<id>\d+)
-		(?>[^\s<>]*)?
 	)
+	(?>[^\s<>]*)?
 	(?>\s*+)?
 	(?><\/a>)?
 	(?>\s*+)?

--- a/packages/mastodon/lib/pattern.js
+++ b/packages/mastodon/lib/pattern.js
@@ -14,7 +14,7 @@ module.exports = function(hostname) {
 		/@(?<user>\w+)
 		 @?(?<server>[\w\.]+)?
 		/(?<id>\d+)
-		\S*
+		(?>[^\s<>]*)?
 	)
 	(?>\s*+)?
 	(?><\/a>)?

--- a/packages/mastodon/test/_validStrings.mjs
+++ b/packages/mastodon/test/_validStrings.mjs
@@ -1,21 +1,33 @@
-import validUrls from './_validUrls.mjs';
+import {federatedUrls, originUrls} from './_validUrls.mjs';
 
-export default validUrls.flatMap(url => [
-  // One line
-  `<p>${url}</p>`,
-  
-  // Whitespace
-  `<p>
-      ${url}
-  </p>`,
-  
-  // One line, links
-  `<p><a href="${url}">${url}</a></p>`,
-  
-  // Whitespace, links
-  `<p>
-      <a href="${url}">
-        ${url}
-      </a>
-  </p>`
-]);
+export const federatedStrings = urlsToParagraphs(federatedUrls);
+export const originStrings = urlsToParagraphs(originUrls);
+
+
+/**
+ * For an array of URLs, return an array of paragraphs
+ * in a variety of formats.
+ * @param {array} urls - An array of URL strings
+ * @returns {array} - An array of HTML paragraphs
+ */
+function urlsToParagraphs(urls) {
+	return urls.flatMap(url => [
+		// One line
+		`<p>${url}</p>`,
+
+		// Whitespace
+		`<p>
+				${url}
+		</p>`,
+
+		// One line, links
+		`<p><a href="${url}">${url}</a></p>`,
+
+		// Whitespace, links
+		`<p>
+				<a href="${url}">
+					${url}
+				</a>
+		</p>`
+	]);
+}

--- a/packages/mastodon/test/_validUrls.mjs
+++ b/packages/mastodon/test/_validUrls.mjs
@@ -1,20 +1,12 @@
 /**
  * VALID URLS
  *
- * Starting with a short list of valid URL fragments, return
+ * Starting with a few valid URL fragments, return
  * all possible valid URL permutations.
  */
 
 import permute from 'permute-arrays';
 
-/**
- * Core URL structures accepted by the plugin
- * Domain and path only
- */
-const validUrls = [
- 'social.vivaldi.net/@username@example.com/123456789123456789',
- 'social.vivaldi.net/@foo/987654321987654321',
-]
 
 
 /**
@@ -27,4 +19,6 @@ const validSuffixes = ['/', '/foo', '?', '%3F', '?foo', '%3Ffoo', '?foo=bar', '%
 /**
  * Cumulative lists of all URL permutations.
  */
-export default permute(validUrls, validPrefixes, validSuffixes);
+export const federatedUrls = permute('social.vivaldi.net/@username@example.com/123456789123456789', validPrefixes, validSuffixes);
+export const originUrls = permute('social.vivaldi.net/@foo/987654321987654321', validPrefixes, validSuffixes);
+

--- a/packages/mastodon/test/pattern.test.mjs
+++ b/packages/mastodon/test/pattern.test.mjs
@@ -1,39 +1,48 @@
 import { describe, it, expect } from 'vitest';
 import patternGenerator from '../lib/pattern.js';
-import validStrings from './_validStrings.mjs';
+import {federatedStrings, originStrings} from './_validStrings.mjs';
 
 const pattern = patternGenerator('social.vivaldi.net');
 
-describe('URL valid pattern tests', () => {
-  validStrings.forEach((str, index) => {
+const allStrings = [...federatedStrings, ...originStrings];
+
+describe('Valid federated URL patterns', () => {
+  allStrings.forEach((str, index) => {
     it(`Regex test ${index}: ${str}`, () => {
+			pattern.lastIndex = 0;
       expect(str).toMatch(pattern);
     });
   });
 });
 
-describe('Destructuring works as expected', () => {
-
-		it('Captures expected data for federated toots', () => {
-			// Reset the pattern's lastIndex property to 0
+// social.vivaldi.net/@username@example.com/123456789123456789
+describe('Destructuring works for federated posts', () => {
+  federatedStrings.forEach((str, index) => {
+    it(`Regex test ${index}: ${str}`, () => {
 			pattern.lastIndex = 0;
-			const match = pattern.exec('<p>https://social.vivaldi.net/@foo@example.com/123</p>');
-			const { hostname, user, server, id } = match.groups;
+			const match = pattern.exec(str);
+			const { hostname, user, server, id, url } = match.groups;
 			expect(hostname).toBe('social.vivaldi.net');
-			expect(user).toBe('foo');
+			expect(user).toBe('username');
 			expect(server).toBe('example.com');
-			expect(id).toBe('123');
-		});
+			expect(id).toBe('123456789123456789');
+			expect(url).toBe('social.vivaldi.net/@username@example.com/123456789123456789');
+    });
+  });
+});
 
-		it('Federated server is absent for non-federated toots', () => {
-			// Reset the pattern's lastIndex property to 0
+// social.vivaldi.net/@foo/987654321987654321
+describe('Destructuring works for origin posts', () => {
+  originStrings.forEach((str, index) => {
+    it(`Regex test ${index}: ${str}`, () => {
 			pattern.lastIndex = 0;
-			const match = pattern.exec('<p>https://social.vivaldi.net/@foo/123</p>');
-			const { hostname, user, server, id } = match.groups;
+			const match = pattern.exec(str);
+			const { hostname, user, server, id, url } = match.groups;
 			expect(hostname).toBe('social.vivaldi.net');
 			expect(user).toBe('foo');
-			expect(id).toBe('123');
+			expect(id).toBe('987654321987654321');
 			expect(server).toBe(undefined);
-		});
-
+			expect(url).toBe('social.vivaldi.net/@foo/987654321987654321');
+    });
+  });
 });


### PR DESCRIPTION
Fixes #315 

This PR updates the regular expression for the Mastodon plugin so that it correctly handles trailing `</a>` anchor tags. The previous version was too permissive, accepting any trailing non-whitespace character (`\S`). That meant the `url` group returned by the regular expression was incorrectly capturing trailing `</a>` tags. So when you query Mastodon for the url `/api/oembed?url=https://{hostname}/{user}/{id}</a>`, obviously it throws a 404 and bails.

This restricts the acceptable trailing characters in the URL so it won't capture any closing tags. (This is a pattern already in use in the other plugins, I forget why I didn't just use it here). It also updates the tests to catch this type of issue in future.