### PR TITLE
Remove `modestbranding` option that YouTube no longer supports

### DIFF
--- a/.changeset/ripe-carrots-kick.md
+++ b/.changeset/ripe-carrots-kick.md
@@ -1,0 +1,6 @@
+---
+"eleventy-plugin-youtube-embed": patch
+"eleventy-plugin-embed-everything": patch
+---
+
+Drop “modestbranding” config since YouTube no longer supports it

--- a/packages/youtube/lib/defaults.js
+++ b/packages/youtube/lib/defaults.js
@@ -21,7 +21,6 @@ const defaults = {
   embedClass: 'eleventy-plugin-youtube-embed',
   lazy: false,
   lite: false,
-  modestBranding: false,
   noCookie: true,
   recommendSelfOnly: false,
   title: 'Embedded YouTube video',

--- a/packages/youtube/lib/embed.js
+++ b/packages/youtube/lib/embed.js
@@ -148,7 +148,6 @@ function stringifyUrlParams(options){
   // autoplay is _technically_ possible, but be cool, don't do this
   if(options.allowAutoplay) params.push('autoplay=1');
   if(options.recommendSelfOnly) params.push('rel=0');
-  if(options.modestBranding) params.push('modestbranding=1');
   if(options.startTime) params.push(`start=${options.startTime}`);
 
   if (params.length === 0) return '';
@@ -293,7 +292,6 @@ function __constructEmbedSrc(url, opt) {
     list: playlist,
     autoplay: opt.allowAutoplay ? 1 : 0,
     rel: opt.recommendSelfOnly ? 1 : 0,
-    modestbranding: opt.modestBranding ? 1 : 0,
     start: parseInt(opt.startTime ?? t ?? start),
   };
 

--- a/packages/youtube/test/embed.default.playlist.test.js
+++ b/packages/youtube/test/embed.default.playlist.test.js
@@ -67,12 +67,6 @@ test(`Playlist embed default mode, override noCookie`, async t => {
   );
 });
 
-test(`Playlist embed default mode, override modestBranding`, async t => {
-  t.is(await embed(extract(testString), override({modestBranding: true})),
-    '<div id="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/videoseries?list=PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW&modestbranding=1" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe></div>'
-  );
-});
-
 test(`Playlist embed default mode, override recommendSelfOnly`, async t => {
   t.is(await embed(extract(testString), override({recommendSelfOnly: true})),
     '<div id="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/videoseries?list=PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW&rel=1" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe></div>'

--- a/packages/youtube/test/embed.default.test.js
+++ b/packages/youtube/test/embed.default.test.js
@@ -74,12 +74,6 @@ test(`Build embed default mode, override noCookie`, async t => {
   );
 });
 
-test(`Build embed default mode, override modestBranding`, async t => {
-  t.is(await embed(extract(testString), override({modestBranding: true})),
-    '<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/hIs5StN8J-0?modestbranding=1" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe></div>'
-  );
-});
-
 test(`Build embed default mode, override recommendSelfOnly`, async t => {
   t.is(await embed(extract(testString), override({recommendSelfOnly: true})),
     '<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/hIs5StN8J-0?rel=1" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe></div>'

--- a/packages/youtube/test/embed.lite.test.js
+++ b/packages/youtube/test/embed.lite.test.js
@@ -255,9 +255,6 @@ test(`Stringify URL params returns expected string in default mode, autoplay`, t
 test(`Stringify URL params returns expected string in default mode, recommendations`, t => {
 	t.is(stringifyUrlParams({recommendSelfOnly: true}), '?rel=0');
 });
-test(`Stringify URL params returns expected string in default mode, modest branding`, t => {
-	t.is(stringifyUrlParams({modestBranding: true}), '?modestbranding=1');
-});
 test(`Stringify URL params returns expected string in default mode, multiple values`, t => {
 	const o = {
 		allowAutoplay: true,
@@ -279,13 +276,6 @@ test(`Stringify URL params returns expected string in lite mode, recommendations
 		recommendSelfOnly: true,
 	}
 	t.is(stringifyUrlParams(o), 'rel=0');
-});
-test(`Stringify URL params returns expected string in lite mode, modest branding`, t => {
-	const o = {
-		lite: true,
-		modestBranding: true,
-	}
-	t.is(stringifyUrlParams(o), 'modestbranding=1');
 });
 test(`Stringify URL params returns expected string in lite mode, multiple values`, t => {
 	const o = {


### PR DESCRIPTION
YouTube [dropped support](https://developers.google.com/youtube/player_parameters#release_notes_08_15_2023) for its `modestbranding` embed option in August 2023, so this setting doesn't do anything anymore, and hasn't for some time.

If your config still references this option it simply no longer gets checked for, or used.