### PR TITLE
Make YouTube inline CSS editable via options

### DIFF
--- a/.changeset/bumpy-meals-mix.md
+++ b/.changeset/bumpy-meals-mix.md
@@ -1,0 +1,6 @@
+---
+"eleventy-plugin-youtube-embed": minor
+"eleventy-plugin-embed-everything": minor
+---
+
+Make YouTube inline CSS configurable

--- a/packages/youtube/lib/defaults.js
+++ b/packages/youtube/lib/defaults.js
@@ -3,6 +3,8 @@
  * @property {string} [allowAttrs] - Allowed attributes.
  * @property {boolean} [allowAutoplay] - Whether autoplay is allowed.
  * @property {boolean} [allowFullscreen] - Whether fullscreen is allowed.
+ * @property {string} [cssWrapper] - Inline CSS for the wrapper.
+ * @property {string} [cssIframe] - Inline CSS for the iframe.
  * @property {string} [embedClass] - The class for the embed.
  * @property {boolean} [lazy] - Whether lazy loading is enabled.
  * @property {boolean} [lite] - Whether lite mode is enabled.
@@ -18,7 +20,9 @@ const defaults = {
   allowAttrs: 'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture',
   allowAutoplay: false,
   allowFullscreen: true,
-  embedClass: 'eleventy-plugin-youtube-embed',
+  cssWrapper: 'position:relative;width:100%;padding-top: 56.25%;',
+	cssIframe: 'position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;',
+	embedClass: 'eleventy-plugin-youtube-embed',
   lazy: false,
   lite: false,
   modestBranding: false,

--- a/packages/youtube/lib/embed.js
+++ b/packages/youtube/lib/embed.js
@@ -50,11 +50,8 @@ async function defaultEmbed(url, options){
   const embedSrc = __constructEmbedSrc(url, options);
 
   let out = `<div id="${id ?? playlist}" class="${options.embedClass}" `;
-  // intrinsic aspect ratio; currently hard-coded to 16:9
-  // TODO: make configurable somehow
-  out += 'style="position:relative;width:100%;padding-top: 56.25%;">';
-  out +=
-    '<iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;"';
+  out += `style="${options.cssWrapper}">`;
+  out += `<iframe style="${options.cssIframe}"`;
   out += ` width="100%" height="100%" frameborder="0" title="${title}"`;
   out += ` src="${embedSrc}"`;
   out += ` allow="${options.allowAttrs}"`;


### PR DESCRIPTION
This PR makes the inline CSS configurable, both for the YouTube iframe element and its wrapper div.

The `padding-top: 56.25%` trick is still very reliable, but for those who want it, this opens the option to use more modern methods like `aspect-ratio`.