### PR TITLE
Add Node 24 to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,17 +1,17 @@
 name: CI
-on: 
+on:
   push:
     paths-ignore:
       - '.changeset/*.md'
 jobs:
-  
+
   unit_tests:
     name: Node.js ${{ matrix.node }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        node: ["18", "20", "22"]
+        node: ["18", "20", "22", "24"]
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -26,7 +26,7 @@ jobs:
         run: pnpm install
       - name: Run tests using ava
         run: pnpm test
-  
+
   # end_to_end_tests:
   #   name: Run e2e tests
   #   runs-on: "ubuntu-latest"
@@ -57,7 +57,7 @@ jobs:
   #         # TODO figure out how to handle this with multiple packages
   #         path: packages/youtube/playwright-report/
   #         retention-days: 30
-  
+
   code_coverage:
     name: Check test coverage
     runs-on: "ubuntu-latest"
@@ -79,4 +79,4 @@ jobs:
       - name: Run tests using ava
         run: pnpm coverage
       - name: Upload coverage to Codecov.io
-        uses: codecov/codecov-action@v5    
+        uses: codecov/codecov-action@v5


### PR DESCRIPTION
Start testing on Node 24. Even though it's EOL I'll keep Node 18 on the list as long as 11ty still tests against it.