### PR TITLE
Remove unnecessary dependency for terminal colors

### DIFF
--- a/.changeset/bitter-lands-ask.md
+++ b/.changeset/bitter-lands-ask.md
@@ -1,0 +1,5 @@
+---
+"eleventy-plugin-embed-twitch": patch
+---
+
+Remove kleur dependency in favor of native console colors

--- a/packages/twitch/lib/buildEmbed.js
+++ b/packages/twitch/lib/buildEmbed.js
@@ -1,5 +1,3 @@
-const kleur = require('kleur');
-
 module.exports = function(media, options) {
 
   /**
@@ -9,11 +7,14 @@ module.exports = function(media, options) {
    * We coerce the empty string to falsy with the triple-bang trick.
    */
   if ( !!!options.parent ) {
-    console.error(`⚠️  ${ kleur.red('Error embedding Twitch video') }
-  Eleventy plugin ${kleur.cyan('eleventy-plugin-embed-twitch')} requires a \`parent\` option to be set.
-  🔗  See ${kleur.cyan().underline('https://bit.ly/11ty-plugin-twitch-parent-error')} for details.`);
-}
-  
+    console.warn(
+			"", // Blank line for spacing, also works around console quirk in monorepo
+			"\n⚠️ \x1b[31mError embedding Twitch video",
+			"\nEleventy plugin '\x1b[36meleventy-plugin-embed-twitch\x1b[0m' requires a \`parent\` option to be set.",
+			"\n🔗  See \x1b[36m\x1b[4m'https://bit.ly/11ty-plugin-twitch-parent-error'\x1b[0m for details."
+		);
+	}
+
   // Build the string, using config data as we go
   // id based on channel or video id
   // TODO:
@@ -25,7 +26,7 @@ module.exports = function(media, options) {
   // intrinsic aspect ratio; currently hard-coded to 16:9
   // TODO: make configurable somehow
   out += `style="position:relative;width:100%;padding-top: 56.25%;">`;
-  
+
   out +=
     `<iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" `;
   out += `width="100%" height="100%" frameborder="0" scrolling="no" `;

--- a/packages/twitch/package.json
+++ b/packages/twitch/package.json
@@ -28,8 +28,5 @@
     "type": "git",
     "url": "https://github.com/gfscott/eleventy-plugin-embed-everything.git"
   },
-  "bugs": "https://github.com/gfscott/eleventy-plugin-embed-everything/issues",
-  "devDependencies": {
-    "kleur": "^4.1.5"
-  }
+  "bugs": "https://github.com/gfscott/eleventy-plugin-embed-everything/issues"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,13 +17,13 @@ importers:
         version: 1.2.0
       '@vitest/coverage-istanbul':
         specifier: ^3.2.4
-        version: 3.2.4(vitest@3.2.4(@types/node@24.2.1)(msw@2.10.4(@types/node@24.2.1)))
+        version: 3.2.4(vitest@3.2.4(@types/node@12.20.55)(msw@2.10.4(@types/node@12.20.55)))
       ava:
         specifier: ^6.4.1
         version: 6.4.1(rollup@4.46.2)
       msw:
         specifier: ^2.10.4
-        version: 2.10.4(@types/node@24.2.1)
+        version: 2.10.4(@types/node@12.20.55)
       nyc:
         specifier: ^17.1.0
         version: 17.1.0
@@ -35,7 +35,7 @@ importers:
         version: 2.5.5
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@24.2.1)(msw@2.10.4(@types/node@24.2.1))
+        version: 3.2.4(@types/node@12.20.55)(msw@2.10.4(@types/node@12.20.55))
 
   demo:
     devDependencies:
@@ -139,11 +139,7 @@ importers:
         specifier: ^6.0.1
         version: 6.0.1
 
-  packages/twitch:
-    devDependencies:
-      kleur:
-        specifier: ^4.1.5
-        version: 4.1.5
+  packages/twitch: {}
 
   packages/twitter:
     dependencies:
@@ -772,9 +768,6 @@ packages:
 
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
-
-  '@types/node@24.2.1':
-    resolution: {integrity: sha512-DRh5K+ka5eJic8CjH7td8QpYEV6Zo10gfRkjHCO3weqZHWDtAaSTFtl4+VMqOJ4N5jcuhZ9/l+yy8rVgw7BQeQ==}
 
   '@types/statuses@2.0.6':
     resolution: {integrity: sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==}
@@ -2446,9 +2439,6 @@ packages:
   uc.micro@2.1.0:
     resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
 
-  undici-types@7.10.0:
-    resolution: {integrity: sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==}
-
   unicorn-magic@0.3.0:
     resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
     engines: {node: '>=18'}
@@ -3108,17 +3098,17 @@ snapshots:
   '@esbuild/win32-x64@0.25.8':
     optional: true
 
-  '@inquirer/confirm@5.1.14(@types/node@24.2.1)':
+  '@inquirer/confirm@5.1.14(@types/node@12.20.55)':
     dependencies:
-      '@inquirer/core': 10.1.15(@types/node@24.2.1)
-      '@inquirer/type': 3.0.8(@types/node@24.2.1)
+      '@inquirer/core': 10.1.15(@types/node@12.20.55)
+      '@inquirer/type': 3.0.8(@types/node@12.20.55)
     optionalDependencies:
-      '@types/node': 24.2.1
+      '@types/node': 12.20.55
 
-  '@inquirer/core@10.1.15(@types/node@24.2.1)':
+  '@inquirer/core@10.1.15(@types/node@12.20.55)':
     dependencies:
       '@inquirer/figures': 1.0.13
-      '@inquirer/type': 3.0.8(@types/node@24.2.1)
+      '@inquirer/type': 3.0.8(@types/node@12.20.55)
       ansi-escapes: 4.3.2
       cli-width: 4.1.0
       mute-stream: 2.0.0
@@ -3126,13 +3116,13 @@ snapshots:
       wrap-ansi: 6.2.0
       yoctocolors-cjs: 2.1.2
     optionalDependencies:
-      '@types/node': 24.2.1
+      '@types/node': 12.20.55
 
   '@inquirer/figures@1.0.13': {}
 
-  '@inquirer/type@3.0.8(@types/node@24.2.1)':
+  '@inquirer/type@3.0.8(@types/node@12.20.55)':
     optionalDependencies:
-      '@types/node': 24.2.1
+      '@types/node': 12.20.55
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -3343,11 +3333,6 @@ snapshots:
 
   '@types/node@12.20.55': {}
 
-  '@types/node@24.2.1':
-    dependencies:
-      undici-types: 7.10.0
-    optional: true
-
   '@types/statuses@2.0.6': {}
 
   '@types/tough-cookie@4.0.5': {}
@@ -3371,7 +3356,7 @@ snapshots:
       - rollup
       - supports-color
 
-  '@vitest/coverage-istanbul@3.2.4(vitest@3.2.4(@types/node@24.2.1)(msw@2.10.4(@types/node@24.2.1)))':
+  '@vitest/coverage-istanbul@3.2.4(vitest@3.2.4(@types/node@12.20.55)(msw@2.10.4(@types/node@12.20.55)))':
     dependencies:
       '@istanbuljs/schema': 0.1.3
       debug: 4.4.1
@@ -3383,7 +3368,7 @@ snapshots:
       magicast: 0.3.5
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/node@24.2.1)(msw@2.10.4(@types/node@24.2.1))
+      vitest: 3.2.4(@types/node@12.20.55)(msw@2.10.4(@types/node@12.20.55))
     transitivePeerDependencies:
       - supports-color
 
@@ -3395,14 +3380,14 @@ snapshots:
       chai: 5.2.1
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(msw@2.10.4(@types/node@24.2.1))(vite@7.1.2(@types/node@24.2.1))':
+  '@vitest/mocker@3.2.4(msw@2.10.4(@types/node@12.20.55))(vite@7.1.2(@types/node@12.20.55))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      msw: 2.10.4(@types/node@24.2.1)
-      vite: 7.1.2(@types/node@24.2.1)
+      msw: 2.10.4(@types/node@12.20.55)
+      vite: 7.1.2(@types/node@12.20.55)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -4375,12 +4360,12 @@ snapshots:
 
   ms@2.1.3: {}
 
-  msw@2.10.4(@types/node@24.2.1):
+  msw@2.10.4(@types/node@12.20.55):
     dependencies:
       '@bundled-es-modules/cookie': 2.0.1
       '@bundled-es-modules/statuses': 1.0.1
       '@bundled-es-modules/tough-cookie': 0.1.6
-      '@inquirer/confirm': 5.1.14(@types/node@24.2.1)
+      '@inquirer/confirm': 5.1.14(@types/node@12.20.55)
       '@mswjs/interceptors': 0.39.5
       '@open-draft/deferred-promise': 2.2.0
       '@open-draft/until': 2.1.0
@@ -4951,9 +4936,6 @@ snapshots:
 
   uc.micro@2.1.0: {}
 
-  undici-types@7.10.0:
-    optional: true
-
   unicorn-magic@0.3.0: {}
 
   universalify@0.1.2: {}
@@ -4977,13 +4959,13 @@ snapshots:
 
   uuid@8.3.2: {}
 
-  vite-node@3.2.4(@types/node@24.2.1):
+  vite-node@3.2.4(@types/node@12.20.55):
     dependencies:
       cac: 6.7.14
       debug: 4.4.1
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.1.2(@types/node@24.2.1)
+      vite: 7.1.2(@types/node@12.20.55)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -4998,7 +4980,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@7.1.2(@types/node@24.2.1):
+  vite@7.1.2(@types/node@12.20.55):
     dependencies:
       esbuild: 0.25.8
       fdir: 6.4.6(picomatch@4.0.3)
@@ -5007,14 +4989,14 @@ snapshots:
       rollup: 4.46.2
       tinyglobby: 0.2.14
     optionalDependencies:
-      '@types/node': 24.2.1
+      '@types/node': 12.20.55
       fsevents: 2.3.3
 
-  vitest@3.2.4(@types/node@24.2.1)(msw@2.10.4(@types/node@24.2.1)):
+  vitest@3.2.4(@types/node@12.20.55)(msw@2.10.4(@types/node@12.20.55)):
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(msw@2.10.4(@types/node@24.2.1))(vite@7.1.2(@types/node@24.2.1))
+      '@vitest/mocker': 3.2.4(msw@2.10.4(@types/node@12.20.55))(vite@7.1.2(@types/node@12.20.55))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -5032,11 +5014,11 @@ snapshots:
       tinyglobby: 0.2.14
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.1.2(@types/node@24.2.1)
-      vite-node: 3.2.4(@types/node@24.2.1)
+      vite: 7.1.2(@types/node@12.20.55)
+      vite-node: 3.2.4(@types/node@12.20.55)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 24.2.1
+      '@types/node': 12.20.55
     transitivePeerDependencies:
       - jiti
       - less


### PR DESCRIPTION
This PR removes the `kleur` dependency, since it isn't really needed.