### PR TITLE
Replace AVA test runner with Node.js built-in test utilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,9 +29,7 @@
   "devDependencies": {
     "@svitejs/changesets-changelog-github-compact": "^1.2.0",
     "@vitest/coverage-istanbul": "^4.1.2",
-    "ava": "^7.0.0",
     "msw": "^2.12.14",
-    "nyc": "^18.0.0",
     "permute-arrays": "workspace:^",
     "vitest": "^4.1.2"
   },

--- a/packages/everything/package.json
+++ b/packages/everything/package.json
@@ -4,8 +4,8 @@
   "description": "An Eleventy plugin that allows you to quickly add common web embeds to markdown posts, using only their URLs",
   "main": ".eleventy.js",
   "scripts": {
-    "test": "npx ava",
-    "coverage": "nyc --reporter=lcov ava"
+    "test": "node --test",
+    "coverage": "node --test --experimental-test-coverage --test-reporter=lcov --test-reporter-destination=lcov.info"
   },
   "files": [
     ".eleventy.js",

--- a/packages/everything/test/test-configOptions.js
+++ b/packages/everything/test/test-configOptions.js
@@ -1,4 +1,5 @@
-const test = require("ava");
+const test = require("node:test");
+const assert = require("node:assert/strict");
 const config = require("../lib/configOptions.js");
 
 const defaultOptions = {
@@ -33,57 +34,57 @@ function clone(obj) {
 
 test(
 	"Config returns expected default output without input param",
-	(t) => {
+	() => {
 		let output = config();
-		t.deepEqual(output, defaultOptions);
+		assert.deepEqual(output, defaultOptions);
 	},
 );
 
 test(
 	"Config returns expected default output with empty config object param",
-	(t) => {
+	() => {
 		let output = config({});
-		t.deepEqual(output, defaultOptions);
+		assert.deepEqual(output, defaultOptions);
 	},
 );
 
 test(
 	`Config returns default output with invalid "add" option`,
-	(t) => {
+	() => {
 		let output = config({
 			add: ["wrong"],
 		});
-		t.deepEqual(output, defaultOptions);
+		assert.deepEqual(output, defaultOptions);
 	},
 );
 
 test(
 	`Config returns expected output with valid "add" option`,
-	(t) => {
+	() => {
 		let output = config({
 			add: ["soundcloud"],
 		});
 		let expected = clone(defaultOptions);
 		expected.activePlugins = [...expected.activePlugins, "soundcloud"].sort();
 		expected.activePluginOptions.soundcloud = {options: {}};
-		t.deepEqual(output, expected);
+		assert.deepEqual(output, expected);
 	},
 );
 
 test(
 	`Config "add" option returns deduplicated output when adding plugins already included by default`,
-	(t) => {
+	() => {
 		let output = config({
 			// These are already active by default, so `add`ing should do nothing
 			add: ["youtube", "vimeo"],
 		});
-		t.deepEqual(output, defaultOptions);
+		assert.deepEqual(output, defaultOptions);
 	},
 )
 
 test(
 	`Config returns expected output with valid "use" option`,
-	(t) => {
+	() => {
 		let output = config({
 			use: ["vimeo", "youtube"],
 		});
@@ -94,13 +95,13 @@ test(
 				youtube: {options: {}},
 			},
 		};
-		t.deepEqual(output, expected);
+		assert.deepEqual(output, expected);
 	},
 );
 
 test(
 	`Config "use" option overrides valid "add" option as expected`,
-	(t) => {
+	() => {
 		let output = config({
 			add: ["soundcloud"],
 			use: ["vimeo", "youtube"],
@@ -112,13 +113,13 @@ test(
 				youtube: {options: {}},
 			},
 		};
-		t.deepEqual(output, expected);
+		assert.deepEqual(output, expected);
 	},
 );
 
 test(
 	`Config "use" option overrides invalid "add" option as expected`,
-	(t) => {
+	() => {
 		let output = config({
 			add: ["wrong"],
 			use: ["vimeo", "youtube"],
@@ -130,13 +131,13 @@ test(
 				youtube: {options: {}},
 			},
 		};
-		t.deepEqual(output, expected);
+		assert.deepEqual(output, expected);
 	},
 );
 
 test(
 	"Passing an option to a plugin produces expected config output",
-	(t) => {
+	() => {
 		let output = config({
 			youtube: {
 				options: {
@@ -146,13 +147,13 @@ test(
 		});
 		let expected = clone(defaultOptions);
 		expected.activePluginOptions.youtube.options.lite = true;
-		t.deepEqual(output, expected);
+		assert.deepEqual(output, expected);
 	},
 );
 
 test(
 	"Passing an option to a plugin produces expected output",
-	(t) => {
+	() => {
 		let output = config({
 			twitter: {
 				options: {
@@ -162,13 +163,13 @@ test(
 		});
 		let expected = clone(defaultOptions);
 		expected.activePluginOptions.twitter.options.cacheText = true;
-		t.deepEqual(output, expected);
+		assert.deepEqual(output, expected);
 	},
 );
 
 test(
 	"Passing an option to a subset of plugins produces expected output",
-	(t) => {
+	() => {
 		let output = config({
 			use: ["soundcloud"],
 			soundcloud: {
@@ -187,13 +188,13 @@ test(
 				},
 			},
 		};
-		t.deepEqual(output, expected);
+		assert.deepEqual(output, expected);
 	},
 );
 
 test(
 	"Config does not return options for invalid/nonexistent plugins",
-	(t) => {
+	() => {
 		let output = config({
 			use: ["soundcloud"],
 			soundcloud: {options: {small: true}},
@@ -205,13 +206,13 @@ test(
 				soundcloud: {options: {small: true}},
 			},
 		};
-		t.deepEqual(output, expected);
+		assert.deepEqual(output, expected);
 	},
 );
 
 test(
 	"Config does not return options for valid but unused plugins",
-	(t) => {
+	() => {
 		let output = config({
 			use: ["soundcloud"],
 			soundcloud: {options: {small: true}},
@@ -223,13 +224,13 @@ test(
 				soundcloud: {options: {small: true}},
 			},
 		};
-		t.deepEqual(output, expected);
+		assert.deepEqual(output, expected);
 	},
 );
 
 test(
 	"Config returns expected output when adding a plugin and passing options",
-	(t) => {
+	() => {
 		let output = config({
 			add: ["soundcloud"],
 			soundcloud: {options: {small: true}},
@@ -237,6 +238,6 @@ test(
 		let expected = clone(defaultOptions);
 		expected.activePlugins = [...expected.activePlugins, "soundcloud"].sort();
 		expected.activePluginOptions.soundcloud = {options: {small: true}};
-		t.deepEqual(output, expected);
+		assert.deepEqual(output, expected);
 	},
 );

--- a/packages/everything/test/test-validatePlugins.js
+++ b/packages/everything/test/test-validatePlugins.js
@@ -1,67 +1,68 @@
-const test = require("ava");
+const test = require("node:test");
+const assert = require("node:assert/strict");
 const validatePlugins = require("../lib/validatePlugins.js");
 const {defaultPlugins, validPlugins} = require("../lib/pluginDefaults.js");
 
 test(
 	"Validator returns expected default plugin array",
-	(t) => {
+	() => {
 		let output = validatePlugins(defaultPlugins);
-		t.deepEqual(output, defaultPlugins);
+		assert.deepEqual(output, defaultPlugins);
 	},
 );
 
 test(
 	"Validator rejects invalid plugin strings, returns defaults",
-	(t) => {
+	() => {
 		let list = [...defaultPlugins, "wrong"];
 		let output = validatePlugins(list);
-		t.deepEqual(output, defaultPlugins);
+		assert.deepEqual(output, defaultPlugins);
 	},
 );
 
 test(
 	"Validator accepts valid non-default plugin string",
-	(t) => {
+	() => {
 		let list = [...defaultPlugins, "soundcloud"];
 		let output = validatePlugins(list);
 		for (let p of output) {
-			t.true(validPlugins.includes(p));
+			assert.ok(validPlugins.includes(p));
 		}
 	},
 );
 
 test(
 	"Validator returns non-alphabetical list in alphabetical order",
-	(t) => {
+	() => {
 		let list = ["youtube", "vimeo", "twitter"];
 		let output = validatePlugins(list);
-		t.deepEqual(output, ["twitter", "vimeo", "youtube"]);
+		assert.deepEqual(output, ["twitter", "vimeo", "youtube"]);
 	},
 );
 
 test(
 	"Validator returns expected valid plugin list subset",
-	(t) => {
+	() => {
 		let list = ["instagram", "soundcloud", "spotify"];
 		let output = validatePlugins(list);
-		t.deepEqual(output, list);
+		assert.deepEqual(output, list);
 	},
 );
 
 test(
 	"Validator returns expected subset, but rejects invalid plugin",
-	(t) => {
+	() => {
 		let list = ["instagram", "spotify", "wrong"];
 		let output = validatePlugins(list);
-		t.deepEqual(output, ["instagram", "spotify"]);
+		assert.deepEqual(output, ["instagram", "spotify"]);
 	},
 );
 
 test(
 	"Validator rejects non-string array items",
-	(t) => {
+	() => {
 		let list = [false, "instagram", "spotify", true, 123, {foo: "bar"}];
 		let output = validatePlugins(list);
-		t.deepEqual(output, ["instagram", "spotify"]);
+		assert.deepEqual(output, ["instagram", "spotify"]);
 	},
 );

--- a/packages/openstreetmap/package.json
+++ b/packages/openstreetmap/package.json
@@ -10,8 +10,8 @@
   ],
   "main": "index.js",
   "scripts": {
-    "test": "npx ava",
-    "coverage": "nyc --reporter=lcov ava"
+    "test": "node --test",
+    "coverage": "node --test --experimental-test-coverage --test-reporter=lcov --test-reporter-destination=lcov.info"
   },
   "files": [
     "index.js",

--- a/packages/openstreetmap/test/pattern.test.mjs
+++ b/packages/openstreetmap/test/pattern.test.mjs
@@ -1,4 +1,5 @@
-import test from 'ava';
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
 import pattern from '../lib/pattern.js';
 import permuteArrays from 'permute-arrays';
 
@@ -14,16 +15,16 @@ const suffixes = [
 const validUrls = new Set(permuteArrays(base, prefixes, suffixes).slice(prefixes.length))
 
 for (let url of validUrls) {
-  test(`${url} is a valid URL`, t => {
+  test(`${url} is a valid URL`, () => {
     pattern.lastIndex = 0;
-    t.regex(`<p>${url}</p>`, pattern);
+    assert.match(`<p>${url}</p>`, pattern);
   });
 
-  test(`Expected values extracted from ${url}`, t => {
+  test(`Expected values extracted from ${url}`, () => {
     pattern.lastIndex = 0;
     const { groups: { zoom, lat, long } } = pattern.exec(`<p>${url}</p>`);
-    t.is(zoom, '8');
-    t.is(lat, '46.195');
-    t.is(long, '-81.362');
+    assert.equal(zoom, '8');
+    assert.equal(lat, '46.195');
+    assert.equal(long, '-81.362');
   })
 }

--- a/packages/openstreetmap/test/replace.test.mjs
+++ b/packages/openstreetmap/test/replace.test.mjs
@@ -1,9 +1,10 @@
-import test from 'ava';
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
 import pattern from '../lib/pattern.js';
 import replace from '../lib/replace.js';
 import { getBoundingBox } from '../lib/replace.js';
 
-test('Custom bounding box calculation is within acceptable variance from OSM', t => {
+test('Custom bounding box calculation is within acceptable variance from OSM', () => {
 
   // These are values produced by the OSM embed service
   const expected = {
@@ -30,44 +31,44 @@ test('Custom bounding box calculation is within acceptable variance from OSM', t
   // https://github.com/openstreetmap/openstreetmap-website/blob/master/lib/bounding_box.rb
   const acceptableDrift = 0.01;
 
-  t.is(Math.abs(long_s - expected.long_s) < acceptableDrift, true);
-  t.is(Math.abs(lat_e - expected.lat_e) < acceptableDrift, true);
-  t.is(Math.abs(long_e - expected.long_e) < acceptableDrift, true);
-  t.is(Math.abs(lat_s - expected.lat_s) < acceptableDrift, true);
+  assert.equal(Math.abs(long_s - expected.long_s) < acceptableDrift, true);
+  assert.equal(Math.abs(lat_e - expected.lat_e) < acceptableDrift, true);
+  assert.equal(Math.abs(long_e - expected.long_e) < acceptableDrift, true);
+  assert.equal(Math.abs(lat_s - expected.lat_s) < acceptableDrift, true);
 
 });
 
-test('Input produces expected output with default options', t => {
+test('Input produces expected output with default options', () => {
   const input = '<p>https://www.openstreetmap.org/#map=11/47.9012/106.8911</p>';
   const output = input.replace(pattern, (...match) => replace(match));
   const expected = '<div class="eleventy-plugin-embed-openstreetmap" style="aspect-ratio: 16/9"><iframe width="100%" height="100%" frameborder="0" src="https://www.openstreetmap.org/export/embed.html?bbox=106.59927565917968%2C47.73983206904563%2C107.1829243408203%2C48.06206649357146&layer=mapnik"></iframe></div>';
-  t.is(output, expected);
+  assert.equal(output, expected);
 });
 
-test('Input produces expected output with custom class name', t => {
+test('Input produces expected output with custom class name', () => {
   const input = '<p>https://www.openstreetmap.org/#map=11/47.9012/106.8911</p>';
   const output = input.replace(pattern, (...match) => replace(match, {embedClass: 'foo'}));
   const expected = '<div class="foo" style="aspect-ratio: 16/9"><iframe width="100%" height="100%" frameborder="0" src="https://www.openstreetmap.org/export/embed.html?bbox=106.59927565917968%2C47.73983206904563%2C107.1829243408203%2C48.06206649357146&layer=mapnik"></iframe></div>';
-  t.is(output, expected);
+  assert.equal(output, expected);
 });
 
-test('Input produces expected output with custom wrapper style', t => {
+test('Input produces expected output with custom wrapper style', () => {
   const input = '<p>https://www.openstreetmap.org/#map=11/47.9012/106.8911</p>';
   const output = input.replace(pattern, (...match) => replace(match, { wrapperStyle: 'width: 100%; height: 500px;' }));
   const expected = '<div class="eleventy-plugin-embed-openstreetmap" style="width: 100%; height: 500px;"><iframe width="100%" height="100%" frameborder="0" src="https://www.openstreetmap.org/export/embed.html?bbox=106.59927565917968%2C47.73983206904563%2C107.1829243408203%2C48.06206649357146&layer=mapnik"></iframe></div>';
-  t.is(output, expected);
+  assert.equal(output, expected);
 });
 
-test('Input produces expected output with custom map layer', t => {
+test('Input produces expected output with custom map layer', () => {
   const input = '<p>https://www.openstreetmap.org/#map=11/47.9012/106.8911</p>';
   const output = input.replace(pattern, (...match) => replace(match, {layer: 'cycle'}));
   const expected = '<div class="eleventy-plugin-embed-openstreetmap" style="aspect-ratio: 16/9"><iframe width="100%" height="100%" frameborder="0" src="https://www.openstreetmap.org/export/embed.html?bbox=106.59927565917968%2C47.73983206904563%2C107.1829243408203%2C48.06206649357146&layer=cycle"></iframe></div>';
-  t.is(output, expected);
+  assert.equal(output, expected);
 });
 
-test('Input produces expected output with marker option active', t => {
+test('Input produces expected output with marker option active', () => {
   const input = '<p>https://www.openstreetmap.org/#map=11/47.9012/106.8911</p>';
   const output = input.replace(pattern, (...match) => replace(match, {includeMarker: true}));
   const expected = '<div class="eleventy-plugin-embed-openstreetmap" style="aspect-ratio: 16/9"><iframe width="100%" height="100%" frameborder="0" src="https://www.openstreetmap.org/export/embed.html?bbox=106.59927565917968%2C47.73983206904563%2C107.1829243408203%2C48.06206649357146&layer=mapnik&marker=47.9012%2C106.8911"></iframe></div>';
-  t.is(output, expected);
+  assert.equal(output, expected);
 });

--- a/packages/soundcloud/package.json
+++ b/packages/soundcloud/package.json
@@ -10,8 +10,8 @@
   ],
   "main": ".eleventy.js",
   "scripts": {
-    "test": "npx ava",
-    "coverage": "nyc --reporter=lcov ava"
+    "test": "node --test",
+    "coverage": "node --test --experimental-test-coverage --test-reporter=lcov --test-reporter-destination=lcov.info"
   },
   "files": [
     ".eleventy.js",

--- a/packages/soundcloud/test/getEmbed.test.mjs
+++ b/packages/soundcloud/test/getEmbed.test.mjs
@@ -1,4 +1,5 @@
-import test from 'ava';
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
 import getEmbed from '../lib/getEmbed.js';
 import pluginDefaults from '../lib/pluginDefaults.js';
 
@@ -20,40 +21,40 @@ const expectedSetOutput_sm = '<div class="eleventy-plugin-embed-soundcloud"><ifr
  * For the three supported URL types, check that the plugin produces 
  * the expected markup
  */
-test(`Artist URL`, async t => {
+test(`Artist URL`, async () => {
   let out = await getEmbed(artistUrl, pluginDefaults);
-  t.is(out, expectedArtistOutput);
+  assert.equal(out, expectedArtistOutput);
 });
-test(`Track URL`, async t => {
+test(`Track URL`, async () => {
   let out = await getEmbed(trackUrl, pluginDefaults);
-  t.is(out, expectedTrackOutput);
+  assert.equal(out, expectedTrackOutput);
 });
-test(`Set URL`, async t => {
+test(`Set URL`, async () => {
   let out = await getEmbed(setUrl, pluginDefaults);
-  t.is(out, expectedSetOutput);
+  assert.equal(out, expectedSetOutput);
 });
 
 /**
  * For the three supported URL types, check that the plugin produces 
  * the expected markup with the "small" embed type specified
  */
-test(`Artist URL, small version`, async t => {
+test(`Artist URL, small version`, async () => {
   let out = await getEmbed(artistUrl, smallPlayer);
-  t.is(out, expectedArtistOutput_sm);
+  assert.equal(out, expectedArtistOutput_sm);
 });
-test(`Track URL, small version`, async t => {
+test(`Track URL, small version`, async () => {
   let out = await getEmbed(trackUrl, smallPlayer);
-  t.is(out, expectedTrackOutput_sm);
+  assert.equal(out, expectedTrackOutput_sm);
 });
-test(`Set URL, small version`, async t => {
+test(`Set URL, small version`, async () => {
   let out = await getEmbed(setUrl, smallPlayer);
-  t.is(out, expectedSetOutput_sm);
+  assert.equal(out, expectedSetOutput_sm);
 });
 
 /**
  * On request failure, return the URL unchanged
  */
-test(`oEmbed fetch failure`, async t => {
+test(`oEmbed fetch failure`, async () => {
   let out = await getEmbed(badUrl, pluginDefaults);
-  t.is(out, badUrl);
+  assert.equal(out, badUrl);
 });

--- a/packages/soundcloud/test/test-spotPattern.mjs
+++ b/packages/soundcloud/test/test-spotPattern.mjs
@@ -1,4 +1,5 @@
-import test from 'ava';
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
 import spotPattern from '../lib/spotPattern.js';
 import validUrls from './_validUrls.mjs';
 import invalidUrls from './_invalidUrls.mjs';
@@ -13,22 +14,22 @@ import invalidUrls from './_invalidUrls.mjs';
  */
 for (let [index, url] of validUrls.entries()) {
   
-  test(`Valid-${index}: without link, without whitespace`, t => {
-    t.truthy(spotPattern(`<p>${url}</p>`));
+  test(`Valid-${index}: without link, without whitespace`, () => {
+    assert.ok(spotPattern(`<p>${url}</p>`));
   }); 
   
-  test(`Valid-${index}: without link, with whitespace`, t => {
-    t.truthy(spotPattern(`<p>
+  test(`Valid-${index}: without link, with whitespace`, () => {
+    assert.ok(spotPattern(`<p>
       ${url}
     </p>`));
   }); 
   
-  test(`Valid-${index}: with link, without whitespace`, t => {
-    t.truthy(spotPattern(`<p><a href="${url}">${url}</a></p>`));
+  test(`Valid-${index}: with link, without whitespace`, () => {
+    assert.ok(spotPattern(`<p><a href="${url}">${url}</a></p>`));
   }); 
 
-  test(`Valid-${index}: with link, with whitespace`, t => {
-    t.truthy(spotPattern(`<p>
+  test(`Valid-${index}: with link, with whitespace`, () => {
+    assert.ok(spotPattern(`<p>
       <a href="${url}">
         ${url}
       </a>
@@ -47,22 +48,22 @@ for (let [index, url] of validUrls.entries()) {
  */
  for (let [index, url] of invalidUrls.entries()) {
   
-  test(`Invalid-${index}: without link, without whitespace`, t => {
-    t.falsy(spotPattern(`<p>${url}</p>`));
+  test(`Invalid-${index}: without link, without whitespace`, () => {
+    assert.ok(!spotPattern(`<p>${url}</p>`));
   }); 
   
-  test(`Invalid-${index}: without link, with whitespace`, t => {
-    t.falsy(spotPattern(`<p>
+  test(`Invalid-${index}: without link, with whitespace`, () => {
+    assert.ok(!spotPattern(`<p>
       ${url}
     </p>`));
   }); 
   
-  test(`Invalid-${index}: with link, without whitespace`, t => {
-    t.falsy(spotPattern(`<p><a href="${url}">${url}</a></p>`));
+  test(`Invalid-${index}: with link, without whitespace`, () => {
+    assert.ok(!spotPattern(`<p><a href="${url}">${url}</a></p>`));
   }); 
 
-  test(`Invalid-${index}: with link, with whitespace`, t => {
-    t.falsy(spotPattern(`<p>
+  test(`Invalid-${index}: with link, with whitespace`, () => {
+    assert.ok(!spotPattern(`<p>
       <a href="${url}">
         ${url}
       </a>

--- a/packages/spotify/package.json
+++ b/packages/spotify/package.json
@@ -10,19 +10,13 @@
   ],
   "main": "index.js",
   "scripts": {
-    "test": "npx ava",
-    "coverage": "nyc --reporter=lcov ava"
+    "test": "node --test",
+    "coverage": "node --test --experimental-test-coverage --test-reporter=lcov --test-reporter-destination=lcov.info"
   },
   "files": [
     "index.js",
     "lib/**"
   ],
-  "ava": {
-    "files": [
-      "!test/inc",
-      "!test/html"
-    ]
-  },
   "author": {
     "name": "Graham F. Scott",
     "email": "gfscott@gmail.com",

--- a/packages/spotify/test/pattern.test.mjs
+++ b/packages/spotify/test/pattern.test.mjs
@@ -1,39 +1,40 @@
-import test from 'ava';
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
 import pattern from '../lib/pattern.js';
 import { all } from './_validUrls.mjs';
 
 for (let [index, url] of all.entries()) {
-  
-  test(`Regex test ${index}-a: ${url}`, async t => {
+
+  test(`Regex test ${index}-a: ${url}`, async () => {
     // The whole deal with `lastIndex`:
     // https://github.com/gfscott/eleventy-plugin-embed-everything/blob/2bbe639177606deead2f9583d9c34f5557727f6d/packages/ted/test/pattern.test.js#L8-L30
     pattern.lastIndex = 0;
     let str = `<p>${url}</p>`
-    t.regex(str, pattern);
+    assert.match(str, pattern);
   });
 
-  test(`Regex test ${index}-b: ${url}, with whitespace`, async t => {
+  test(`Regex test ${index}-b: ${url}, with whitespace`, async () => {
     pattern.lastIndex = 0;
     let str = `<p>
                 ${url}
               </p>`
-    t.regex(str, pattern);
+    assert.match(str, pattern);
   });
 
-  test(`Regex test ${index}-c: ${url}, with link`, async t => {
+  test(`Regex test ${index}-c: ${url}, with link`, async () => {
     pattern.lastIndex = 0;
     let str = `<p><a href="${url}">${url}</a></p>`
-    t.regex(str, pattern);
+    assert.match(str, pattern);
   });
 
-  test(`Regex test ${index}-d: ${url}, with link and whitespace`, async t => {
+  test(`Regex test ${index}-d: ${url}, with link and whitespace`, async () => {
     pattern.lastIndex = 0;
     let str = `<p>
                 <a href="${url}">
                   ${url}
                 </a>
               </p>`
-    t.regex(str, pattern);
+    assert.match(str, pattern);
   });
 
   /**
@@ -42,23 +43,23 @@ for (let [index, url] of all.entries()) {
    * @see https://github.com/avajs/ava/blob/main/docs/03-assertions.md#notregexcontents-regex-message
    */
 
-  test(`Regex test ${index}-e: ${url}, with invalid prepended text`, async t => {
+  test(`Regex test ${index}-e: ${url}, with invalid prepended text`, async () => {
     pattern.lastIndex = 0;
     let str = `<p>foo ${url}</p>`
-    t.notRegex(str, pattern);
+    assert.doesNotMatch(str, pattern);
   })
 
-  test(`Regex test ${index}-e: ${url}, with invalid appended text`, async t => {
+  test(`Regex test ${index}-e: ${url}, with invalid appended text`, async () => {
     pattern.lastIndex = 0;
     let str = `<p>${url} foo</p>`
-    t.notRegex(str, pattern);
+    assert.doesNotMatch(str, pattern);
   })
 
-  test(`Regex test ${index}-e: ${url}, with invalid ID length`, async t => {
+  test(`Regex test ${index}-e: ${url}, with invalid ID length`, async () => {
     pattern.lastIndex = 0;
     // Remove the last 14 characters from the URL. This accounts for the
     // variants that have URL parameters, which max out at 12 characters.
     let str = `<p>${url.slice(0, -14)}</p>`
-    t.notRegex(str, pattern);
+    assert.doesNotMatch(str, pattern);
   })
 }

--- a/packages/spotify/test/replace.test.mjs
+++ b/packages/spotify/test/replace.test.mjs
@@ -1,4 +1,5 @@
-import test from 'ava';
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
 import defaults from '../lib/defaults.js';
 import pattern from '../lib/pattern.js';
 import replace from '../lib/replace.js';
@@ -19,16 +20,16 @@ const allStrings = {
  */
 for (let [index, str] of allStrings.album.entries()) {
 
-  test(`${index}: Embed album, default options`, async t => {
+  test(`${index}: Embed album, default options`, async () => {
     const config = Object.assign({}, defaults, {});
     let embed = str.replace(pattern, (...match) => replace(match, config));
-    t.is(embed, '<div id="spotify-album-75qojmHz1id8sL2LDR5qVz" class="eleventy-plugin-embed-spotify eleventy-plugin-embed-spotify-album"><iframe style="border-radius:12px;" title="Spotify album" src="https://open.spotify.com/embed/album/75qojmHz1id8sL2LDR5qVz" width="100%" height="352" frameborder="0" allowtransparency="true" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe></div>')
+    assert.equal(embed, '<div id="spotify-album-75qojmHz1id8sL2LDR5qVz" class="eleventy-plugin-embed-spotify eleventy-plugin-embed-spotify-album"><iframe style="border-radius:12px;" title="Spotify album" src="https://open.spotify.com/embed/album/75qojmHz1id8sL2LDR5qVz" width="100%" height="352" frameborder="0" allowtransparency="true" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe></div>')
   })
 
-  test(`${index}: Embed album, custom options`, async t => {
+  test(`${index}: Embed album, custom options`, async () => {
     const config = Object.assign({}, defaults, {width: 300, height: 400, embedClass: 'custom-class', iframeStyle: 'border-radius: 0;'});
     let embed = str.replace(pattern, (...match) => replace(match, config));
-    t.is(embed, '<div id="spotify-album-75qojmHz1id8sL2LDR5qVz" class="custom-class custom-class-album"><iframe style="border-radius: 0;" title="Spotify album" src="https://open.spotify.com/embed/album/75qojmHz1id8sL2LDR5qVz" width="300" height="400" frameborder="0" allowtransparency="true" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe></div>')
+    assert.equal(embed, '<div id="spotify-album-75qojmHz1id8sL2LDR5qVz" class="custom-class custom-class-album"><iframe style="border-radius: 0;" title="Spotify album" src="https://open.spotify.com/embed/album/75qojmHz1id8sL2LDR5qVz" width="300" height="400" frameborder="0" allowtransparency="true" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe></div>')
   })
 
 }
@@ -41,13 +42,13 @@ for (let [index, str] of allStrings.artist.entries()) {
   test(`${index}: Embed artist, default options`, async t => {
     const config = Object.assign({}, defaults, {});
     let embed = str.replace(pattern, (...match) => replace(match, config));
-    t.is(embed, '<div id="spotify-artist-066X20Nz7iquqkkCW6Jxy6" class="eleventy-plugin-embed-spotify eleventy-plugin-embed-spotify-artist"><iframe style="border-radius:12px;" title="Spotify artist" src="https://open.spotify.com/embed/artist/066X20Nz7iquqkkCW6Jxy6" width="100%" height="352" frameborder="0" allowtransparency="true" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe></div>')
+    assert.equal(embed, '<div id="spotify-artist-066X20Nz7iquqkkCW6Jxy6" class="eleventy-plugin-embed-spotify eleventy-plugin-embed-spotify-artist"><iframe style="border-radius:12px;" title="Spotify artist" src="https://open.spotify.com/embed/artist/066X20Nz7iquqkkCW6Jxy6" width="100%" height="352" frameborder="0" allowtransparency="true" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe></div>')
   })
 
   test(`${index}: Embed artist, custom options`, async t => {
     const config = Object.assign({}, defaults, {width: 300, height: 400, embedClass: 'custom-class', iframeStyle: 'border-radius: 0;'});
     let embed = str.replace(pattern, (...match) => replace(match, config));
-    t.is(embed, '<div id="spotify-artist-066X20Nz7iquqkkCW6Jxy6" class="custom-class custom-class-artist"><iframe style="border-radius: 0;" title="Spotify artist" src="https://open.spotify.com/embed/artist/066X20Nz7iquqkkCW6Jxy6" width="300" height="400" frameborder="0" allowtransparency="true" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe></div>')
+    assert.equal(embed, '<div id="spotify-artist-066X20Nz7iquqkkCW6Jxy6" class="custom-class custom-class-artist"><iframe style="border-radius: 0;" title="Spotify artist" src="https://open.spotify.com/embed/artist/066X20Nz7iquqkkCW6Jxy6" width="300" height="400" frameborder="0" allowtransparency="true" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe></div>')
   })
 }
 
@@ -59,13 +60,13 @@ for (let [index, str] of allStrings.playlist.entries()) {
   test(`${index}: Embed playlist, default options`, async t => {
     const config = Object.assign({}, defaults, {});
     let embed = str.replace(pattern, (...match) => replace(match, config));
-    t.is(embed, '<div id="spotify-playlist-7zv2xFPTH1MBynYafuvtCj" class="eleventy-plugin-embed-spotify eleventy-plugin-embed-spotify-playlist"><iframe style="border-radius:12px;" title="Spotify playlist" src="https://open.spotify.com/embed/playlist/7zv2xFPTH1MBynYafuvtCj" width="100%" height="352" frameborder="0" allowtransparency="true" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe></div>')
+    assert.equal(embed, '<div id="spotify-playlist-7zv2xFPTH1MBynYafuvtCj" class="eleventy-plugin-embed-spotify eleventy-plugin-embed-spotify-playlist"><iframe style="border-radius:12px;" title="Spotify playlist" src="https://open.spotify.com/embed/playlist/7zv2xFPTH1MBynYafuvtCj" width="100%" height="352" frameborder="0" allowtransparency="true" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe></div>')
   })
 
   test(`${index}: Embed playlist, custom options`, async t => {
     const config = Object.assign({}, defaults, {width: 300, height: 400, embedClass: 'custom-class', iframeStyle: 'border-radius: 0;'});
     let embed = str.replace(pattern, (...match) => replace(match, config));
-    t.is(embed, '<div id="spotify-playlist-7zv2xFPTH1MBynYafuvtCj" class="custom-class custom-class-playlist"><iframe style="border-radius: 0;" title="Spotify playlist" src="https://open.spotify.com/embed/playlist/7zv2xFPTH1MBynYafuvtCj" width="300" height="400" frameborder="0" allowtransparency="true" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe></div>')
+    assert.equal(embed, '<div id="spotify-playlist-7zv2xFPTH1MBynYafuvtCj" class="custom-class custom-class-playlist"><iframe style="border-radius: 0;" title="Spotify playlist" src="https://open.spotify.com/embed/playlist/7zv2xFPTH1MBynYafuvtCj" width="300" height="400" frameborder="0" allowtransparency="true" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe></div>')
   })
 }
 
@@ -77,13 +78,13 @@ for (let [index, str] of allStrings.userPlaylist.entries()) {
   test(`${index}: Embed user playlist, default options`, async t => {
     const config = Object.assign({}, defaults, {});
     let embed = str.replace(pattern, (...match) => replace(match, config));
-    t.is(embed, '<div id="spotify-playlist-7zv2xFPTH1MBynYafuvtCj" class="eleventy-plugin-embed-spotify eleventy-plugin-embed-spotify-playlist"><iframe style="border-radius:12px;" title="Spotify playlist" src="https://open.spotify.com/embed/playlist/7zv2xFPTH1MBynYafuvtCj" width="100%" height="352" frameborder="0" allowtransparency="true" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe></div>')
+    assert.equal(embed, '<div id="spotify-playlist-7zv2xFPTH1MBynYafuvtCj" class="eleventy-plugin-embed-spotify eleventy-plugin-embed-spotify-playlist"><iframe style="border-radius:12px;" title="Spotify playlist" src="https://open.spotify.com/embed/playlist/7zv2xFPTH1MBynYafuvtCj" width="100%" height="352" frameborder="0" allowtransparency="true" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe></div>')
   })
 
   test(`${index}: Embed user playlist, custom options`, async t => {
     const config = Object.assign({}, defaults, {width: 300, height: 400, embedClass: 'custom-class', iframeStyle: 'border-radius: 0;'});
     let embed = str.replace(pattern, (...match) => replace(match, config));
-    t.is(embed, '<div id="spotify-playlist-7zv2xFPTH1MBynYafuvtCj" class="custom-class custom-class-playlist"><iframe style="border-radius: 0;" title="Spotify playlist" src="https://open.spotify.com/embed/playlist/7zv2xFPTH1MBynYafuvtCj" width="300" height="400" frameborder="0" allowtransparency="true" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe></div>')
+    assert.equal(embed, '<div id="spotify-playlist-7zv2xFPTH1MBynYafuvtCj" class="custom-class custom-class-playlist"><iframe style="border-radius: 0;" title="Spotify playlist" src="https://open.spotify.com/embed/playlist/7zv2xFPTH1MBynYafuvtCj" width="300" height="400" frameborder="0" allowtransparency="true" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe></div>')
   })
 }
 
@@ -96,13 +97,13 @@ for (let [index, str] of allStrings.track.entries()) {
   test(`${index}: Embed track, default options`, async t => {
     const config = Object.assign({}, defaults, {});
     let embed = str.replace(pattern, (...match) => replace(match, config));
-    t.is(embed, '<div id="spotify-track-3gsCAGsWr6pUm1Vy7CPPob" class="eleventy-plugin-embed-spotify eleventy-plugin-embed-spotify-track"><iframe style="border-radius:12px;" title="Spotify track" src="https://open.spotify.com/embed/track/3gsCAGsWr6pUm1Vy7CPPob" width="100%" height="352" frameborder="0" allowtransparency="true" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe></div>')
+    assert.equal(embed, '<div id="spotify-track-3gsCAGsWr6pUm1Vy7CPPob" class="eleventy-plugin-embed-spotify eleventy-plugin-embed-spotify-track"><iframe style="border-radius:12px;" title="Spotify track" src="https://open.spotify.com/embed/track/3gsCAGsWr6pUm1Vy7CPPob" width="100%" height="352" frameborder="0" allowtransparency="true" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe></div>')
   })
 
   test(`${index}: Embed track, custom options`, async t => {
     const config = Object.assign({}, defaults, {width: 300, height: 400, embedClass: 'custom-class', iframeStyle: 'border-radius: 0;'});
     let embed = str.replace(pattern, (...match) => replace(match, config));
-    t.is(embed, '<div id="spotify-track-3gsCAGsWr6pUm1Vy7CPPob" class="custom-class custom-class-track"><iframe style="border-radius: 0;" title="Spotify track" src="https://open.spotify.com/embed/track/3gsCAGsWr6pUm1Vy7CPPob" width="300" height="400" frameborder="0" allowtransparency="true" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe></div>')
+    assert.equal(embed, '<div id="spotify-track-3gsCAGsWr6pUm1Vy7CPPob" class="custom-class custom-class-track"><iframe style="border-radius: 0;" title="Spotify track" src="https://open.spotify.com/embed/track/3gsCAGsWr6pUm1Vy7CPPob" width="300" height="400" frameborder="0" allowtransparency="true" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe></div>')
   })
 }
 
@@ -115,13 +116,13 @@ for (let [index, str] of allStrings.episode.entries()) {
   test(`${index}: Embed episode, default options`, async t => {
     const config = Object.assign({}, defaults, {});
     let embed = str.replace(pattern, (...match) => replace(match, config));
-    t.is(embed, '<div id="spotify-episode-7G5O2wWmch1ciYDPZS4a4O" class="eleventy-plugin-embed-spotify eleventy-plugin-embed-spotify-episode"><iframe style="border-radius:12px;" title="Spotify episode" src="https://open.spotify.com/embed/episode/7G5O2wWmch1ciYDPZS4a4O" width="100%" height="352" frameborder="0" allowtransparency="true" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe></div>')
+    assert.equal(embed, '<div id="spotify-episode-7G5O2wWmch1ciYDPZS4a4O" class="eleventy-plugin-embed-spotify eleventy-plugin-embed-spotify-episode"><iframe style="border-radius:12px;" title="Spotify episode" src="https://open.spotify.com/embed/episode/7G5O2wWmch1ciYDPZS4a4O" width="100%" height="352" frameborder="0" allowtransparency="true" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe></div>')
   })
 
   test(`${index}: Embed episode, custom options`, async t => {
     const config = Object.assign({}, defaults, {width: 300, height: 400, embedClass: 'custom-class', iframeStyle: 'border-radius: 0;'});
     let embed = str.replace(pattern, (...match) => replace(match, config));
-    t.is(embed, '<div id="spotify-episode-7G5O2wWmch1ciYDPZS4a4O" class="custom-class custom-class-episode"><iframe style="border-radius: 0;" title="Spotify episode" src="https://open.spotify.com/embed/episode/7G5O2wWmch1ciYDPZS4a4O" width="300" height="400" frameborder="0" allowtransparency="true" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe></div>')
+    assert.equal(embed, '<div id="spotify-episode-7G5O2wWmch1ciYDPZS4a4O" class="custom-class custom-class-episode"><iframe style="border-radius: 0;" title="Spotify episode" src="https://open.spotify.com/embed/episode/7G5O2wWmch1ciYDPZS4a4O" width="300" height="400" frameborder="0" allowtransparency="true" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe></div>')
   })
 
 }
@@ -134,13 +135,13 @@ for (let [index, str] of allStrings.show.entries()) {
   test(`${index}: Embed show, default options`, async t => {
     const config = Object.assign({}, defaults, {});
     let embed = str.replace(pattern, (...match) => replace(match, config));
-    t.is(embed, '<div id="spotify-show-3rDR8CfpIEMpITG2UC3w5W" class="eleventy-plugin-embed-spotify eleventy-plugin-embed-spotify-show"><iframe style="border-radius:12px;" title="Spotify show" src="https://open.spotify.com/embed/show/3rDR8CfpIEMpITG2UC3w5W" width="100%" height="352" frameborder="0" allowtransparency="true" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe></div>')
+    assert.equal(embed, '<div id="spotify-show-3rDR8CfpIEMpITG2UC3w5W" class="eleventy-plugin-embed-spotify eleventy-plugin-embed-spotify-show"><iframe style="border-radius:12px;" title="Spotify show" src="https://open.spotify.com/embed/show/3rDR8CfpIEMpITG2UC3w5W" width="100%" height="352" frameborder="0" allowtransparency="true" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe></div>')
   })
 
   test(`${index}: Embed show, custom options`, async t => {
     const config = Object.assign({}, defaults, {width: 300, height: 400, embedClass: 'custom-class', iframeStyle: 'border-radius: 0;'});
     let embed = str.replace(pattern, (...match) => replace(match, config));
-    t.is(embed, '<div id="spotify-show-3rDR8CfpIEMpITG2UC3w5W" class="custom-class custom-class-show"><iframe style="border-radius: 0;" title="Spotify show" src="https://open.spotify.com/embed/show/3rDR8CfpIEMpITG2UC3w5W" width="300" height="400" frameborder="0" allowtransparency="true" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe></div>')
+    assert.equal(embed, '<div id="spotify-show-3rDR8CfpIEMpITG2UC3w5W" class="custom-class custom-class-show"><iframe style="border-radius: 0;" title="Spotify show" src="https://open.spotify.com/embed/show/3rDR8CfpIEMpITG2UC3w5W" width="300" height="400" frameborder="0" allowtransparency="true" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe></div>')
   })
 }
 
@@ -150,7 +151,7 @@ for (let [index, str] of allStrings.show.entries()) {
 
 /**
  * Paragraphs helper function
- * @param {Array} arr 
+ * @param {Array} arr
  * @returns Array of strings with all valid combinations of paragraphs and links
  */
 function paragraphs(arr) {
@@ -158,7 +159,7 @@ function paragraphs(arr) {
   arr.map(url => {
     // No whitespace
     out.push(`<p>${url}</p>`)
-    
+
     // With whitespace
     out.push(`<p>
       ${url}
@@ -166,7 +167,7 @@ function paragraphs(arr) {
 
     // With link, no whitespace
     out.push(`<p><a href="${url}">${url}</a></p>`)
-    
+
     // With whitespace and link
     out.push(`<p>
       <a href="${url}">

--- a/packages/twitch/package.json
+++ b/packages/twitch/package.json
@@ -10,8 +10,8 @@
   ],
   "main": ".eleventy.js",
   "scripts": {
-    "test": "npx ava",
-    "coverage": "nyc --reporter=lcov ava"
+    "test": "node --test",
+    "coverage": "node --test --experimental-test-coverage --test-reporter=lcov --test-reporter-destination=lcov.info"
   },
   "files": [
     ".eleventy.js",

--- a/packages/twitch/test.js
+++ b/packages/twitch/test.js
@@ -1,4 +1,5 @@
-const test = require('ava');
+const test = require('node:test');
+const assert = require('node:assert/strict');
 const patternPresent = require('./lib/spotPattern.js');
 // TODO: Finish tests for extracting ID strings and correct outputs
 const extractVideoId = require('./lib/extractMatches.js');
@@ -31,40 +32,40 @@ const invalidStrings = [
 ]
 
 validStrings.forEach(function(obj){
-  test(`${obj.type} ideal case`, t => {
+  test(`${obj.type} ideal case`, () => {
     let idealCase = `<p>${obj.str}</p>`;
-    t.truthy(patternPresent(idealCase));
+    assert.ok(patternPresent(idealCase));
   });
-  test(`${obj.type} with links`, t => {
+  test(`${obj.type} with links`, () => {
     let withLinks = `<p><a href="">${obj.str}</a></p>`;
-    t.truthy(patternPresent(withLinks));
+    assert.ok(patternPresent(withLinks));
   });
-  test(`${obj.type} with whitespace`, t => {
+  test(`${obj.type} with whitespace`, () => {
     let withWhitespace = `<p>
       ${obj.str}
     </p>`;
-    t.truthy(patternPresent(withWhitespace));
+    assert.ok(patternPresent(withWhitespace));
   });
-  test(`${obj.type} with links and whitespace`, t => {
+  test(`${obj.type} with links and whitespace`, () => {
     let withLinksAndWhitespace = `<p>
       <a href="">
         ${obj.str}
       </a>
     </p>`;
-    t.truthy(patternPresent(withLinksAndWhitespace));
+    assert.ok(patternPresent(withLinksAndWhitespace));
   });
 });
 
 invalidStrings.forEach(function(obj){
-  test(`${obj.type} ideal case`, t => {
+  test(`${obj.type} ideal case`, () => {
     let idealCase = `<p>${obj.str}</p>`;
-    t.falsy(patternPresent(idealCase));
+    assert.ok(!patternPresent(idealCase));
   });
-  test(`${obj.type} with whitespace`, t => {
+  test(`${obj.type} with whitespace`, () => {
     let withWhitespace = `<p>
       ${obj.str}
     </p>`;
-    t.falsy(patternPresent(withWhitespace));
+    assert.ok(!patternPresent(withWhitespace));
   });
 });
 
@@ -73,34 +74,34 @@ invalidStrings.forEach(function(obj){
  * type and ID.
  */
 validStrings.forEach(function(obj){
-  test(`Extract ID, ${obj.type}, ideal case`, t => {
+  test(`Extract ID, ${obj.type}, ideal case`, () => {
     let idealCase = `<p>${obj.str}</p>`;
     let out = extractVideoId(idealCase);
-    t.assert(['channel', 'video'].includes(out.type));
-    t.assert(['vixella', '597008599'].includes(out.id));
+    assert.ok(['channel', 'video'].includes(out.type));
+    assert.ok(['vixella', '597008599'].includes(out.id));
   });
-  test(`Extract ID, ${obj.type}, with links`, t => {
+  test(`Extract ID, ${obj.type}, with links`, () => {
     let withLinks = `<p><a href="">${obj.str}</a></p>`;
     let out = extractVideoId(withLinks);
-    t.assert(['channel', 'video'].includes(out.type));
-    t.assert(['vixella', '597008599'].includes(out.id));
+    assert.ok(['channel', 'video'].includes(out.type));
+    assert.ok(['vixella', '597008599'].includes(out.id));
   });
-  test(`Extract ID, ${obj.type}, with whitespace`, t => {
+  test(`Extract ID, ${obj.type}, with whitespace`, () => {
     let withWhitespace = `<p>
       ${obj.str}
     </p>`;
     let out = extractVideoId(withWhitespace);
-    t.assert(['channel', 'video'].includes(out.type));
-    t.assert(['vixella', '597008599'].includes(out.id));
+    assert.ok(['channel', 'video'].includes(out.type));
+    assert.ok(['vixella', '597008599'].includes(out.id));
   });
-  test(`Extract ID, ${obj.type}, with links and whitespace`, t => {
+  test(`Extract ID, ${obj.type}, with links and whitespace`, () => {
     let withLinksAndWhitespace = `<p>
       <a href="">
         ${obj.str}
       </a>
     </p>`;
     let out = extractVideoId(withLinksAndWhitespace);
-    t.assert(['channel', 'video'].includes(out.type));
-    t.assert(['vixella', '597008599'].includes(out.id));
+    assert.ok(['channel', 'video'].includes(out.type));
+    assert.ok(['vixella', '597008599'].includes(out.id));
   });
 });

--- a/packages/twitter/package.json
+++ b/packages/twitter/package.json
@@ -10,8 +10,8 @@
   ],
   "main": ".eleventy.js",
   "scripts": {
-    "test": "npx ava",
-    "coverage": "nyc --reporter=lcov ava"
+    "test": "node --test",
+    "coverage": "node --test --experimental-test-coverage --test-reporter=lcov --test-reporter-destination=lcov.info"
   },
   "files": [
     ".eleventy.js",

--- a/packages/twitter/test/test-buildEmbed.js
+++ b/packages/twitter/test/test-buildEmbed.js
@@ -1,4 +1,5 @@
-const test = require("ava");
+const test = require("node:test");
+const assert = require("node:assert/strict");
 const merge = require("deepmerge");
 const extractMatch = require("../lib/extractMatch.js");
 const buildEmbed = require("../lib/buildEmbed.js");
@@ -11,12 +12,12 @@ const validStrings = require("./_validStrings.js");
 validStrings.forEach(function(obj) {
 	test(
 		`${obj.type} default embed behavior`,
-		(t) => {
+		() => {
 			const idealCase = `<p>${obj.str}</p>`;
 			const tweetObj = extractMatch(idealCase);
 			const output = buildEmbed(tweetObj, pluginDefaults, 0);
 			const expected = '<div class="eleventy-plugin-embed-twitter"><blockquote id="tweet-1289865845053652994" class="twitter-tweet"><a href="https://twitter.com/SaraSoueidan/status/1289865845053652994"></a></blockquote></div><script src="https://platform.twitter.com/widgets.js" charset="utf-8" async></script>';
-			t.is(output, expected);
+			assert.equal(output, expected);
 		},
 	);
 });
@@ -27,12 +28,12 @@ validStrings.forEach(function(obj) {
 validStrings.forEach(function(obj) {
 	test(
 		`${obj.type} default embed behavior, nonzero array index`,
-		(t) => {
+		() => {
 			const idealCase = `<p>${obj.str}</p>`;
 			const tweetObj = extractMatch(idealCase);
 			const output = buildEmbed(tweetObj, pluginDefaults, 1);
 			const expected = '<div class="eleventy-plugin-embed-twitter"><blockquote id="tweet-1289865845053652994" class="twitter-tweet"><a href="https://twitter.com/SaraSoueidan/status/1289865845053652994"></a></blockquote></div>';
-			t.is(output, expected);
+			assert.equal(output, expected);
 		},
 	);
 });
@@ -43,7 +44,7 @@ validStrings.forEach(function(obj) {
 validStrings.forEach(function(obj) {
 	test(
 		`${obj.type} default embed, synchronous twitter script`,
-		(t) => {
+		() => {
 			const twitterAsyncFalse = {
 				twitterScript: {
 					async: false,
@@ -54,7 +55,7 @@ validStrings.forEach(function(obj) {
 			const tweetObj = extractMatch(idealCase);
 			const output = buildEmbed(tweetObj, customOpt, 0);
 			const expected = '<div class="eleventy-plugin-embed-twitter"><blockquote id="tweet-1289865845053652994" class="twitter-tweet"><a href="https://twitter.com/SaraSoueidan/status/1289865845053652994"></a></blockquote></div><script src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>';
-			t.is(output, expected);
+			assert.equal(output, expected);
 		},
 	);
 });
@@ -65,7 +66,7 @@ validStrings.forEach(function(obj) {
 validStrings.forEach(function(obj) {
 	test(
 		`${obj.type} default embed, deferred twitter script`,
-		(t) => {
+		() => {
 			const twitterDeferTrue = {
 				twitterScript: {
 					defer: true,
@@ -76,7 +77,7 @@ validStrings.forEach(function(obj) {
 			const tweetObj = extractMatch(idealCase);
 			const output = buildEmbed(tweetObj, customOpt, 0);
 			const expected = '<div class="eleventy-plugin-embed-twitter"><blockquote id="tweet-1289865845053652994" class="twitter-tweet"><a href="https://twitter.com/SaraSoueidan/status/1289865845053652994"></a></blockquote></div><script src="https://platform.twitter.com/widgets.js" charset="utf-8" async defer></script>';
-			t.is(output, expected);
+			assert.equal(output, expected);
 		},
 	);
 });
@@ -87,7 +88,7 @@ validStrings.forEach(function(obj) {
 validStrings.forEach(function(obj) {
 	test(
 		`${obj.type} default embed, disabled twitter script`,
-		(t) => {
+		() => {
 			const twitterScriptEnabledFalse = {
 				twitterScript: {
 					enabled: false,
@@ -98,7 +99,7 @@ validStrings.forEach(function(obj) {
 			const tweetObj = extractMatch(idealCase);
 			const output = buildEmbed(tweetObj, customOpt, 0);
 			const expected = '<div class="eleventy-plugin-embed-twitter"><blockquote id="tweet-1289865845053652994" class="twitter-tweet"><a href="https://twitter.com/SaraSoueidan/status/1289865845053652994"></a></blockquote></div>';
-			t.is(output, expected);
+			assert.equal(output, expected);
 		},
 	);
 });
@@ -109,7 +110,7 @@ validStrings.forEach(function(obj) {
 validStrings.forEach(function(obj) {
 	test(
 		`${obj.type} default embed, dark theme`,
-		(t) => {
+		() => {
 			const darkTheme = {
 				theme: "dark",
 			};
@@ -118,7 +119,7 @@ validStrings.forEach(function(obj) {
 			const tweetObj = extractMatch(idealCase);
 			const output = buildEmbed(tweetObj, customOpt, 0);
 			const expected = '<div class="eleventy-plugin-embed-twitter"><blockquote id="tweet-1289865845053652994" class="twitter-tweet" data-theme="dark"><a href="https://twitter.com/SaraSoueidan/status/1289865845053652994"></a></blockquote></div><script src="https://platform.twitter.com/widgets.js" charset="utf-8" async></script>';
-			t.is(output, expected);
+			assert.equal(output, expected);
 		},
 	);
 });
@@ -129,7 +130,7 @@ validStrings.forEach(function(obj) {
 validStrings.forEach(function(obj) {
 	test(
 		`${obj.type} default embed, do not track`,
-		(t) => {
+		() => {
 			const doNotTrack = {
 				doNotTrack: true,
 			};
@@ -138,7 +139,7 @@ validStrings.forEach(function(obj) {
 			const tweetObj = extractMatch(idealCase);
 			const output = buildEmbed(tweetObj, customOpt, 0);
 			const expected = '<div class="eleventy-plugin-embed-twitter"><blockquote id="tweet-1289865845053652994" class="twitter-tweet" data-dnt="true"><a href="https://twitter.com/SaraSoueidan/status/1289865845053652994"></a></blockquote></div><script src="https://platform.twitter.com/widgets.js" charset="utf-8" async></script>';
-			t.is(output, expected);
+			assert.equal(output, expected);
 		},
 	);
 });
@@ -149,7 +150,7 @@ validStrings.forEach(function(obj) {
 validStrings.forEach(function(obj) {
 	test(
 		`${obj.type} default embed, dark mode`,
-		(t) => {
+		() => {
 			const darkMode = {
 				theme: "dark",
 			};
@@ -158,7 +159,7 @@ validStrings.forEach(function(obj) {
 			const tweetObj = extractMatch(idealCase);
 			const output = buildEmbed(tweetObj, customOpt, 0);
 			const expected = '<div class="eleventy-plugin-embed-twitter"><blockquote id="tweet-1289865845053652994" class="twitter-tweet" data-theme="dark"><a href="https://twitter.com/SaraSoueidan/status/1289865845053652994"></a></blockquote></div><script src="https://platform.twitter.com/widgets.js" charset="utf-8" async></script>';
-			t.is(output, expected);
+			assert.equal(output, expected);
 		},
 	);
 });
@@ -169,7 +170,7 @@ validStrings.forEach(function(obj) {
 validStrings.forEach(function(obj) {
 	test(
 		`${obj.type} default embed, custom alignment`,
-		(t) => {
+		() => {
 			const align = {
 				align: "right",
 			};
@@ -178,7 +179,7 @@ validStrings.forEach(function(obj) {
 			const tweetObj = extractMatch(idealCase);
 			const output = buildEmbed(tweetObj, customOpt, 0);
 			const expected = '<div class="eleventy-plugin-embed-twitter"><blockquote id="tweet-1289865845053652994" class="twitter-tweet" data-align="right"><a href="https://twitter.com/SaraSoueidan/status/1289865845053652994"></a></blockquote></div><script src="https://platform.twitter.com/widgets.js" charset="utf-8" async></script>';
-			t.is(output, expected);
+			assert.equal(output, expected);
 		},
 	);
 });
@@ -189,7 +190,7 @@ validStrings.forEach(function(obj) {
 validStrings.forEach(function(obj) {
 	test(
 		`${obj.type} default embed, disable cards/media`,
-		(t) => {
+		() => {
 			const cards = {
 				cards: "hidden",
 			};
@@ -198,7 +199,7 @@ validStrings.forEach(function(obj) {
 			const tweetObj = extractMatch(idealCase);
 			const output = buildEmbed(tweetObj, customOpt, 0);
 			const expected = '<div class="eleventy-plugin-embed-twitter"><blockquote id="tweet-1289865845053652994" class="twitter-tweet" data-cards="hidden"><a href="https://twitter.com/SaraSoueidan/status/1289865845053652994"></a></blockquote></div><script src="https://platform.twitter.com/widgets.js" charset="utf-8" async></script>';
-			t.is(output, expected);
+			assert.equal(output, expected);
 		},
 	);
 });
@@ -209,7 +210,7 @@ validStrings.forEach(function(obj) {
 validStrings.forEach(function(obj) {
 	test(
 		`${obj.type} default embed, disable conversation/threading`,
-		(t) => {
+		() => {
 			const conversation = {
 				conversation: "none",
 			};
@@ -218,7 +219,7 @@ validStrings.forEach(function(obj) {
 			const tweetObj = extractMatch(idealCase);
 			const output = buildEmbed(tweetObj, customOpt, 0);
 			const expected = '<div class="eleventy-plugin-embed-twitter"><blockquote id="tweet-1289865845053652994" class="twitter-tweet" data-conversation="none"><a href="https://twitter.com/SaraSoueidan/status/1289865845053652994"></a></blockquote></div><script src="https://platform.twitter.com/widgets.js" charset="utf-8" async></script>';
-			t.is(output, expected);
+			assert.equal(output, expected);
 		},
 	);
 });
@@ -229,7 +230,7 @@ validStrings.forEach(function(obj) {
 validStrings.forEach(function(obj) {
 	test(
 		`${obj.type} default embed, custom language`,
-		(t) => {
+		() => {
 			const lang = {
 				lang: "es",
 			};
@@ -238,7 +239,7 @@ validStrings.forEach(function(obj) {
 			const tweetObj = extractMatch(idealCase);
 			const output = buildEmbed(tweetObj, customOpt, 0);
 			const expected = '<div class="eleventy-plugin-embed-twitter"><blockquote id="tweet-1289865845053652994" class="twitter-tweet" data-lang="es"><a href="https://twitter.com/SaraSoueidan/status/1289865845053652994"></a></blockquote></div><script src="https://platform.twitter.com/widgets.js" charset="utf-8" async></script>';
-			t.is(output, expected);
+			assert.equal(output, expected);
 		},
 	);
 });
@@ -249,7 +250,7 @@ validStrings.forEach(function(obj) {
 validStrings.forEach(function(obj) {
 	test(
 		`${obj.type} default embed, custom width`,
-		(t) => {
+		() => {
 			const width = {
 				width: 329,
 			};
@@ -258,7 +259,7 @@ validStrings.forEach(function(obj) {
 			const tweetObj = extractMatch(idealCase);
 			const output = buildEmbed(tweetObj, customOpt, 0);
 			const expected = '<div class="eleventy-plugin-embed-twitter"><blockquote id="tweet-1289865845053652994" class="twitter-tweet" data-width="329"><a href="https://twitter.com/SaraSoueidan/status/1289865845053652994"></a></blockquote></div><script src="https://platform.twitter.com/widgets.js" charset="utf-8" async></script>';
-			t.is(output, expected);
+			assert.equal(output, expected);
 		},
 	);
 });
@@ -274,13 +275,13 @@ validStrings.forEach(function(obj) {
 validStrings.forEach(function(obj) {
 	test(
 		`${obj.type} cached oembed behavior`,
-		async (t) => {
+		async () => {
 			const oEmbedOption = merge(pluginDefaults, {cacheText: true});
 			const idealCase = `<p>${obj.str}</p>`;
 			const tweetObj = extractMatch(idealCase);
 			const output = await buildEmbed(tweetObj, oEmbedOption, 0);
 			const expected = '<div class="eleventy-plugin-embed-twitter"><blockquote class="twitter-tweet"><p lang="en" dir="ltr">I&#39;ve been increasingly feeling like Grid or Flex has become the new Tabs or Spaces.</p>&mdash; Sara Soueidan (@SaraSoueidan) <a href="https://twitter.com/SaraSoueidan/status/1289865845053652994?ref_src=twsrc%5Etfw">August 2, 2020</a></blockquote>\n<script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>\n\n</div>';
-			t.is(output, expected);
+			assert.equal(output, expected);
 		},
 	);
 });
@@ -291,13 +292,13 @@ validStrings.forEach(function(obj) {
 validStrings.forEach(function(obj) {
 	test(
 		`${obj.type} cached oembed behavior, nonzero array index`,
-		async (t) => {
+		async () => {
 			const oEmbedOption = merge(pluginDefaults, {cacheText: true});
 			const idealCase = `<p>${obj.str}</p>`;
 			const tweetObj = extractMatch(idealCase);
 			const output = await buildEmbed(tweetObj, oEmbedOption, 1);
 			const expected = '<div class="eleventy-plugin-embed-twitter"><blockquote class="twitter-tweet"><p lang="en" dir="ltr">I&#39;ve been increasingly feeling like Grid or Flex has become the new Tabs or Spaces.</p>&mdash; Sara Soueidan (@SaraSoueidan) <a href="https://twitter.com/SaraSoueidan/status/1289865845053652994?ref_src=twsrc%5Etfw">August 2, 2020</a></blockquote>\n\n</div>';
-			t.is(output, expected);
+			assert.equal(output, expected);
 		},
 	);
 });
@@ -308,7 +309,7 @@ validStrings.forEach(function(obj) {
 validStrings.forEach(function(obj) {
 	test(
 		`${obj.type} cached oembed behavior, disabled twitter script`,
-		async (t) => {
+		async () => {
 			const oEmbedOption = merge(
 				pluginDefaults,
 				{
@@ -322,7 +323,7 @@ validStrings.forEach(function(obj) {
 			const tweetObj = extractMatch(idealCase);
 			const output = await buildEmbed(tweetObj, oEmbedOption, 0);
 			const expected = '<div class="eleventy-plugin-embed-twitter"><blockquote class="twitter-tweet"><p lang="en" dir="ltr">I&#39;ve been increasingly feeling like Grid or Flex has become the new Tabs or Spaces.</p>&mdash; Sara Soueidan (@SaraSoueidan) <a href="https://twitter.com/SaraSoueidan/status/1289865845053652994?ref_src=twsrc%5Etfw">August 2, 2020</a></blockquote>\n\n</div>';
-			t.is(output, expected);
+			assert.equal(output, expected);
 		},
 	);
 });
@@ -333,7 +334,7 @@ validStrings.forEach(function(obj) {
 validStrings.forEach(function(obj) {
 	test(
 		`${obj.type} cached oembed behavior, dark theme`,
-		async (t) => {
+		async () => {
 			const oEmbedOption = merge(
 				pluginDefaults,
 				{
@@ -345,7 +346,7 @@ validStrings.forEach(function(obj) {
 			const tweetObj = extractMatch(idealCase);
 			const output = await buildEmbed(tweetObj, oEmbedOption, 0);
 			const expected = '<div class="eleventy-plugin-embed-twitter"><blockquote class="twitter-tweet" data-theme="dark"><p lang="en" dir="ltr">I&#39;ve been increasingly feeling like Grid or Flex has become the new Tabs or Spaces.</p>&mdash; Sara Soueidan (@SaraSoueidan) <a href="https://twitter.com/SaraSoueidan/status/1289865845053652994?ref_src=twsrc%5Etfw">August 2, 2020</a></blockquote>\n<script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>\n\n</div>';
-			t.is(output, expected);
+			assert.equal(output, expected);
 		},
 	);
 });
@@ -356,7 +357,7 @@ validStrings.forEach(function(obj) {
 validStrings.forEach(function(obj) {
 	test(
 		`${obj.type} cached oembed behavior, do not track`,
-		async (t) => {
+		async () => {
 			const oEmbedOption = merge(
 				pluginDefaults,
 				{
@@ -368,7 +369,7 @@ validStrings.forEach(function(obj) {
 			const tweetObj = extractMatch(idealCase);
 			const output = await buildEmbed(tweetObj, oEmbedOption, 0);
 			const expected = '<div class="eleventy-plugin-embed-twitter"><blockquote class="twitter-tweet" data-dnt="true"><p lang="en" dir="ltr">I&#39;ve been increasingly feeling like Grid or Flex has become the new Tabs or Spaces.</p>&mdash; Sara Soueidan (@SaraSoueidan) <a href="https://twitter.com/SaraSoueidan/status/1289865845053652994?ref_src=twsrc%5Etfw">August 2, 2020</a></blockquote>\n<script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>\n\n</div>';
-			t.is(output, expected);
+			assert.equal(output, expected);
 		},
 	);
 });
@@ -379,7 +380,7 @@ validStrings.forEach(function(obj) {
 validStrings.forEach(function(obj) {
 	test(
 		`${obj.type} cached oembed behavior, custom alignment`,
-		async (t) => {
+		async () => {
 			const oEmbedOption = merge(
 				pluginDefaults,
 				{
@@ -391,7 +392,7 @@ validStrings.forEach(function(obj) {
 			const tweetObj = extractMatch(idealCase);
 			const output = await buildEmbed(tweetObj, oEmbedOption, 0);
 			const expected = '<div class="eleventy-plugin-embed-twitter"><blockquote class="twitter-tweet" align="center"><p lang="en" dir="ltr">I&#39;ve been increasingly feeling like Grid or Flex has become the new Tabs or Spaces.</p>&mdash; Sara Soueidan (@SaraSoueidan) <a href="https://twitter.com/SaraSoueidan/status/1289865845053652994?ref_src=twsrc%5Etfw">August 2, 2020</a></blockquote>\n<script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>\n\n</div>';
-			t.is(output, expected);
+			assert.equal(output, expected);
 		},
 	);
 });
@@ -402,7 +403,7 @@ validStrings.forEach(function(obj) {
 validStrings.forEach(function(obj) {
 	test(
 		`${obj.type} cached oembed behavior, cards deactivated`,
-		async (t) => {
+		async () => {
 			const oEmbedOption = merge(
 				pluginDefaults,
 				{
@@ -414,7 +415,7 @@ validStrings.forEach(function(obj) {
 			const tweetObj = extractMatch(idealCase);
 			const output = await buildEmbed(tweetObj, oEmbedOption, 0);
 			const expected = '<div class="eleventy-plugin-embed-twitter"><blockquote class="twitter-tweet" data-cards="hidden"><p lang="en" dir="ltr">I&#39;ve been increasingly feeling like Grid or Flex has become the new Tabs or Spaces.</p>&mdash; Sara Soueidan (@SaraSoueidan) <a href="https://twitter.com/SaraSoueidan/status/1289865845053652994?ref_src=twsrc%5Etfw">August 2, 2020</a></blockquote>\n<script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>\n\n</div>';
-			t.is(output, expected);
+			assert.equal(output, expected);
 		},
 	);
 });
@@ -428,7 +429,7 @@ validStrings.forEach(function(obj) {
 validStrings.forEach(function(obj) {
 	test(
 		`${obj.type} cached oembed behavior, conversations deactivated`,
-		async (t) => {
+		async () => {
 			const oEmbedOption = merge(
 				pluginDefaults,
 				{
@@ -440,7 +441,7 @@ validStrings.forEach(function(obj) {
 			const tweetObj = extractMatch(idealCase);
 			const output = await buildEmbed(tweetObj, oEmbedOption, 0);
 			const expected = '<div class="eleventy-plugin-embed-twitter"><blockquote class="twitter-tweet"><p lang="en" dir="ltr">I&#39;ve been increasingly feeling like Grid or Flex has become the new Tabs or Spaces.</p>&mdash; Sara Soueidan (@SaraSoueidan) <a href="https://twitter.com/SaraSoueidan/status/1289865845053652994?ref_src=twsrc%5Etfw">August 2, 2020</a></blockquote>\n<script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>\n\n</div>';
-			t.is(output, expected);
+			assert.equal(output, expected);
 		},
 	);
 });
@@ -454,7 +455,7 @@ validStrings.forEach(function(obj) {
 
 test(
 	"Response tweet, cached oembed behavior, conversation deactivated for a response",
-	async (t) => {
+	async () => {
 		const oEmbedOption = merge(
 			pluginDefaults,
 			{
@@ -466,7 +467,7 @@ test(
 		const tweetObj = extractMatch(idealCase);
 		const output = await buildEmbed(tweetObj, oEmbedOption, 0);
 		const expected = '<div class="eleventy-plugin-embed-twitter"><blockquote class="twitter-tweet" data-conversation="none"><p lang="en" dir="ltr">what is your preference?</p>&mdash; Juan Stoppa (@juanstoppa) <a href="https://twitter.com/juanstoppa/status/1289865999425167360?ref_src=twsrc%5Etfw">August 2, 2020</a></blockquote>\n<script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>\n\n</div>';
-		t.is(output, expected);
+		assert.equal(output, expected);
 	},
 );
 
@@ -481,7 +482,7 @@ test(
 validStrings.forEach(function(obj) {
 	test(
 		`${obj.type} cached oembed behavior, custom language`,
-		async (t) => {
+		async () => {
 			const oEmbedOption = merge(
 				pluginDefaults,
 				{
@@ -493,7 +494,7 @@ validStrings.forEach(function(obj) {
 			const tweetObj = extractMatch(idealCase);
 			const output = await buildEmbed(tweetObj, oEmbedOption, 0);
 			const expected = '<div class="eleventy-plugin-embed-twitter"><blockquote class="twitter-tweet" data-lang="es"><p lang="en" dir="ltr">I&#39;ve been increasingly feeling like Grid or Flex has become the new Tabs or Spaces.</p>&mdash; Sara Soueidan (@SaraSoueidan) <a href="https://twitter.com/SaraSoueidan/status/1289865845053652994?ref_src=twsrc%5Etfw">2 de agosto de 2020</a></blockquote>\n<script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>\n\n</div>';
-			t.is(output, expected);
+			assert.equal(output, expected);
 		},
 	);
 });
@@ -507,7 +508,7 @@ validStrings.forEach(function(obj) {
  */
 test(
 	"Non-English tweet, cached oembed behavior, custom language",
-	async (t) => {
+	async () => {
 		const oEmbedOption = merge(
 			pluginDefaults,
 			{
@@ -519,7 +520,7 @@ test(
 		const tweetObj = extractMatch(idealCase);
 		const output = await buildEmbed(tweetObj, oEmbedOption, 0);
 		const expected = '<div class="eleventy-plugin-embed-twitter"><blockquote class="twitter-tweet" data-lang="es"><p lang="es" dir="ltr">\xa1Eso me pareci\xf3 a mi!</p>&mdash; Antonio Laguna \u30c4 (@ant_laguna) <a href="https://twitter.com/ant_laguna/status/1250020567538905088?ref_src=twsrc%5Etfw">14 de abril de 2020</a></blockquote>\n<script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>\n\n</div>';
-		t.is(output, expected);
+		assert.equal(output, expected);
 	},
 );
 
@@ -529,7 +530,7 @@ test(
 validStrings.forEach(function(obj) {
 	test(
 		`${obj.type} cached oembed behavior, custom width`,
-		async (t) => {
+		async () => {
 			const oEmbedOption = merge(
 				pluginDefaults,
 				{
@@ -541,7 +542,7 @@ validStrings.forEach(function(obj) {
 			const tweetObj = extractMatch(idealCase);
 			const output = await buildEmbed(tweetObj, oEmbedOption, 0);
 			const expected = '<div class="eleventy-plugin-embed-twitter"><blockquote class="twitter-tweet" data-width="325"><p lang="en" dir="ltr">I&#39;ve been increasingly feeling like Grid or Flex has become the new Tabs or Spaces.</p>&mdash; Sara Soueidan (@SaraSoueidan) <a href="https://twitter.com/SaraSoueidan/status/1289865845053652994?ref_src=twsrc%5Etfw">August 2, 2020</a></blockquote>\n<script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>\n\n</div>';
-			t.is(output, expected);
+			assert.equal(output, expected);
 		},
 	);
 });
@@ -552,7 +553,7 @@ validStrings.forEach(function(obj) {
 validStrings.forEach(function(obj) {
 	test(
 		`${obj.type} network failure case`,
-		async (t) => {
+		async () => {
 			const oEmbedOption = merge(pluginDefaults, {cacheText: true});
 			const idealCase = `<p>${obj.str}</p>`;
 			const tweetObj = extractMatch(idealCase);
@@ -561,7 +562,7 @@ validStrings.forEach(function(obj) {
 			const output = await buildEmbed(tweetObj, oEmbedOption, 0);
 			// Remember, the expected returned value is still an invalid URL for the purposes of this test!
 			const expected = "https://twitter.com/SaraSoueidan/status/1289865845053652900";
-			t.is(output, expected);
+			assert.equal(output, expected);
 		},
 	);
 });

--- a/packages/twitter/test/test-buildOptions.js
+++ b/packages/twitter/test/test-buildOptions.js
@@ -1,4 +1,5 @@
-const test = require("ava");
+const test = require("node:test");
+const assert = require("node:assert/strict");
 const merge = require("deepmerge");
 const buildOptions = require("../lib/buildOptions.js");
 const pluginDefaults = require("../lib/pluginDefaults.js");
@@ -8,140 +9,140 @@ const pluginDefaults = require("../lib/pluginDefaults.js");
  */
 test(
 	"Default data attribute: No options specified",
-	(t) => {
+	() => {
 		let expected = "";
 		let computed = buildOptions(pluginDefaults);
-		t.is(expected, computed);
+		assert.equal(expected, computed);
 	},
 );
 
 test(
 	"Default data attribute: Dark theme",
-	(t) => {
+	() => {
 		let opt = merge(pluginDefaults, {theme: "dark"});
 		let expected = 'data-theme="dark"';
 		let computed = buildOptions(opt);
-		t.is(expected, computed);
+		assert.equal(expected, computed);
 	},
 );
 
 test(
 	"Default data attribute: Do Not Track",
-	(t) => {
+	() => {
 		let opt = merge(pluginDefaults, {doNotTrack: true});
 		let expected = 'data-dnt="true"';
 		let computed = buildOptions(opt);
-		t.is(expected, computed);
+		assert.equal(expected, computed);
 	},
 );
 
 test(
 	"Default data attribute: Alignment left",
-	(t) => {
+	() => {
 		let opt = merge(pluginDefaults, {align: "left"});
 		let expected = 'data-align="left"';
 		let computed = buildOptions(opt);
-		t.is(expected, computed);
+		assert.equal(expected, computed);
 	},
 );
 
 test(
 	"Default data attribute: Alignment center",
-	(t) => {
+	() => {
 		let opt = merge(pluginDefaults, {align: "center"});
 		let expected = 'data-align="center"';
 		let computed = buildOptions(opt);
-		t.is(expected, computed);
+		assert.equal(expected, computed);
 	},
 );
 
 test(
 	"Default data attribute: Alignment right",
-	(t) => {
+	() => {
 		let opt = merge(pluginDefaults, {align: "right"});
 		let expected = 'data-align="right"';
 		let computed = buildOptions(opt);
-		t.is(expected, computed);
+		assert.equal(expected, computed);
 	},
 );
 
 test(
 	"Default data attribute: Alignment is invalid",
-	(t) => {
+	() => {
 		let opt = merge(pluginDefaults, {align: "foo"});
 		let expected = "";
 		let computed = buildOptions(opt);
-		t.is(expected, computed);
+		assert.equal(expected, computed);
 	},
 );
 
 test(
 	"Default data attribute: Cards are hidden",
-	(t) => {
+	() => {
 		let opt = merge(pluginDefaults, {cards: "hidden"});
 		let expected = 'data-cards="hidden"';
 		let computed = buildOptions(opt);
-		t.is(expected, computed);
+		assert.equal(expected, computed);
 	},
 );
 
 test(
 	"Default data attribute: Conversations are deactivated",
-	(t) => {
+	() => {
 		let opt = merge(pluginDefaults, {conversation: "none"});
 		let expected = 'data-conversation="none"';
 		let computed = buildOptions(opt);
-		t.is(expected, computed);
+		assert.equal(expected, computed);
 	},
 );
 
 test(
 	"Default data attribute: Lang is configurable",
-	(t) => {
+	() => {
 		let opt = merge(pluginDefaults, {lang: "es"});
 		let expected = 'data-lang="es"';
 		let computed = buildOptions(opt);
-		t.is(expected, computed);
+		assert.equal(expected, computed);
 	},
 );
 
 test(
 	"Default data attribute: Width is configurable",
-	(t) => {
+	() => {
 		let opt = merge(pluginDefaults, {width: 325});
 		let expected = 'data-width="325"';
 		let computed = buildOptions(opt);
-		t.is(expected, computed);
+		assert.equal(expected, computed);
 	},
 );
 
 test(
 	"Default data attribute: Width must be a number",
-	(t) => {
+	() => {
 		let opt = merge(pluginDefaults, {width: "foo"});
 		let expected = "";
 		let computed = buildOptions(opt);
-		t.is(expected, computed);
+		assert.equal(expected, computed);
 	},
 );
 
 test(
 	"Default data attribute: oEmbed-only omit_script option produces no data attribute",
-	(t) => {
+	() => {
 		let opt = merge(pluginDefaults, {omit_script: true});
 		let expected = "";
 		let computed = buildOptions(opt);
-		t.is(expected, computed);
+		assert.equal(expected, computed);
 	},
 );
 
 test(
 	"Default data attribute: oEmbed-only tweetUrl option produces no data attribute",
-	(t) => {
+	() => {
 		let opt = merge(pluginDefaults, {tweetUrl: "https://www.example.com"});
 		let expected = "";
 		let computed = buildOptions(opt);
-		t.is(expected, computed);
+		assert.equal(expected, computed);
 	},
 );
 
@@ -151,41 +152,41 @@ test(
 
 test(
 	"Combined data attributes: dark theme AND dnt",
-	(t) => {
+	() => {
 		let opt = merge(pluginDefaults, {theme: "dark", doNotTrack: true});
 		let expected = 'data-theme="dark" data-dnt="true"';
 		let computed = buildOptions(opt);
-		t.is(expected, computed);
+		assert.equal(expected, computed);
 	},
 );
 
 test(
 	"Combined data attributes: cards hidden AND conversation off",
-	(t) => {
+	() => {
 		let opt = merge(pluginDefaults, {cards: "hidden", conversation: "none"});
 		let expected = 'data-cards="hidden" data-conversation="none"';
 		let computed = buildOptions(opt);
-		t.is(expected, computed);
+		assert.equal(expected, computed);
 	},
 );
 
 test(
 	"Combined data attributes: align center AND custom width",
-	(t) => {
+	() => {
 		let opt = merge(pluginDefaults, {align: "center", width: 310});
 		let expected = 'data-align="center" data-width="310"';
 		let computed = buildOptions(opt);
-		t.is(expected, computed);
+		assert.equal(expected, computed);
 	},
 );
 
 test(
 	"Combined data attributes: custom lang AND invalid alignment",
-	(t) => {
+	() => {
 		let opt = merge(pluginDefaults, {lang: "fr", align: "foo"});
 		let expected = 'data-lang="fr"';
 		let computed = buildOptions(opt);
-		t.is(expected, computed);
+		assert.equal(expected, computed);
 	},
 );
 
@@ -194,124 +195,124 @@ test(
  */
 test(
 	"Custom URL param attribute: Dark theme",
-	(t) => {
+	() => {
 		let opt = merge(pluginDefaults, {theme: "dark"});
 		let expected = "?theme=dark";
 		let computed = buildOptions(opt, "url");
-		t.is(expected, computed);
+		assert.equal(expected, computed);
 	},
 );
 
 test(
 	"Custom URL param attribute: Do Not Track",
-	(t) => {
+	() => {
 		let opt = merge(pluginDefaults, {doNotTrack: true});
 		let expected = "?dnt=true";
 		let computed = buildOptions(opt, "url");
-		t.is(expected, computed);
+		assert.equal(expected, computed);
 	},
 );
 
 test(
 	"Custom URL param attribute: Alignment left",
-	(t) => {
+	() => {
 		let opt = merge(pluginDefaults, {align: "left"});
 		let expected = "?align=left";
 		let computed = buildOptions(opt, "url");
-		t.is(expected, computed);
+		assert.equal(expected, computed);
 	},
 );
 
 test(
 	"Custom URL param attribute: Alignment center",
-	(t) => {
+	() => {
 		let opt = merge(pluginDefaults, {align: "center"});
 		let expected = "?align=center";
 		let computed = buildOptions(opt, "url");
-		t.is(expected, computed);
+		assert.equal(expected, computed);
 	},
 );
 
 test(
 	"Custom URL param attribute: Alignment right",
-	(t) => {
+	() => {
 		let opt = merge(pluginDefaults, {align: "right"});
 		let expected = "?align=right";
 		let computed = buildOptions(opt, "url");
-		t.is(expected, computed);
+		assert.equal(expected, computed);
 	},
 );
 
 test(
 	"Custom URL param attribute: Alignment is invalid",
-	(t) => {
+	() => {
 		let opt = merge(pluginDefaults, {align: "foo"});
 		let expected = "";
 		let computed = buildOptions(opt, "url");
-		t.is(expected, computed);
+		assert.equal(expected, computed);
 	},
 );
 
 test(
 	"Custom URL param attribute: Cards are hidden",
-	(t) => {
+	() => {
 		let opt = merge(pluginDefaults, {cards: "hidden"});
 		let expected = "?hide_media=true";
 		let computed = buildOptions(opt, "url");
-		t.is(expected, computed);
+		assert.equal(expected, computed);
 	},
 );
 
 test(
 	"Custom URL param attribute: Conversations are deactivated",
-	(t) => {
+	() => {
 		let opt = merge(pluginDefaults, {conversation: "none"});
 		let expected = "?hide_thread=true";
 		let computed = buildOptions(opt, "url");
-		t.is(expected, computed);
+		assert.equal(expected, computed);
 	},
 );
 
 test(
 	"Custom URL param attribute: Lang is configurable",
-	(t) => {
+	() => {
 		let opt = merge(pluginDefaults, {lang: "es"});
 		let expected = "?lang=es";
 		let computed = buildOptions(opt, "url");
-		t.is(expected, computed);
+		assert.equal(expected, computed);
 	},
 );
 
 test(
 	"Custom URL param attribute: Width must be a number",
-	(t) => {
+	() => {
 		let opt = merge(pluginDefaults, {width: "foo"});
 		let expected = "";
 		let computed = buildOptions(opt, "url");
-		t.is(expected, computed);
+		assert.equal(expected, computed);
 	},
 );
 
 test(
 	"Custom URL param attribute: Omit script",
-	(t) => {
+	() => {
 		let opt = merge(pluginDefaults, {omit_script: true});
 		let expected = "?omit_script=true";
 		let computed = buildOptions(opt, "url");
-		t.is(expected, computed);
+		assert.equal(expected, computed);
 	},
 );
 
 test(
 	"Custom URL param attribute: Tweet url param returns URLencoded",
-	(t) => {
+	() => {
 		let opt = merge(
 			pluginDefaults,
 			{tweetUrl: "https://twitter.com/SaraSoueidan/status/1289865845053652994"},
 		);
 		let expected = "?url=https%3A%2F%2Ftwitter.com%2FSaraSoueidan%2Fstatus%2F1289865845053652994";
 		let computed = buildOptions(opt, "url");
-		t.is(expected, computed);
+		assert.equal(expected, computed);
 	},
 );
 
@@ -321,40 +322,40 @@ test(
 
 test(
 	"Combined URL param attributes: dark theme AND dnt",
-	(t) => {
+	() => {
 		let opt = merge(pluginDefaults, {theme: "dark", doNotTrack: true});
 		let expected = "?theme=dark&dnt=true";
 		let computed = buildOptions(opt, "url");
-		t.is(expected, computed);
+		assert.equal(expected, computed);
 	},
 );
 
 test(
 	"Combined URL param attributes: cards hidden AND conversation off",
-	(t) => {
+	() => {
 		let opt = merge(pluginDefaults, {cards: "hidden", conversation: "none"});
 		let expected = "?hide_media=true&hide_thread=true";
 		let computed = buildOptions(opt, "url");
-		t.is(expected, computed);
+		assert.equal(expected, computed);
 	},
 );
 
 test(
 	"Combined URL param attributes: align center AND custom width",
-	(t) => {
+	() => {
 		let opt = merge(pluginDefaults, {align: "center", width: 310});
 		let expected = "?align=center&maxwidth=310";
 		let computed = buildOptions(opt, "url");
-		t.is(expected, computed);
+		assert.equal(expected, computed);
 	},
 );
 
 test(
 	"Combined URL param attributes: custom lang AND invalid alignment",
-	(t) => {
+	() => {
 		let opt = merge(pluginDefaults, {lang: "fr", align: "foo"});
 		let expected = "?lang=fr";
 		let computed = buildOptions(opt, "url");
-		t.is(expected, computed);
+		assert.equal(expected, computed);
 	},
 );

--- a/packages/twitter/test/test-extractMatch.js
+++ b/packages/twitter/test/test-extractMatch.js
@@ -1,4 +1,5 @@
-const test = require("ava");
+const test = require("node:test");
+const assert = require("node:assert/strict");
 const extractMatch = require("../lib/extractMatch.js");
 const validStrings = require("./_validStrings.js");
 
@@ -13,9 +14,9 @@ const expected = {userHandle: "SaraSoueidan", tweetId: "1289865845053652994"};
 validStrings.forEach(function(obj) {
 	test(
 		`${obj.type} ideal case`,
-		(t) => {
+		() => {
 			const idealCase = `<p>${obj.str}</p>`;
-			t.deepEqual(extractMatch(idealCase), expected);
+			assert.deepEqual(extractMatch(idealCase), expected);
 		},
 	);
 });
@@ -26,11 +27,11 @@ validStrings.forEach(function(obj) {
 validStrings.forEach(function(obj) {
 	test(
 		`${obj.type} withWhitespace`,
-		(t) => {
+		() => {
 			let withWhitespace = `<p>
       ${obj.str}
     </p>`;
-			t.deepEqual(extractMatch(withWhitespace), expected);
+			assert.deepEqual(extractMatch(withWhitespace), expected);
 		},
 	);
 });
@@ -41,9 +42,9 @@ validStrings.forEach(function(obj) {
 validStrings.forEach(function(obj) {
 	test(
 		`${obj.type} with links`,
-		(t) => {
+		() => {
 			let withLinks = `<p><a href="">${obj.str}</a></p>`;
-			t.deepEqual(extractMatch(withLinks), expected);
+			assert.deepEqual(extractMatch(withLinks), expected);
 		},
 	);
 });
@@ -54,40 +55,40 @@ validStrings.forEach(function(obj) {
 validStrings.forEach(function(obj) {
 	test(
 		`${obj.type} with links and whitespace`,
-		(t) => {
+		() => {
 			let withLinksAndWhitespace = `<p>
       <a href="">
         ${obj.str}
       </a>
     </p>`;
-			t.deepEqual(extractMatch(withLinksAndWhitespace), expected);
+			assert.deepEqual(extractMatch(withLinksAndWhitespace), expected);
 		},
 	);
 });
 
 /**
  * TESTS: RegEx doesn’t greedily consume subsequent paragraph tags in minified HTML
- * 
+ *
  * @since			1.3.3
  * @see				https://github.com/gfscott/eleventy-plugin-embed-twitter/issues/33
- * 
- * This is more of a problem for lib/spotPattern.js but testing this ensures consistent 
+ *
+ * This is more of a problem for lib/spotPattern.js but testing this ensures consistent
  * behavior for the two regular expressions.
  */
 test(
 	"RegEx doesn't greedily consume subsequent paragraph tags in minified HTML",
-	(t) => {
+	() => {
 		let paragraphs = "<p>https://twitter.com/SaraSoueidan/status/1289865845053652994</p><p>Foo</p>";
 		let output = extractMatch(paragraphs);
-		t.deepEqual(output, expected);
+		assert.deepEqual(output, expected);
 	},
 );
 
 test(
 	"RegEx doesn't greedily consume subsequent paragraph tags in minified HTML, including anchor tags",
-	(t) => {
+	() => {
 		let paragraphs = `<p><a href="foo">https://twitter.com/SaraSoueidan/status/1289865845053652994</a></p><p>Foo</p>`;
 		let output = extractMatch(paragraphs);
-		t.deepEqual(output, expected);
+		assert.deepEqual(output, expected);
 	},
 );

--- a/packages/twitter/test/test-spotPattern.js
+++ b/packages/twitter/test/test-spotPattern.js
@@ -1,4 +1,5 @@
-const test = require("ava");
+const test = require("node:test");
+const assert = require("node:assert/strict");
 const patternPresent = require("../lib/spotPattern.js");
 const validStrings = require("./_validStrings.js");
 // const invalidStrings = require("./_invalidStrings.js");
@@ -9,9 +10,9 @@ const validStrings = require("./_validStrings.js");
 validStrings.forEach(function(obj) {
 	test(
 		`${obj.type} ideal case`,
-		(t) => {
+		() => {
 			let idealCase = `<p>${obj.str}</p>`;
-			t.truthy(patternPresent(idealCase));
+			assert.ok(patternPresent(idealCase));
 		},
 	);
 });
@@ -23,11 +24,11 @@ validStrings.forEach(function(obj) {
 validStrings.forEach(function(obj) {
 	test(
 		`${obj.type} with whitespace`,
-		(t) => {
+		() => {
 			let withWhitespace = `<p>
       ${obj.str}
     </p>`;
-			t.truthy(patternPresent(withWhitespace));
+			assert.ok(patternPresent(withWhitespace));
 		},
 	);
 });
@@ -38,9 +39,9 @@ validStrings.forEach(function(obj) {
 validStrings.forEach(function(obj) {
 	test(
 		`${obj.type} with links`,
-		(t) => {
+		() => {
 			let withLinks = `<p><a href="">${obj.str}</a></p>`;
-			t.truthy(patternPresent(withLinks));
+			assert.ok(patternPresent(withLinks));
 		},
 	);
 });
@@ -52,13 +53,13 @@ validStrings.forEach(function(obj) {
 validStrings.forEach(function(obj) {
 	test(
 		`${obj.type} with links and whitespace`,
-		(t) => {
+		() => {
 			let withLinksAndWhitespace = `<p>
       <a href="">
         ${obj.str}
       </a>
     </p>`;
-			t.truthy(patternPresent(withLinksAndWhitespace));
+			assert.ok(patternPresent(withLinksAndWhitespace));
 		},
 	);
 });
@@ -70,24 +71,24 @@ validStrings.forEach(function(obj) {
  */
 test(
 	"Regex doesn't greedily consume subsequent paragraph tags in minified HTML",
-	(t) => {
+	() => {
 		let multipleParagraphs = "<p>https://twitter.com/SaraSoueidan/status/1289865845053652994</p><p>Foo</p>";
 		let output = patternPresent(multipleParagraphs);
 		let expected = [
 			"<p>https://twitter.com/SaraSoueidan/status/1289865845053652994</p>",
 		];
-		t.deepEqual(output, expected);
+		assert.deepEqual(output, expected);
 	},
 );
 
 test(
 	"Regex doesn't greedily consume subsequent paragraph tags in minified HTML, including anchor tags",
-	(t) => {
+	() => {
 		let multipleParagraphs = `<p><a href="foo">https://twitter.com/SaraSoueidan/status/1289865845053652994</a></p><p>Foo</p>`;
 		let output = patternPresent(multipleParagraphs);
 		let expected = [
 			'<p><a href="foo">https://twitter.com/SaraSoueidan/status/1289865845053652994</a></p>',
 		];
-		t.deepEqual(output, expected);
+		assert.deepEqual(output, expected);
 	},
 );

--- a/packages/vimeo/package.json
+++ b/packages/vimeo/package.json
@@ -10,8 +10,8 @@
   ],
   "main": "index.js",
   "scripts": {
-    "test": "npx ava",
-    "coverage": "nyc --reporter=lcov ava"
+    "test": "node --test",
+    "coverage": "node --test --experimental-test-coverage --test-reporter=lcov --test-reporter-destination=lcov.info"
   },
   "files": [
     "index.js",

--- a/packages/vimeo/test/hash.test.mjs
+++ b/packages/vimeo/test/hash.test.mjs
@@ -1,39 +1,40 @@
-import test from 'ava';
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
 import pattern from '../lib/pattern.js';
 import {getHashIfExists} from "../lib/replace.js";
 
-test("Hash returns undefined when absent", t => {
+test("Hash returns undefined when absent", () => {
 	const match = pattern.exec("<p>https://vimeo.com/123456</p>");
-	t.is(getHashIfExists(match), undefined);
+	assert.equal(getHashIfExists(match), undefined);
 	pattern.lastIndex = 0;
 });
 
-test("Hash returned correctly via regex", t => {
+test("Hash returned correctly via regex", () => {
 	const match = pattern.exec("<p>https://vimeo.com/123456/asdf1234</p>");
-	t.is(getHashIfExists(match), "asdf1234");
+	assert.equal(getHashIfExists(match), "asdf1234");
 	pattern.lastIndex = 0;
 });
 
-test("Hash returned correctly via param", t => {
+test("Hash returned correctly via param", () => {
 	const match = pattern.exec("<p>https://vimeo.com/123456?h=asdf1234</p>");
-	t.is(getHashIfExists(match), "asdf1234");
+	assert.equal(getHashIfExists(match), "asdf1234");
 	pattern.lastIndex = 0;
 });
 
-test("Hash returned correctly via param, multiple params", t => {
+test("Hash returned correctly via param, multiple params", () => {
 	const match = pattern.exec("<p>https://vimeo.com/123456?foo=bar&h=asdf1234</p>");
-	t.is(getHashIfExists(match), "asdf1234");
+	assert.equal(getHashIfExists(match), "asdf1234");
 	pattern.lastIndex = 0;
 });
 
-test("Hash returned correctly via regex, with additional params", t => {
+test("Hash returned correctly via regex, with additional params", () => {
 	const match = pattern.exec("<p>https://vimeo.com/123456/asdf1234?foo=bar</p>");
-	t.is(getHashIfExists(match), "asdf1234");
+	assert.equal(getHashIfExists(match), "asdf1234");
 	pattern.lastIndex = 0;
 });
 
-test("Hash returned correctly with both", t => {
+test("Hash returned correctly with both", () => {
 	const match = pattern.exec("<p>https://vimeo.com/123456/asdf1234?h=asdf1234</p>");
-	t.is(getHashIfExists(match), "asdf1234");
+	assert.equal(getHashIfExists(match), "asdf1234");
 	pattern.lastIndex = 0;
 });

--- a/packages/vimeo/test/params.test.mjs
+++ b/packages/vimeo/test/params.test.mjs
@@ -1,27 +1,28 @@
-import test from 'ava';
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
 import {addEmbedUrlParams} from "../lib/replace.js";
 
-test("Missing input returns default string", t => {
+test("Missing input returns default string", () => {
 	const str = addEmbedUrlParams()
-	t.is(str, "dnt=1")
+	assert.equal(str, "dnt=1")
 });
 
-test("Empty object returns default string", t => {
+test("Empty object returns default string", () => {
 	const str = addEmbedUrlParams({})
-	t.is(str, "dnt=1")
+	assert.equal(str, "dnt=1")
 });
 
-test("Custom DNT value matches default", t => {
+test("Custom DNT value matches default", () => {
 	const str = addEmbedUrlParams({dnt: true})
-	t.is(str, "dnt=1")
+	assert.equal(str, "dnt=1")
 });
 
-test("Custom DNT off", t => {
+test("Custom DNT off", () => {
 	const str = addEmbedUrlParams({dnt: false})
-	t.is(str, "dnt=0")
+	assert.equal(str, "dnt=0")
 });
 
-test("Privacy hash", t => {
+test("Privacy hash", () => {
 	const str = addEmbedUrlParams({hash: 'asdf1234'})
-	t.is(str, "dnt=1&h=asdf1234")
+	assert.equal(str, "dnt=1&h=asdf1234")
 });

--- a/packages/vimeo/test/pattern.test.mjs
+++ b/packages/vimeo/test/pattern.test.mjs
@@ -1,4 +1,5 @@
-import test from 'ava';
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
 import pattern from '../lib/pattern.js';
 import {publicUrls, privateUrls} from './_validUrls.mjs';
 
@@ -6,34 +7,34 @@ const validUrls = [...publicUrls, ...privateUrls];
 
 for (let [index, url] of validUrls.entries()) {
 
-  test(`Regex test ${index}-a: ${url}`, async t => {
+  test(`Regex test ${index}-a: ${url}`, async () => {
     pattern.lastIndex = 0;
     let str = `<p>${url}</p>`
-    t.regex(str, pattern);
+    assert.match(str, pattern);
   });
 
-  test(`Regex test ${index}-b: ${url}, with whitespace`, async t => {
+  test(`Regex test ${index}-b: ${url}, with whitespace`, async () => {
     pattern.lastIndex = 0;
     let str = `<p>
                 ${url}
               </p>`
-    t.regex(str, pattern);
+    assert.match(str, pattern);
   });
 
-  test(`Regex test ${index}-c: ${url}, with link`, async t => {
+  test(`Regex test ${index}-c: ${url}, with link`, async () => {
     pattern.lastIndex = 0;
     let str = `<p><a href="${url}">${url}</a></p>`
-    t.regex(str, pattern);
+    assert.match(str, pattern);
   });
 
-  test(`Regex test ${index}-d: ${url}, with link and whitespace`, async t => {
+  test(`Regex test ${index}-d: ${url}, with link and whitespace`, async () => {
     pattern.lastIndex = 0;
     let str = `<p>
                 <a href="${url}">
                   ${url}
                 </a>
               </p>`
-    t.regex(str, pattern);
+    assert.match(str, pattern);
   });
 
 }

--- a/packages/vimeo/test/replace.private.test.mjs
+++ b/packages/vimeo/test/replace.private.test.mjs
@@ -1,4 +1,5 @@
-import test from 'ava';
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
 import defaults from '../lib/defaults.js';
 import pattern from '../lib/pattern.js';
 import replace from '../lib/replace.js';
@@ -21,40 +22,40 @@ const allStrings = privateUrls.map(url => {
 
 for (let [index, str] of allStrings.flat().entries()) {
 
-  test(`${index} (Private video): Embed string, default options`, async t => {
+  test(`${index} (Private video): Embed string, default options`, async () => {
     const config = Object.assign({}, defaults, {});
     let embed = str.replace(pattern, (...match) => replace(match, config));
-    t.is(embed, '<div id="vimeo-123456" class="eleventy-plugin-vimeo-embed" style="position:relative;width:100%;padding-top:56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" frameborder="0" src="https://player.vimeo.com/video/123456?dnt=1&h=asdf1234" allowfullscreen></iframe></div>')
+    assert.equal(embed, '<div id="vimeo-123456" class="eleventy-plugin-vimeo-embed" style="position:relative;width:100%;padding-top:56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" frameborder="0" src="https://player.vimeo.com/video/123456?dnt=1&h=asdf1234" allowfullscreen></iframe></div>')
   });
 
-  test(`${index} (Private video): Embed string, no fullscreen`, async t => {
+  test(`${index} (Private video): Embed string, no fullscreen`, async () => {
     const config = Object.assign({}, defaults, { allowFullscreen: false });
     let embed = str.replace(pattern, (...match) => replace(match, config));
-    t.is(embed, '<div id="vimeo-123456" class="eleventy-plugin-vimeo-embed" style="position:relative;width:100%;padding-top:56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" frameborder="0" src="https://player.vimeo.com/video/123456?dnt=1&h=asdf1234"></iframe></div>')
+    assert.equal(embed, '<div id="vimeo-123456" class="eleventy-plugin-vimeo-embed" style="position:relative;width:100%;padding-top:56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" frameborder="0" src="https://player.vimeo.com/video/123456?dnt=1&h=asdf1234"></iframe></div>')
   });
 
-  test(`${index} (Private video): Embed string, custom dnt`, async t => {
+  test(`${index} (Private video): Embed string, custom dnt`, async () => {
     const config = Object.assign({}, defaults, { dnt: false });
     let embed = str.replace(pattern, (...match) => replace(match, config));
-    t.is(embed, '<div id="vimeo-123456" class="eleventy-plugin-vimeo-embed" style="position:relative;width:100%;padding-top:56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" frameborder="0" src="https://player.vimeo.com/video/123456?dnt=0&h=asdf1234" allowfullscreen></iframe></div>')
+    assert.equal(embed, '<div id="vimeo-123456" class="eleventy-plugin-vimeo-embed" style="position:relative;width:100%;padding-top:56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" frameborder="0" src="https://player.vimeo.com/video/123456?dnt=0&h=asdf1234" allowfullscreen></iframe></div>')
   });
 
-  test(`${index} (Private video): Embed string, custom class`, async t => {
+  test(`${index} (Private video): Embed string, custom class`, async () => {
     const config = Object.assign({}, defaults, { embedClass: 'foo' });
     let embed = str.replace(pattern, (...match) => replace(match, config));
-    t.is(embed, '<div id="vimeo-123456" class="foo" style="position:relative;width:100%;padding-top:56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" frameborder="0" src="https://player.vimeo.com/video/123456?dnt=1&h=asdf1234" allowfullscreen></iframe></div>')
+    assert.equal(embed, '<div id="vimeo-123456" class="foo" style="position:relative;width:100%;padding-top:56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" frameborder="0" src="https://player.vimeo.com/video/123456?dnt=1&h=asdf1234" allowfullscreen></iframe></div>')
   });
 
-  test(`${index} (Private video): Embed string, custom iframe style`, async t => {
+  test(`${index} (Private video): Embed string, custom iframe style`, async () => {
     const config = Object.assign({}, defaults, { iframeStyle: 'foo'});
     let embed = str.replace(pattern, (...match) => replace(match, config));
-    t.is(embed, '<div id="vimeo-123456" class="eleventy-plugin-vimeo-embed" style="position:relative;width:100%;padding-top:56.25%;"><iframe style="foo" frameborder="0" src="https://player.vimeo.com/video/123456?dnt=1&h=asdf1234" allowfullscreen></iframe></div>')
+    assert.equal(embed, '<div id="vimeo-123456" class="eleventy-plugin-vimeo-embed" style="position:relative;width:100%;padding-top:56.25%;"><iframe style="foo" frameborder="0" src="https://player.vimeo.com/video/123456?dnt=1&h=asdf1234" allowfullscreen></iframe></div>')
   });
 
-  test(`${index} (Private video): Embed string, custom wrapper style`, async t => {
+  test(`${index} (Private video): Embed string, custom wrapper style`, async () => {
     const config = Object.assign({}, defaults, { wrapperStyle: 'foo' });
     let embed = str.replace(pattern, (...match) => replace(match, config));
-    t.is(embed, '<div id="vimeo-123456" class="eleventy-plugin-vimeo-embed" style="foo"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" frameborder="0" src="https://player.vimeo.com/video/123456?dnt=1&h=asdf1234" allowfullscreen></iframe></div>')
+    assert.equal(embed, '<div id="vimeo-123456" class="eleventy-plugin-vimeo-embed" style="foo"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" frameborder="0" src="https://player.vimeo.com/video/123456?dnt=1&h=asdf1234" allowfullscreen></iframe></div>')
   });
 
 }

--- a/packages/vimeo/test/replace.test.mjs
+++ b/packages/vimeo/test/replace.test.mjs
@@ -1,4 +1,5 @@
-import test from 'ava';
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
 import defaults from '../lib/defaults.js';
 import pattern from '../lib/pattern.js';
 import replace from '../lib/replace.js';
@@ -21,40 +22,40 @@ const allStrings = publicUrls.map(url => {
 
 for (let [index, str] of allStrings.flat().entries()) {
 
-  test(`${index}: Embed string, default options`, async t => {
+  test(`${index}: Embed string, default options`, async () => {
     const config = Object.assign({}, defaults, {});
     let embed = str.replace(pattern, (...match) => replace(match, config));
-    t.is(embed, '<div id="vimeo-123456" class="eleventy-plugin-vimeo-embed" style="position:relative;width:100%;padding-top:56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" frameborder="0" src="https://player.vimeo.com/video/123456?dnt=1" allowfullscreen></iframe></div>')
+    assert.equal(embed, '<div id="vimeo-123456" class="eleventy-plugin-vimeo-embed" style="position:relative;width:100%;padding-top:56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" frameborder="0" src="https://player.vimeo.com/video/123456?dnt=1" allowfullscreen></iframe></div>')
   });
 
-  test(`${index}: Embed string, no fullscreen`, async t => {
+  test(`${index}: Embed string, no fullscreen`, async () => {
     const config = Object.assign({}, defaults, { allowFullscreen: false });
     let embed = str.replace(pattern, (...match) => replace(match, config));
-    t.is(embed, '<div id="vimeo-123456" class="eleventy-plugin-vimeo-embed" style="position:relative;width:100%;padding-top:56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" frameborder="0" src="https://player.vimeo.com/video/123456?dnt=1"></iframe></div>')
+    assert.equal(embed, '<div id="vimeo-123456" class="eleventy-plugin-vimeo-embed" style="position:relative;width:100%;padding-top:56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" frameborder="0" src="https://player.vimeo.com/video/123456?dnt=1"></iframe></div>')
   });
 
-  test(`${index}: Embed string, custom dnt`, async t => {
+  test(`${index}: Embed string, custom dnt`, async () => {
     const config = Object.assign({}, defaults, { dnt: false });
     let embed = str.replace(pattern, (...match) => replace(match, config));
-    t.is(embed, '<div id="vimeo-123456" class="eleventy-plugin-vimeo-embed" style="position:relative;width:100%;padding-top:56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" frameborder="0" src="https://player.vimeo.com/video/123456?dnt=0" allowfullscreen></iframe></div>')
+    assert.equal(embed, '<div id="vimeo-123456" class="eleventy-plugin-vimeo-embed" style="position:relative;width:100%;padding-top:56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" frameborder="0" src="https://player.vimeo.com/video/123456?dnt=0" allowfullscreen></iframe></div>')
   });
 
-  test(`${index}: Embed string, custom class`, async t => {
+  test(`${index}: Embed string, custom class`, async () => {
     const config = Object.assign({}, defaults, { embedClass: 'foo' });
     let embed = str.replace(pattern, (...match) => replace(match, config));
-    t.is(embed, '<div id="vimeo-123456" class="foo" style="position:relative;width:100%;padding-top:56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" frameborder="0" src="https://player.vimeo.com/video/123456?dnt=1" allowfullscreen></iframe></div>')
+    assert.equal(embed, '<div id="vimeo-123456" class="foo" style="position:relative;width:100%;padding-top:56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" frameborder="0" src="https://player.vimeo.com/video/123456?dnt=1" allowfullscreen></iframe></div>')
   });
 
-  test(`${index}: Embed string, custom iframe style`, async t => {
+  test(`${index}: Embed string, custom iframe style`, async () => {
     const config = Object.assign({}, defaults, { iframeStyle: 'foo'});
     let embed = str.replace(pattern, (...match) => replace(match, config));
-    t.is(embed, '<div id="vimeo-123456" class="eleventy-plugin-vimeo-embed" style="position:relative;width:100%;padding-top:56.25%;"><iframe style="foo" frameborder="0" src="https://player.vimeo.com/video/123456?dnt=1" allowfullscreen></iframe></div>')
+    assert.equal(embed, '<div id="vimeo-123456" class="eleventy-plugin-vimeo-embed" style="position:relative;width:100%;padding-top:56.25%;"><iframe style="foo" frameborder="0" src="https://player.vimeo.com/video/123456?dnt=1" allowfullscreen></iframe></div>')
   });
 
-  test(`${index}: Embed string, custom wrapper style`, async t => {
+  test(`${index}: Embed string, custom wrapper style`, async () => {
     const config = Object.assign({}, defaults, { wrapperStyle: 'foo' });
     let embed = str.replace(pattern, (...match) => replace(match, config));
-    t.is(embed, '<div id="vimeo-123456" class="eleventy-plugin-vimeo-embed" style="foo"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" frameborder="0" src="https://player.vimeo.com/video/123456?dnt=1" allowfullscreen></iframe></div>')
+    assert.equal(embed, '<div id="vimeo-123456" class="eleventy-plugin-vimeo-embed" style="foo"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" frameborder="0" src="https://player.vimeo.com/video/123456?dnt=1" allowfullscreen></iframe></div>')
   });
 
 }

--- a/packages/youtube/package.json
+++ b/packages/youtube/package.json
@@ -14,8 +14,8 @@
     "lib"
   ],
   "scripts": {
-    "test": "npx ava",
-    "coverage": "nyc --reporter=lcov ava"
+    "test": "node --test",
+    "coverage": "node --test --experimental-test-coverage --test-reporter=lcov --test-reporter-destination=lcov.info"
   },
   "author": {
     "name": "Graham F. Scott",

--- a/packages/youtube/test/embed.default.playlist.test.js
+++ b/packages/youtube/test/embed.default.playlist.test.js
@@ -1,4 +1,5 @@
-const test = require('ava');
+const test = require('node:test');
+const assert = require('node:assert/strict');
 const merge = require('deepmerge');
 const pattern = require('../lib/pattern.js');
 const embed = require('../lib/embed.js');
@@ -26,49 +27,49 @@ const override = (obj) => merge(defaults, obj);
 const testString = '<p>https://www.youtube.com/playlist?list=PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW</p>';
 
 test(`Playlist embed default mode, default settings`, async t => {
-  t.is(await embed(extract(testString), defaults),
+  assert.equal(await embed(extract(testString), defaults),
     '<div id="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/videoseries?list=PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe></div>'
   );
 });
 
 test(`Playlist embed default mode, override allowAttrs`, async t => {
-  t.is(await embed(extract(testString), override({allowAttrs: 'foo'})),
+  assert.equal(await embed(extract(testString), override({allowAttrs: 'foo'})),
     '<div id="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/videoseries?list=PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" allow="foo" allowfullscreen></iframe></div>'
   );
 });
 
 test(`Playlist embed default mode, override allowFullscreen`, async t => {
-  t.is(await embed(extract(testString), override({allowFullscreen: false})),
+  assert.equal(await embed(extract(testString), override({allowFullscreen: false})),
     '<div id="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/videoseries?list=PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"></iframe></div>'
   );
 });
 
 test(`Playlist embed default mode, override allowAutoplay`, async t => {
-  t.is(await embed(extract(testString), override({allowAutoplay: true})),
+  assert.equal(await embed(extract(testString), override({allowAutoplay: true})),
     '<div id="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/videoseries?list=PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW&autoplay=1" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe></div>'
   );
 });
 
 test(`Playlist embed default mode, override embed class`, async t => {
-  t.is(await embed(extract(testString), override({embedClass: 'foo'})),
+  assert.equal(await embed(extract(testString), override({embedClass: 'foo'})),
     '<div id="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" class="foo" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/videoseries?list=PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe></div>'
   );
 });
 
 test(`Playlist embed default mode, override lazy loading`, async t => {
-  t.is(await embed(extract(testString), override({lazy: true})),
+  assert.equal(await embed(extract(testString), override({lazy: true})),
     '<div id="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/videoseries?list=PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen loading="lazy"></iframe></div>'
   );
 });
 
 test(`Playlist embed default mode, override noCookie`, async t => {
-  t.is(await embed(extract(testString), override({noCookie: false})),
+  assert.equal(await embed(extract(testString), override({noCookie: false})),
     '<div id="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube.com/embed/videoseries?list=PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe></div>'
   );
 });
 
 test(`Playlist embed default mode, override recommendSelfOnly`, async t => {
-  t.is(await embed(extract(testString), override({recommendSelfOnly: true})),
+  assert.equal(await embed(extract(testString), override({recommendSelfOnly: true})),
     '<div id="PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/videoseries?list=PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW&rel=1" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe></div>'
   );
 });

--- a/packages/youtube/test/embed.default.test.js
+++ b/packages/youtube/test/embed.default.test.js
@@ -1,4 +1,5 @@
-const test = require('ava');
+const test = require('node:test');
+const assert = require('node:assert/strict');
 const merge = require('deepmerge');
 const pattern = require('../lib/pattern.js');
 const embed = require('../lib/embed.js');
@@ -25,81 +26,81 @@ const override = (obj) => merge(defaults, obj);
 
 const testString = '<p>https://www.youtube.com/watch?v=hIs5StN8J-0</p>';
 
-test(`Build embed default mode, default settings`, async t => {
-  t.is(await embed(extract(testString), defaults),
+test(`Build embed default mode, default settings`, async () => {
+  assert.equal(await embed(extract(testString), defaults),
     '<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/hIs5StN8J-0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe></div>'
   );
 });
 
-test(`Build embed default mode, override nothing`, async t => {
-  t.is(
+test(`Build embed default mode, override nothing`, async () => {
+  assert.equal(
     (await embed(extract(testString), defaults)),
     '<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/hIs5StN8J-0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe></div>'
   );
 });
 
-test(`Build embed default mode, override allowAttrs`, async t => {
-  t.is(await embed(extract(testString), override({allowAttrs: 'foo'})),
+test(`Build embed default mode, override allowAttrs`, async () => {
+  assert.equal(await embed(extract(testString), override({allowAttrs: 'foo'})),
     '<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/hIs5StN8J-0" allow="foo" allowfullscreen></iframe></div>'
   );
 });
 
-test(`Build embed default mode, override allowFullscreen`, async t => {
-  t.is(await embed(extract(testString), override({allowFullscreen: false})),
+test(`Build embed default mode, override allowFullscreen`, async () => {
+  assert.equal(await embed(extract(testString), override({allowFullscreen: false})),
     '<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/hIs5StN8J-0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"></iframe></div>'
   );
 });
 
-test(`Build embed default mode, override allowAutoplay`, async t => {
-  t.is(await embed(extract(testString), override({allowAutoplay: true})),
+test(`Build embed default mode, override allowAutoplay`, async () => {
+  assert.equal(await embed(extract(testString), override({allowAutoplay: true})),
     '<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/hIs5StN8J-0?autoplay=1" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe></div>'
   );
 });
 
-test(`Build embed default mode, override embedClass`, async t => {
-  t.is(await embed(extract(testString), override({embedClass: 'foo'})),
+test(`Build embed default mode, override embedClass`, async () => {
+  assert.equal(await embed(extract(testString), override({embedClass: 'foo'})),
     '<div id="hIs5StN8J-0" class="foo" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/hIs5StN8J-0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe></div>'
   );
 });
 
-test(`Build embed default mode, override lazy`, async t => {
-  t.is(await embed(extract(testString), override({lazy: true})),
+test(`Build embed default mode, override lazy`, async () => {
+  assert.equal(await embed(extract(testString), override({lazy: true})),
     '<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/hIs5StN8J-0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen loading="lazy"></iframe></div>'
   );
 });
 
-test(`Build embed default mode, override noCookie`, async t => {
-  t.is(await embed(extract(testString), override({noCookie: false})),
+test(`Build embed default mode, override noCookie`, async () => {
+  assert.equal(await embed(extract(testString), override({noCookie: false})),
     '<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube.com/embed/hIs5StN8J-0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe></div>'
   );
 });
 
-test(`Build embed default mode, override recommendSelfOnly`, async t => {
-  t.is(await embed(extract(testString), override({recommendSelfOnly: true})),
+test(`Build embed default mode, override recommendSelfOnly`, async () => {
+  assert.equal(await embed(extract(testString), override({recommendSelfOnly: true})),
     '<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/hIs5StN8J-0?rel=1" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe></div>'
   );
 });
 
-test(`Build embed default mode, download YouTube title`, async t => {
-  t.is(await embed(extract(testString), override({titleOptions: { download: true }})),
+test(`Build embed default mode, download YouTube title`, async () => {
+  assert.equal(await embed(extract(testString), override({titleOptions: { download: true }})),
   '<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Animotion - Obsession" src="https://www.youtube-nocookie.com/embed/hIs5StN8J-0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe></div>'
   );
 });
 
-test(`Build embed default mode, override start time`, async t => {
-  t.is(await embed(extract(testString), override({startTime: 30})),
+test(`Build embed default mode, override start time`, async () => {
+  assert.equal(await embed(extract(testString), override({startTime: 30})),
     '<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/hIs5StN8J-0?start=30" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe></div>'
   );
 });
 
-test(`Build embed default mode, override start time via URL`, async t => {
-  t.is(await embed(extract('<p>https://www.youtube.com/watch?v=hIs5StN8J-0&t=30s</p>'), override({})),
+test(`Build embed default mode, override start time via URL`, async () => {
+  assert.equal(await embed(extract('<p>https://www.youtube.com/watch?v=hIs5StN8J-0&t=30s</p>'), override({})),
     '<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/hIs5StN8J-0?start=30" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe></div>'
   );
 });
 
-test(`Build embed default mode, short link with override start time via URL`, async t => {
-  t.is(await embed(extract('<p>https://youtu.be/hIs5StN8J-0?t=30</p>'), override({})),
+test(`Build embed default mode, short link with override start time via URL`, async () => {
+  assert.equal(await embed(extract('<p>https://youtu.be/hIs5StN8J-0?t=30</p>'), override({})),
     '<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/hIs5StN8J-0?start=30" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe></div>'
   );
 });

--- a/packages/youtube/test/embed.lite.multiple.test.js
+++ b/packages/youtube/test/embed.lite.multiple.test.js
@@ -1,4 +1,5 @@
-const test = require('ava');
+const test = require('node:test');
+const assert = require('node:assert/strict');
 const merge = require('deepmerge');
 const pattern = require('../lib/pattern.js');
 const embed = require('../lib/embed.js');
@@ -37,6 +38,6 @@ test(`Build embed lite mode, two videos, start time should not bleed into the se
     return await embed(match, config, index++)
   });
 
-  t.is(result, `<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.css">\n<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.js"></script>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');" params="start=5"><div class="lty-playbtn"></div></lite-youtube></div><div id="4JS70KB9GS0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="4JS70KB9GS0" style="background-image: url('https://i.ytimg.com/vi/4JS70KB9GS0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`);
+  assert.equal(result, `<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.css">\n<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.js"></script>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');" params="start=5"><div class="lty-playbtn"></div></lite-youtube></div><div id="4JS70KB9GS0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="4JS70KB9GS0" style="background-image: url('https://i.ytimg.com/vi/4JS70KB9GS0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`);
 });
 

--- a/packages/youtube/test/embed.lite.playlist.test.js
+++ b/packages/youtube/test/embed.lite.playlist.test.js
@@ -1,4 +1,5 @@
-const test = require('ava');
+const test = require('node:test');
+const assert = require('node:assert/strict');
 const merge = require('deepmerge');
 const pattern = require('../lib/pattern.js');
 const embed = require('../lib/embed.js');
@@ -37,54 +38,54 @@ const override = (obj) => merge(defaults, obj);
  * Lite mode, zero index (first instance on page includes script and CSS)
  */
 test(`Build embed lite mode, zero index, lite defaults`, async t => {
-	t.is(await embed(extract(testString), override({lite: true}), 0), testString);
+	assert.equal(await embed(extract(testString), override({lite: true}), 0), testString);
 });
 test(`Build embed lite mode, zero index, JS API enabled`, async t => {
-	t.is(await embed(extract(testString), override({lite: {jsApi: true}}), 0), testString);
+	assert.equal(await embed(extract(testString), override({lite: {jsApi: true}}), 0), testString);
 });
 test(`Build embed lite mode, zero index, valid thumbnail format override`, async t => {
-	t.is(await embed(extract(testString), override({lite: {thumbnailFormat: 'webp'}}), 0), testString);
+	assert.equal(await embed(extract(testString), override({lite: {thumbnailFormat: 'webp'}}), 0), testString);
 });
 test(`Build embed lite mode, zero index, invalid thumbnail format override`, async t => {
-	t.is(await embed(extract(testString), override({lite: {thumbnailFormat: 'no'}}), 0), testString);
+	assert.equal(await embed(extract(testString), override({lite: {thumbnailFormat: 'no'}}), 0), testString);
 });
 test(`Build embed lite mode, zero index, valid thumbnail quality override`, async t => {
-	t.is(await embed(extract(testString), override({lite: { thumbnailQuality: 'maxresdefault'}}), 0), testString);
+	assert.equal(await embed(extract(testString), override({lite: { thumbnailQuality: 'maxresdefault'}}), 0), testString);
 });
 test(`Build embed lite mode, zero index, invalid thumbnail quality override`, async t => {
-	t.is(await embed(extract(testString), override({lite: { thumbnailQuality: 'nope'}}), 0), testString);
+	assert.equal(await embed(extract(testString), override({lite: { thumbnailQuality: 'nope'}}), 0), testString);
 });
 test(`Build embed lite mode, zero index, lite defaults with URL start time param`, async t => {
-	t.is(await embed(extract('<p>https://www.youtube.com/playlist?list=PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW&t=30s</p>'), override({lite: true}), 0),
+	assert.equal(await embed(extract('<p>https://www.youtube.com/playlist?list=PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW&t=30s</p>'), override({lite: true}), 0),
 	'<p>https://www.youtube.com/playlist?list=PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW&t=30s</p>'
 	);
 });
 test(`Build embed lite mode, zero index, css disabled`, async t => {
-	t.is(await embed(extract(testString), override({lite:{css:{enabled: false}}}), 0), testString);
+	assert.equal(await embed(extract(testString), override({lite:{css:{enabled: false}}}), 0), testString);
 });
 test(`Build embed lite mode, zero index, css inline`, async t => {
-	t.is(await embed(extract(testString), override({lite:{css:{inline: true}}}), 0), testString);
+	assert.equal(await embed(extract(testString), override({lite:{css:{inline: true}}}), 0), testString);
 });
 test(`Build embed lite mode, zero index, css path override`, async t => {
-	t.is(await embed(extract(testString), override({lite:{css:{path: 'foo'}}}), 0), testString);
+	assert.equal(await embed(extract(testString), override({lite:{css:{path: 'foo'}}}), 0), testString);
 });
 test(`Build embed lite mode, zero index, js disabled`, async t => {
-	t.is(await embed(extract(testString), override({lite:{js:{enabled: false}}}), 0), testString);
+	assert.equal(await embed(extract(testString), override({lite:{js:{enabled: false}}}), 0), testString);
 });
 test(`Build embed lite mode, zero index, js inline`, async t => {
-	t.is(await embed(extract(testString), override({lite:{js:{inline: true}}}), 0), testString);
+	assert.equal(await embed(extract(testString), override({lite:{js:{inline: true}}}), 0), testString);
 });
 test(`Build embed lite mode, zero index, css AND js disabled`, async t => {
-	t.is(await embed(extract(testString), override({lite:{css:{enabled:false},js:{enabled:false}}}), 0), testString);
+	assert.equal(await embed(extract(testString), override({lite:{css:{enabled:false},js:{enabled:false}}}), 0), testString);
 });
 test(`Build embed lite mode, zero index, css AND js path override`, async t => {
-	t.is(await embed(extract(testString), override({lite:{css:{path: 'foo'},js:{path: 'foo'}}}), 0), testString);
+	assert.equal(await embed(extract(testString), override({lite:{css:{path: 'foo'},js:{path: 'foo'}}}), 0), testString);
 });
 test(`Build embed lite mode, zero index, css AND js inline`, async t => {
-	t.is(await embed(extract(testString), override({lite:{css:{inline: true},js:{inline: true}}}), 0), testString);
+	assert.equal(await embed(extract(testString), override({lite:{css:{inline: true},js:{inline: true}}}), 0), testString);
 });
 test(`Build embed lite mode, zero index, responsive true`, async t => {
-	t.is(await embed(extract(testString), override({lite: { responsive: true }}), 0), testString);
+	assert.equal(await embed(extract(testString), override({lite: { responsive: true }}), 0), testString);
 });
 
 
@@ -92,79 +93,79 @@ test(`Build embed lite mode, zero index, responsive true`, async t => {
  * Lite mode, 1+ index (no style or script on subsequent outputs)
  */
 test(`Build embed lite mode, 1+ index, lite defaults`, async t => {
-	t.is(await embed(extract(testString), override({lite: true}), 1), testString);
+	assert.equal(await embed(extract(testString), override({lite: true}), 1), testString);
 });
 test(`Build embed lite mode, 1+ index, JS API enabled`, async t => {
-	t.is(await embed(extract(testString), override({lite: {jsApi: true}}), 1), testString);
+	assert.equal(await embed(extract(testString), override({lite: {jsApi: true}}), 1), testString);
 });
 test(`Build embed lite mode, 1+ index, valid thumbnail quality override`, async t => {
-	t.is(await embed(extract(testString), override({lite: { thumbnailQuality: 'maxresdefault'}}), 1), testString);
+	assert.equal(await embed(extract(testString), override({lite: { thumbnailQuality: 'maxresdefault'}}), 1), testString);
 });
 test(`Build embed lite mode, 1+ index, invalid thumbnail quality override`, async t => {
-	t.is(await embed(extract(testString), override({lite: { thumbnailQuality: 'nope'}}), 1), testString);
+	assert.equal(await embed(extract(testString), override({lite: { thumbnailQuality: 'nope'}}), 1), testString);
 });
 test(`Build embed lite mode, 1+ index, valid thumbnail format override`, async t => {
-	t.is(await embed(extract(testString), override({lite: {thumbnailFormat: 'webp'}}), 1), testString);
+	assert.equal(await embed(extract(testString), override({lite: {thumbnailFormat: 'webp'}}), 1), testString);
 });
 test(`Build embed lite mode, 1+ index, invalid thumbnail format override`, async t => {
-	t.is(await embed(extract(testString), override({lite: {thumbnailFormat: 'foo'}}), 1), testString);
+	assert.equal(await embed(extract(testString), override({lite: {thumbnailFormat: 'foo'}}), 1), testString);
 });
 test(`Build embed lite mode, 1+ index, lite defaults with URL start time param`, async t => {
-	t.is(await embed(extract('<p>https://www.youtube.com/playlist?list=PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW&t=30s</p>'), override({lite: true}), 1),
+	assert.equal(await embed(extract('<p>https://www.youtube.com/playlist?list=PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW&t=30s</p>'), override({lite: true}), 1),
 	'<p>https://www.youtube.com/playlist?list=PLCbA9r6ecYWU6SVyvb32a0YHIzpr9jxnW&t=30s</p>'
 	);
 });
 test(`Build embed lite mode, 1+ index, css disabled`, async t => {
-	t.is(await embed(extract(testString), override({lite:{css:{enabled: false}}}), 1), testString);
+	assert.equal(await embed(extract(testString), override({lite:{css:{enabled: false}}}), 1), testString);
 });
 test(`Build embed lite mode, 1+ index, css inline`, async t => {
-	t.is(await embed(extract(testString), override({lite:{css:{inline: true}}}), 1), testString);
+	assert.equal(await embed(extract(testString), override({lite:{css:{inline: true}}}), 1), testString);
 });
 test(`Build embed lite mode, 1+ index, css path override`, async t => {
-	t.is(await embed(extract(testString), override({lite:{css:{path: 'foo'}}}), 1), testString);
+	assert.equal(await embed(extract(testString), override({lite:{css:{path: 'foo'}}}), 1), testString);
 });
 test(`Build embed lite mode, 1+ index, js disabled`, async t => {
-	t.is(await embed(extract(testString), override({lite:{js:{enabled: false}}}), 1), testString);
+	assert.equal(await embed(extract(testString), override({lite:{js:{enabled: false}}}), 1), testString);
 });
 test(`Build embed lite mode, 1+ index, js inline`, async t => {
-	t.is(await embed(extract(testString), override({lite:{js:{inline: true}}}), 1), testString);
+	assert.equal(await embed(extract(testString), override({lite:{js:{inline: true}}}), 1), testString);
 });
 test(`Build embed lite mode, 1+ index, responsive true`, async t => {
-	t.is(await embed(extract(testString), override({lite: { responsive: true }}), 1), testString);
+	assert.equal(await embed(extract(testString), override({lite: { responsive: true }}), 1), testString);
 });
 
 /**
  * In lite mode, test that the thumbnail validators return the expected values.
 */
 test(`Thumbnail size validator returns default value in response to empty parameter`, t => {
-  t.is(validateThumbnailSize(), 'hqdefault');
+  assert.equal(validateThumbnailSize(), 'hqdefault');
 });
 test(`Thumbnail size validator returns default value in response to incorrect parameter types`, t => {
-  t.is(validateThumbnailSize(1), 'hqdefault');
-  t.is(validateThumbnailSize(true), 'hqdefault');
+  assert.equal(validateThumbnailSize(1), 'hqdefault');
+  assert.equal(validateThumbnailSize(true), 'hqdefault');
 });
 test(`Thumbnail size validator returns default value in response to invalid string`, t => {
-  t.is(validateThumbnailSize('foo'), 'hqdefault');
+  assert.equal(validateThumbnailSize('foo'), 'hqdefault');
 });
 test(`Thumbnail size validator returns expected strings when passed expected strings`, t => {
-  t.is(validateThumbnailSize('default'), 'default');
-  t.is(validateThumbnailSize('hqdefault'), 'hqdefault');
-  t.is(validateThumbnailSize('mqdefault'), 'mqdefault');
-  t.is(validateThumbnailSize('sddefault'), 'sddefault');
-  t.is(validateThumbnailSize('maxresdefault'), 'maxresdefault');
+  assert.equal(validateThumbnailSize('default'), 'default');
+  assert.equal(validateThumbnailSize('hqdefault'), 'hqdefault');
+  assert.equal(validateThumbnailSize('mqdefault'), 'mqdefault');
+  assert.equal(validateThumbnailSize('sddefault'), 'sddefault');
+  assert.equal(validateThumbnailSize('maxresdefault'), 'maxresdefault');
 });
 
 test(`Thumbnail format validator returns default value in response to empty parameter`, t => {
-  t.is(validateThumbnailFormat(), 'jpg');
+  assert.equal(validateThumbnailFormat(), 'jpg');
 })
 test(`Thumbnail format validator returns default value in response to incorrect parameter types`, t => {
-  t.is(validateThumbnailFormat(1), 'jpg');
-  t.is(validateThumbnailFormat(true), 'jpg');
+  assert.equal(validateThumbnailFormat(1), 'jpg');
+  assert.equal(validateThumbnailFormat(true), 'jpg');
 });
 test(`Thumbnail format validator returns default value in response to invalid string`, t => {
-  t.is(validateThumbnailFormat('avif'), 'jpg');
+  assert.equal(validateThumbnailFormat('avif'), 'jpg');
 });
 test(`Thumbnail format validator returns expected strings when passed expected strings`, t => {
-  t.is(validateThumbnailFormat('jpg'), 'jpg');
-  t.is(validateThumbnailFormat('webp'), 'webp');
+  assert.equal(validateThumbnailFormat('jpg'), 'jpg');
+  assert.equal(validateThumbnailFormat('webp'), 'webp');
 });

--- a/packages/youtube/test/embed.lite.test.js
+++ b/packages/youtube/test/embed.lite.test.js
@@ -1,4 +1,5 @@
-const test = require('ava');
+const test = require('node:test');
+const assert = require('node:assert/strict');
 const merge = require('deepmerge');
 const pattern = require('../lib/pattern.js');
 const embed = require('../lib/embed.js');
@@ -37,92 +38,92 @@ const override = (obj) => merge(defaults, obj);
  * Lite mode, zero index (first instance on page includes script and CSS)
  */
 test(`Build embed lite mode, zero index, lite defaults`, async t => {
-	t.is(await embed(extract(testString), override({lite: true}), 0),
+	assert.equal(await embed(extract(testString), override({lite: true}), 0),
 	`<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.css">\n<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.js"></script>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
 	);
 });
 test(`Build embed lite mode, zero index, JS API enabled`, async t => {
-	t.is(await embed(extract(testString), override({lite: {jsApi: true}}), 0),
+	assert.equal(await embed(extract(testString), override({lite: {jsApi: true}}), 0),
 	`<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.css">\n<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.js"></script>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');" js-api><div class="lty-playbtn"></div></lite-youtube></div>`
 	);
 });
 test(`Build embed lite mode, zero index, valid thumbnail format override`, async t => {
-	t.is(await embed(extract(testString), override({lite: {thumbnailFormat: 'webp'}}), 0),
+	assert.equal(await embed(extract(testString), override({lite: {thumbnailFormat: 'webp'}}), 0),
 	`<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.css">\n<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.js"></script>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi_webp/hIs5StN8J-0/hqdefault.webp');"><div class="lty-playbtn"></div></lite-youtube></div>`
 	);
 });
 test(`Build embed lite mode, zero index, invalid thumbnail format override`, async t => {
-	t.is(await embed(extract(testString), override({lite: {thumbnailFormat: 'no'}}), 0),
+	assert.equal(await embed(extract(testString), override({lite: {thumbnailFormat: 'no'}}), 0),
 	`<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.css">\n<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.js"></script>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
 	);
 });
 test(`Build embed lite mode, zero index, valid thumbnail quality override`, async t => {
-	t.is(await embed(extract(testString), override({lite: { thumbnailQuality: 'maxresdefault'}}), 0),
+	assert.equal(await embed(extract(testString), override({lite: { thumbnailQuality: 'maxresdefault'}}), 0),
 	`<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.css">\n<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.js"></script>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/maxresdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
 	);
 });
 test(`Build embed lite mode, zero index, invalid thumbnail quality override`, async t => {
-	t.is(await embed(extract(testString), override({lite: { thumbnailQuality: 'nope'}}), 0),
+	assert.equal(await embed(extract(testString), override({lite: { thumbnailQuality: 'nope'}}), 0),
 	`<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.css">\n<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.js"></script>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
 	);
 });
 test(`Build embed lite mode, zero index, lite defaults with URL start time param`, async t => {
-	t.is(await embed(extract('<p>https://www.youtube.com/watch?v=hIs5StN8J-0&t=30s</p>'), override({lite: true}), 0),
+	assert.equal(await embed(extract('<p>https://www.youtube.com/watch?v=hIs5StN8J-0&t=30s</p>'), override({lite: true}), 0),
 	`<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.css">\n<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.js"></script>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');" params="start=30"><div class="lty-playbtn"></div></lite-youtube></div>`
 	);
 });
 test(`Build embed lite mode, zero index, css disabled`, async t => {
-	t.is(await embed(extract(testString), override({lite:{css:{enabled: false}}}), 0),
+	assert.equal(await embed(extract(testString), override({lite:{css:{enabled: false}}}), 0),
 	`<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.js"></script>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
 	);
 });
 test(`Build embed lite mode, zero index, css inline`, async t => {
-	t.is(await embed(extract(testString), override({lite:{css:{inline: true}}}), 0),
+	assert.equal(await embed(extract(testString), override({lite:{css:{inline: true}}}), 0),
 	`<style>${inlineCss}</style>\n<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.js"></script>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
 	);
 });
 test(`Build embed lite mode, zero index, css path override`, async t => {
-	t.is(await embed(extract(testString), override({lite:{css:{path: 'foo'}}}), 0),
+	assert.equal(await embed(extract(testString), override({lite:{css:{path: 'foo'}}}), 0),
 	`<link rel="stylesheet" href="foo">\n<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.js"></script>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
 	);
 });
 test(`Build embed lite mode, zero index, js disabled`, async t => {
-	t.is(await embed(extract(testString), override({lite:{js:{enabled: false}}}), 0),
+	assert.equal(await embed(extract(testString), override({lite:{js:{enabled: false}}}), 0),
 	`<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.css">\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
 	);
 });
 test(`Build embed lite mode, zero index, js inline`, async t => {
-	t.is(await embed(extract(testString), override({lite:{js:{inline: true}}}), 0),
+	assert.equal(await embed(extract(testString), override({lite:{js:{inline: true}}}), 0),
 	`<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.css">\n<script>${inlineJs}</script>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
 	);
 });
 test(`Build embed lite mode, zero index, css AND js disabled`, async t => {
-	t.is(await embed(extract(testString), override({lite:{css:{enabled:false},js:{enabled:false}}}), 0),
+	assert.equal(await embed(extract(testString), override({lite:{css:{enabled:false},js:{enabled:false}}}), 0),
 	`<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
 	);
 });
 test(`Build embed lite mode, zero index, css AND js path override`, async t => {
-	t.is(await embed(extract(testString), override({lite:{css:{path: 'foo'},js:{path: 'foo'}}}), 0),
+	assert.equal(await embed(extract(testString), override({lite:{css:{path: 'foo'},js:{path: 'foo'}}}), 0),
 	`<link rel="stylesheet" href="foo">\n<script defer="defer" src="foo"></script>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
 	);
 });
 test(`Build embed lite mode, zero index, css AND js inline`, async t => {
-	t.is(await embed(extract(testString), override({lite:{css:{inline: true},js:{inline: true}}}), 0),
+	assert.equal(await embed(extract(testString), override({lite:{css:{inline: true},js:{inline: true}}}), 0),
 	`<style>${inlineCss}</style>\n<script>${inlineJs}</script>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
 	);
 });
 test(`Build embed lite mode, zero index, responsive true`, async t => {
-	t.is(await embed(extract(testString), override({lite: { responsive: true }}), 0),
+	assert.equal(await embed(extract(testString), override({lite: { responsive: true }}), 0),
 	`<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.css">\n<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.js"></script>\n<style>.eleventy-plugin-youtube-embed lite-youtube {max-width:100%}</style>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
 	);
 });
 test(`Build embed lite mode, zero index, fetch title via oembed`, async t => {
-	t.is(await embed(extract(testString), override({lite: { responsive: true }, titleOptions: {download: true}}), 0),
+	assert.equal(await embed(extract(testString), override({lite: { responsive: true }, titleOptions: {download: true}}), 0),
 	`<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.css">\n<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.js"></script>\n<style>.eleventy-plugin-youtube-embed lite-youtube {max-width:100%}</style>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');" title="Animotion - Obsession"><div class="lty-playbtn"></div></lite-youtube></div>`
 	);
 });
 test(`Build embed lite mode, zero index, default title set but should be ignored`, async t => {
-	t.is(await embed(extract(testString), override({lite: { responsive: true }, title: "Foo"}), 0),
+	assert.equal(await embed(extract(testString), override({lite: { responsive: true }, title: "Foo"}), 0),
 	`<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.css">\n<script defer="defer" src="https://cdn.jsdelivr.net/gh/paulirish/lite-youtube-embed@0.3.3/src/lite-yt-embed.min.js"></script>\n<style>.eleventy-plugin-youtube-embed lite-youtube {max-width:100%}</style>\n<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
 	);
 });
@@ -132,77 +133,77 @@ test(`Build embed lite mode, zero index, default title set but should be ignored
  * Lite mode, 1+ index (no style or script on subsequent outputs)
  */
 test(`Build embed lite mode, 1+ index, lite defaults`, async t => {
-	t.is(await embed(extract(testString), override({lite: true}), 1),
+	assert.equal(await embed(extract(testString), override({lite: true}), 1),
 	`<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
 	);
 });
 test(`Build embed lite mode, 1+ index, JS API enabled`, async t => {
-	t.is(await embed(extract(testString), override({lite: {jsApi: true}}), 1),
+	assert.equal(await embed(extract(testString), override({lite: {jsApi: true}}), 1),
 	`<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');" js-api><div class="lty-playbtn"></div></lite-youtube></div>`
 	);
 });
 test(`Build embed lite mode, 1+ index, valid thumbnail quality override`, async t => {
-	t.is(await embed(extract(testString), override({lite: { thumbnailQuality: 'maxresdefault'}}), 1),
+	assert.equal(await embed(extract(testString), override({lite: { thumbnailQuality: 'maxresdefault'}}), 1),
 	`<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/maxresdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
 	);
 });
 test(`Build embed lite mode, 1+ index, invalid thumbnail quality override`, async t => {
-	t.is(await embed(extract(testString), override({lite: { thumbnailQuality: 'nope'}}), 1),
+	assert.equal(await embed(extract(testString), override({lite: { thumbnailQuality: 'nope'}}), 1),
 	`<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
 	);
 });
 test(`Build embed lite mode, 1+ index, valid thumbnail format override`, async t => {
-	t.is(await embed(extract(testString), override({lite: {thumbnailFormat: 'webp'}}), 1),
+	assert.equal(await embed(extract(testString), override({lite: {thumbnailFormat: 'webp'}}), 1),
 	`<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi_webp/hIs5StN8J-0/hqdefault.webp');"><div class="lty-playbtn"></div></lite-youtube></div>`
 	);
 });
 test(`Build embed lite mode, 1+ index, invalid thumbnail format override`, async t => {
-	t.is(await embed(extract(testString), override({lite: {thumbnailFormat: 'foo'}}), 1),
+	assert.equal(await embed(extract(testString), override({lite: {thumbnailFormat: 'foo'}}), 1),
 	`<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
 	);
 });
 test(`Build embed lite mode, 1+ index, lite defaults with URL start time param`, async t => {
-	t.is(await embed(extract('<p>https://www.youtube.com/watch?v=hIs5StN8J-0&t=30s</p>'), override({lite: true}), 1),
+	assert.equal(await embed(extract('<p>https://www.youtube.com/watch?v=hIs5StN8J-0&t=30s</p>'), override({lite: true}), 1),
 	`<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');" params="start=30"><div class="lty-playbtn"></div></lite-youtube></div>`
 	);
 });
 test(`Build embed lite mode, 1+ index, css disabled`, async t => {
-	t.is(await embed(extract(testString), override({lite:{css:{enabled: false}}}), 1),
+	assert.equal(await embed(extract(testString), override({lite:{css:{enabled: false}}}), 1),
 	`<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
 	);
 });
 test(`Build embed lite mode, 1+ index, css inline`, async t => {
-	t.is(await embed(extract(testString), override({lite:{css:{inline: true}}}), 1),
+	assert.equal(await embed(extract(testString), override({lite:{css:{inline: true}}}), 1),
 	`<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
 	);
 });
 test(`Build embed lite mode, 1+ index, css path override`, async t => {
-	t.is(await embed(extract(testString), override({lite:{css:{path: 'foo'}}}), 1),
+	assert.equal(await embed(extract(testString), override({lite:{css:{path: 'foo'}}}), 1),
 	`<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
 	);
 });
 test(`Build embed lite mode, 1+ index, js disabled`, async t => {
-	t.is(await embed(extract(testString), override({lite:{js:{enabled: false}}}), 1),
+	assert.equal(await embed(extract(testString), override({lite:{js:{enabled: false}}}), 1),
 	`<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
 	);
 });
 test(`Build embed lite mode, 1+ index, js inline`, async t => {
-	t.is(await embed(extract(testString), override({lite:{js:{inline: true}}}), 1),
+	assert.equal(await embed(extract(testString), override({lite:{js:{inline: true}}}), 1),
 	`<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
 	);
 });
 test(`Build embed lite mode, 1+ index, responsive true`, async t => {
-	t.is(await embed(extract(testString), override({lite: { responsive: true }}), 1),
+	assert.equal(await embed(extract(testString), override({lite: { responsive: true }}), 1),
 	`<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
 	);
 });
 test(`Build embed lite mode, 1+ index, fetch title via oembed`, async t => {
-	t.is(await embed(extract(testString), override({lite: { responsive: true }, titleOptions: {download: true}}), 1),
+	assert.equal(await embed(extract(testString), override({lite: { responsive: true }, titleOptions: {download: true}}), 1),
 	`<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');" title="Animotion - Obsession"><div class="lty-playbtn"></div></lite-youtube></div>`
 	);
 });
 test(`Build embed lite mode, 1+ index, default title set but should be ignored`, async t => {
-	t.is(await embed(extract(testString), override({lite: { responsive: true }, title: "Foo"}), 1),
+	assert.equal(await embed(extract(testString), override({lite: { responsive: true }, title: "Foo"}), 1),
 	`<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed"><lite-youtube videoid="hIs5StN8J-0" style="background-image: url('https://i.ytimg.com/vi/hIs5StN8J-0/hqdefault.jpg');"><div class="lty-playbtn"></div></lite-youtube></div>`
 	);
 });
@@ -211,56 +212,56 @@ test(`Build embed lite mode, 1+ index, default title set but should be ignored`,
  * In lite mode, test that the thumbnail validators return the expected values.
 */
 test(`Thumbnail size validator returns default value in response to empty parameter`, t => {
-  t.is(validateThumbnailSize(), 'hqdefault');
+  assert.equal(validateThumbnailSize(), 'hqdefault');
 });
 test(`Thumbnail size validator returns default value in response to incorrect parameter types`, t => {
-  t.is(validateThumbnailSize(1), 'hqdefault');
-  t.is(validateThumbnailSize(true), 'hqdefault');
+  assert.equal(validateThumbnailSize(1), 'hqdefault');
+  assert.equal(validateThumbnailSize(true), 'hqdefault');
 });
 test(`Thumbnail size validator returns default value in response to invalid string`, t => {
-  t.is(validateThumbnailSize('foo'), 'hqdefault');
+  assert.equal(validateThumbnailSize('foo'), 'hqdefault');
 });
 test(`Thumbnail size validator returns expected strings when passed expected strings`, t => {
-  t.is(validateThumbnailSize('default'), 'default');
-  t.is(validateThumbnailSize('hqdefault'), 'hqdefault');
-  t.is(validateThumbnailSize('mqdefault'), 'mqdefault');
-  t.is(validateThumbnailSize('sddefault'), 'sddefault');
-  t.is(validateThumbnailSize('maxresdefault'), 'maxresdefault');
+  assert.equal(validateThumbnailSize('default'), 'default');
+  assert.equal(validateThumbnailSize('hqdefault'), 'hqdefault');
+  assert.equal(validateThumbnailSize('mqdefault'), 'mqdefault');
+  assert.equal(validateThumbnailSize('sddefault'), 'sddefault');
+  assert.equal(validateThumbnailSize('maxresdefault'), 'maxresdefault');
 });
 
 test(`Thumbnail format validator returns default value in response to empty parameter`, t => {
-  t.is(validateThumbnailFormat(), 'jpg');
+  assert.equal(validateThumbnailFormat(), 'jpg');
 })
 test(`Thumbnail format validator returns default value in response to incorrect parameter types`, t => {
-  t.is(validateThumbnailFormat(1), 'jpg');
-  t.is(validateThumbnailFormat(true), 'jpg');
+  assert.equal(validateThumbnailFormat(1), 'jpg');
+  assert.equal(validateThumbnailFormat(true), 'jpg');
 });
 test(`Thumbnail format validator returns default value in response to invalid string`, t => {
-  t.is(validateThumbnailFormat('avif'), 'jpg');
+  assert.equal(validateThumbnailFormat('avif'), 'jpg');
 });
 test(`Thumbnail format validator returns expected strings when passed expected strings`, t => {
-  t.is(validateThumbnailFormat('jpg'), 'jpg');
-  t.is(validateThumbnailFormat('webp'), 'webp');
+  assert.equal(validateThumbnailFormat('jpg'), 'jpg');
+  assert.equal(validateThumbnailFormat('webp'), 'webp');
 });
 
 /**
  * Test that the URL parameters are correctly stringified
  */
 test(`Stringify URL params returns empty string in response to empty object`, t => {
-	t.is(stringifyUrlParams({}), '');
+	assert.equal(stringifyUrlParams({}), '');
 });
 test(`Stringify URL params returns expected string in default mode, autoplay`, t => {
-	t.is(stringifyUrlParams({allowAutoplay: true}), '?autoplay=1');
+	assert.equal(stringifyUrlParams({allowAutoplay: true}), '?autoplay=1');
 });
 test(`Stringify URL params returns expected string in default mode, recommendations`, t => {
-	t.is(stringifyUrlParams({recommendSelfOnly: true}), '?rel=0');
+	assert.equal(stringifyUrlParams({recommendSelfOnly: true}), '?rel=0');
 });
 test(`Stringify URL params returns expected string in default mode, multiple values`, t => {
 	const o = {
 		allowAutoplay: true,
 		recommendSelfOnly: true,
 	}
-	t.is(stringifyUrlParams(o), '?autoplay=1&amp;rel=0');
+	assert.equal(stringifyUrlParams(o), '?autoplay=1&amp;rel=0');
 });
 
 test(`Stringify URL params returns expected string in lite mode, autoplay`, t => {
@@ -268,14 +269,14 @@ test(`Stringify URL params returns expected string in lite mode, autoplay`, t =>
 		lite: true,
 		allowAutoplay: true,
 	}
-	t.is(stringifyUrlParams(o), 'autoplay=1');
+	assert.equal(stringifyUrlParams(o), 'autoplay=1');
 });
 test(`Stringify URL params returns expected string in lite mode, recommendations`, t => {
 	const o = {
 		lite: true,
 		recommendSelfOnly: true,
 	}
-	t.is(stringifyUrlParams(o), 'rel=0');
+	assert.equal(stringifyUrlParams(o), 'rel=0');
 });
 test(`Stringify URL params returns expected string in lite mode, multiple values`, t => {
 	const o = {
@@ -283,6 +284,6 @@ test(`Stringify URL params returns expected string in lite mode, multiple values
 		allowAutoplay: true,
 		recommendSelfOnly: true,
 	}
-	t.is(stringifyUrlParams(o), 'autoplay=1&amp;rel=0');
+	assert.equal(stringifyUrlParams(o), 'autoplay=1&amp;rel=0');
 });
 

--- a/packages/youtube/test/embed.multiple.test.js
+++ b/packages/youtube/test/embed.multiple.test.js
@@ -1,4 +1,5 @@
-const test = require('ava');
+const test = require('node:test');
+const assert = require('node:assert/strict');
 const merge = require('deepmerge');
 const pattern = require('../lib/pattern.js');
 const embed = require('../lib/embed.js');
@@ -8,7 +9,7 @@ const {defaults} = require('../lib/defaults.js');
 const multipleEmbeds = `<p>https://www.youtube.com/watch?v=hIs5StN8J-0</p><p>https://www.youtube.com/watch?v=4JS70KB9GS0</p>`;
 const expected = '<div id="hIs5StN8J-0" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/hIs5StN8J-0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe></div><div id="4JS70KB9GS0" class="eleventy-plugin-youtube-embed" style="position:relative;width:100%;padding-top: 56.25%;"><iframe style="position:absolute;top:0;right:0;bottom:0;left:0;width:100%;height:100%;" width="100%" height="100%" frameborder="0" title="Embedded YouTube video" src="https://www.youtube-nocookie.com/embed/4JS70KB9GS0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe></div>'
 
-test(`Check that output doesn't produce duplicated embeds`, async t => {
+test(`Check that output doesn't produce duplicated embeds`, async () => {
   const {default: asyncReplace} = await import('string-replace-async');
   const content = multipleEmbeds;
   const config = defaults;
@@ -16,7 +17,7 @@ test(`Check that output doesn't produce duplicated embeds`, async t => {
   const result = await asyncReplace(content, pattern, async (...match) => {
     return await embed(match, config, index++)
   });
-  t.is(result, expected);
+  assert.equal(result, expected);
 
 });
 

--- a/packages/youtube/test/index.test.js
+++ b/packages/youtube/test/index.test.js
@@ -1,4 +1,5 @@
-const test = require('ava');
+const test = require("node:test");
+const assert = require("node:assert/strict");
 
 /**
  * This test mocks the behavior of how the plugin index file works.
@@ -10,7 +11,7 @@ const test = require('ava');
  * style and script tags. The default embed doesn't need to be aware of its
  * index.
  */
-test('Index of replacements inside content works as expected', (t) => {
+test('Index of replacements inside content works as expected', () => {
   // `bar` appears twice in the test string.
   const content = 'foo bar foo bar';
   // We expect *only* the first `bar` to be replaced with `baz`.
@@ -27,5 +28,5 @@ test('Index of replacements inside content works as expected', (t) => {
   // Call mockEmbed for each match, passing the index and then incrementing it.
   const result = content.replace(pattern, (...match) => mockEmbed(match, {}, index++));
   // The resulting string should only replace the first instance of `bar`.
-  t.is(result, expected)
+  assert.equal(result, expected);
 })

--- a/packages/youtube/test/oembed.test.js
+++ b/packages/youtube/test/oembed.test.js
@@ -1,19 +1,20 @@
-const test = require('ava');
+const test = require('node:test');
+const assert = require('node:assert/strict');
 const {defaults} = require('../lib/defaults.js');
 const {getYouTubeTitleViaOembed} = require('../lib/embed.js');
 
 
-test('getYouTubeTitleViaOembed returns a string', async (t) => {
+test('getYouTubeTitleViaOembed returns a string', async () => {
   const result = await getYouTubeTitleViaOembed('hIs5StN8J-0', defaults);
-  t.is(typeof result, 'string');
+  assert.equal(typeof result, 'string');
 });
 
-test('getYouTubeTitleViaOembed returns the correct title', async (t) => {
+test('getYouTubeTitleViaOembed returns the correct title', async () => {
   const result = await getYouTubeTitleViaOembed('hIs5StN8J-0', defaults);
-  t.is(result, 'Animotion - Obsession');
+  assert.equal(result, 'Animotion - Obsession');
 });
 
-test('getYouTubeTitleViaOembed returns the default title on network error', async (t) => {
+test('getYouTubeTitleViaOembed returns the default title on network error', async () => {
   const result = await getYouTubeTitleViaOembed('00000000000', defaults);
-  t.is(result, defaults.title);
+  assert.equal(result, defaults.title);
 });

--- a/packages/youtube/test/pattern.test.mjs
+++ b/packages/youtube/test/pattern.test.mjs
@@ -1,25 +1,26 @@
-import test from 'ava';
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
 import { valid, invalid } from './_strings.mjs';
 import { invalid as invalidUrls } from './_urls.mjs';
 import pattern from '../lib/pattern.js';
 
 for (let [index, str] of valid.entries()) {
-  test(`Valid-${index}: (${str})`, async t => {
+  test(`Valid-${index}: (${str})`, async () => {
     pattern.lastIndex = 0;
-    t.regex(str, pattern)
+    assert.match(str, pattern)
   });
 }
 
 for (let [index, str] of invalid.entries()) {
-  test(`Invalid-${index}: (${str})`, async t => {
+  test(`Invalid-${index}: (${str})`, async () => {
     pattern.lastIndex = 0;
-    t.notRegex(str, pattern)
+    assert.doesNotMatch(str, pattern)
   });
 }
 
 for (let [index, str] of invalidUrls.entries()) {
-  test(`Invalid-URL-${index}: (<p>${str}</p>)`, async t => {
+  test(`Invalid-URL-${index}: (<p>${str}</p>)`, async () => {
     pattern.lastIndex = 0;
-    t.notRegex(`<p>${str}</p>`, pattern)
+    assert.doesNotMatch(`<p>${str}</p>`, pattern)
   });
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,15 +26,9 @@ importers:
       '@vitest/coverage-istanbul':
         specifier: ^4.1.2
         version: 4.1.2(vitest@4.1.2(msw@2.12.14)(vite@8.0.0(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)))
-      ava:
-        specifier: ^7.0.0
-        version: 7.0.0
       msw:
         specifier: ^2.12.14
         version: 2.12.14
-      nyc:
-        specifier: ^18.0.0
-        version: 18.0.0
       permute-arrays:
         specifier: workspace:^
         version: link:utils/permute-arrays
@@ -398,14 +392,6 @@ packages:
       '@types/node':
         optional: true
 
-  '@isaacs/fs-minipass@4.0.1':
-    resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
-    engines: {node: '>=18.0.0'}
-
-  '@istanbuljs/load-nyc-config@1.1.0':
-    resolution: {integrity: sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==}
-    engines: {node: '>=8'}
-
   '@istanbuljs/schema@0.1.3':
     resolution: {integrity: sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==}
     engines: {node: '>=8'}
@@ -431,11 +417,6 @@ packages:
 
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
-
-  '@mapbox/node-pre-gyp@2.0.3':
-    resolution: {integrity: sha512-uwPAhccfFJlsfCxMYTwOdVfOz3xqyj8xYL3zJj8f0pb30tLohnnFPhLuqp4/qoEz8sNxe4SESZedcBojRefIzg==}
-    engines: {node: '>=18'}
-    hasBin: true
 
   '@mswjs/interceptors@0.41.3':
     resolution: {integrity: sha512-cXu86tF4VQVfwz8W1SPbhoRyHJkti6mjH/XJIxp40jhO4j2k1m4KYrEykxqWPkFF3vrK4rgQppBh//AwyGSXPA==}
@@ -571,19 +552,6 @@ packages:
   '@rolldown/pluginutils@1.0.0-rc.9':
     resolution: {integrity: sha512-w6oiRWgEBl04QkFZgmW+jnU1EC9b57Oihi2ot3HNWIQRqgHp5PnYDia5iZ5FF7rpa4EQdiqMDXjlqKGXBhsoXw==}
 
-  '@rollup/pluginutils@5.3.0':
-    resolution: {integrity: sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
-    peerDependenciesMeta:
-      rollup:
-        optional: true
-
-  '@sindresorhus/merge-streams@4.0.0':
-    resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
-    engines: {node: '>=18'}
-
   '@sindresorhus/slugify@2.2.1':
     resolution: {integrity: sha512-MkngSCRZ8JdSOCHRaYd+D01XhvU3Hjy6MGl06zhOk614hp9EOAp5gIkBeQg7wtmxpitU6eAL4kdiRMcJa2dlrw==}
     engines: {node: '>=12'}
@@ -616,11 +584,6 @@ packages:
 
   '@types/statuses@2.0.6':
     resolution: {integrity: sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==}
-
-  '@vercel/nft@1.3.2':
-    resolution: {integrity: sha512-HC8venRc4Ya7vNeBsJneKHHMDDWpQie7VaKhAIOst3MKO+DES+Y/SbzSp8mFkD7OzwAE2HhHkeSuSmwS20mz3A==}
-    engines: {node: '>=20'}
-    hasBin: true
 
   '@vitest/coverage-istanbul@4.1.2':
     resolution: {integrity: sha512-WSz7+4a7PcMtMNvIP7AXUMffsq4JrWeJaguC8lg6fSQyGxSfaT4Rf81idqwxTT6qX5kjjZw2t9rAnCRRQobSqw==}
@@ -659,15 +622,6 @@ packages:
   a-sync-waterfall@1.0.1:
     resolution: {integrity: sha512-RYTOHHdWipFUliRFMCS4X2Yn2X8M87V/OpSqWzKKOGhzqyUxzyVmhHDH9sAvG+ZuQf/TAOFsLCpMw09I1ufUnA==}
 
-  abbrev@3.0.1:
-    resolution: {integrity: sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==}
-    engines: {node: ^18.17.0 || >=20.5.0}
-
-  acorn-import-attributes@1.9.5:
-    resolution: {integrity: sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==}
-    peerDependencies:
-      acorn: ^8
-
   acorn-walk@8.3.5:
     resolution: {integrity: sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==}
     engines: {node: '>=0.4.0'}
@@ -677,14 +631,6 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  agent-base@7.1.4:
-    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
-    engines: {node: '>= 14'}
-
-  aggregate-error@3.1.0:
-    resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==}
-    engines: {node: '>=8'}
-
   ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
     engines: {node: '>=6'}
@@ -693,28 +639,13 @@ packages:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
 
-  ansi-regex@6.2.2:
-    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
-    engines: {node: '>=12'}
-
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
-  ansi-styles@6.2.3:
-    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
-    engines: {node: '>=12'}
-
   anymatch@3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
-
-  append-transform@2.0.0:
-    resolution: {integrity: sha512-7yeyCEurROLQJFv5Xj4lEGTy0borxepjFv1g22oAdqFu//SrAlDl1O1Nxx15SH1RoliUml6p8dwJW9jvZughhg==}
-    engines: {node: '>=8'}
-
-  archy@1.0.0:
-    resolution: {integrity: sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw==}
 
   argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
@@ -722,21 +653,9 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
-  array-find-index@1.0.2:
-    resolution: {integrity: sha512-M1HQyIXcBGtVywBt8WVdim+lrNaK7VHp99Qt5pSNziXznKHViIBbXWtfRTpEFpF/c4FdfxNAsCCwPp5phBYJtw==}
-    engines: {node: '>=0.10.0'}
-
   array-union@2.1.0:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
     engines: {node: '>=8'}
-
-  arrgv@1.0.2:
-    resolution: {integrity: sha512-a4eg4yhp7mmruZDQFqVMlxNRFGi/i1r87pt8SDHy0/I8PqSXoUTlWZRdAZo0VXgvEARcujbtTk8kiZRi1uDGRw==}
-    engines: {node: '>=8.0.0'}
-
-  arrify@3.0.0:
-    resolution: {integrity: sha512-tLkvA81vQG/XqE2mjDkGQHoOINtMHtysSnemrmoGe6PydDPMRbVugqyk4A6V/WDWEfm3l+0d8anA9r8cv/5Jaw==}
-    engines: {node: '>=12'}
 
   asap@2.0.6:
     resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
@@ -745,25 +664,8 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
-  async-sema@3.1.1:
-    resolution: {integrity: sha512-tLRNUXati5MFePdAk8dw7Qt7DpxPB60ofAgn8WRhW6a2rcimZnYBP9oxHiv0OHy+Wz7kPMG+t4LGdt31+4EmGg==}
-
-  ava@7.0.0:
-    resolution: {integrity: sha512-4sRJO/gehlfAgSbuH02mClDDiyymnuFmirE3KqPXl2pic1FaFTZaAACKqr85WT4o08iLjViMR9gmMkxzbZ3AgA==}
-    engines: {node: ^20.19 || ^22.20 || ^24.12 || >=25}
-    hasBin: true
-    peerDependencies:
-      '@ava/typescript': '*'
-    peerDependenciesMeta:
-      '@ava/typescript':
-        optional: true
-
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
-
-  balanced-match@4.0.4:
-    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
-    engines: {node: 18 || 20 || >=22}
 
   baseline-browser-mapping@2.10.12:
     resolution: {integrity: sha512-qyq26DxfY4awP2gIRXhhLWfwzwI+N5Nxk6iQi8EFizIaWIjqicQTE4sLnZZVdeKPRcVNoJOkkpfzoIYuvCKaIQ==}
@@ -787,18 +689,8 @@ packages:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
 
-  bindings@1.5.0:
-    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
-
-  blueimp-md5@2.19.0:
-    resolution: {integrity: sha512-DRQrD6gJyy8FbiE4s+bDoXS9hiW3Vbx5uCdwvcCf3zLHL+Iv7LtGHLpr+GZV8rHG8tK766FGYBwRbu8pELTt+w==}
-
   brace-expansion@1.1.13:
     resolution: {integrity: sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==}
-
-  brace-expansion@5.0.5:
-    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
-    engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -809,32 +701,12 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
-  caching-transform@4.0.0:
-    resolution: {integrity: sha512-kpqOvwXnjjN44D89K5ccQC+RUrsy7jB/XLlRrx0D7/2HNcTPqzsb6XgYoErwko6QsV184CA2YgS1fxDiiDZMWA==}
-    engines: {node: '>=8'}
-
-  callsites@4.2.0:
-    resolution: {integrity: sha512-kfzR4zzQtAE9PC7CzZsjl3aBNbXWuXiSeOCdLcPpBfGW8YuCqQHcRPFDbr/BPVmd3EEPVpuFzLyuT/cUhPr4OQ==}
-    engines: {node: '>=12.20'}
-
-  camelcase@5.3.1:
-    resolution: {integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==}
-    engines: {node: '>=6'}
-
   caniuse-lite@1.0.30001781:
     resolution: {integrity: sha512-RdwNCyMsNBftLjW6w01z8bKEvT6e/5tpPVEgtn22TiLGlstHOVecsX2KHFkD5e/vRnIE4EGzpuIODb3mtswtkw==}
-
-  cbor@10.0.11:
-    resolution: {integrity: sha512-vIwORDd/WyB8Nc23o2zNN5RrtFGlR6Fca61TtjkUXueI3Jf2DOZDl1zsshvBntZ3wZHBM9ztjnkXSmzQDaq3WA==}
-    engines: {node: '>=20'}
 
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
-
-  chalk@5.6.2:
-    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
-    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
   chardet@2.1.1:
     resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
@@ -843,46 +715,13 @@ packages:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
     engines: {node: '>= 8.10.0'}
 
-  chownr@3.0.0:
-    resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
-    engines: {node: '>=18'}
-
-  chunkd@2.0.1:
-    resolution: {integrity: sha512-7d58XsFmOq0j6el67Ug9mHf9ELUXsQXYJBkyxhH/k+6Ke0qXRnv0kbemx+Twc6fRJ07C49lcbdgm9FL1Ei/6SQ==}
-
-  ci-info@4.4.0:
-    resolution: {integrity: sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==}
-    engines: {node: '>=8'}
-
-  ci-parallel-vars@1.0.1:
-    resolution: {integrity: sha512-uvzpYrpmidaoxvIQHM+rKSrigjOe9feHYbw4uOI2gdfe1C3xIlxO+kVXq83WQWNniTf8bAxVpy+cQeFQsMERKg==}
-
-  clean-stack@2.2.0:
-    resolution: {integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==}
-    engines: {node: '>=6'}
-
-  cli-truncate@5.2.0:
-    resolution: {integrity: sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==}
-    engines: {node: '>=20'}
-
   cli-width@4.1.0:
     resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
     engines: {node: '>= 12'}
 
-  cliui@6.0.0:
-    resolution: {integrity: sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==}
-
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
-
-  cliui@9.0.1:
-    resolution: {integrity: sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==}
-    engines: {node: '>=20'}
-
-  code-excerpt@4.0.0:
-    resolution: {integrity: sha512-xxodCmBen3iy2i0WtAK8FlFNrRzjUqjRsMfho58xT/wvZU1YTM3fCnRjcy1gJPMepaRlgm/0e6w8SpWHpn3/cA==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -899,32 +738,11 @@ packages:
     resolution: {integrity: sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==}
     engines: {node: '>= 6'}
 
-  common-path-prefix@3.0.0:
-    resolution: {integrity: sha512-QE33hToZseCH3jS0qN96O/bSh3kaw/h+Tq7ngyY9eWDUnTlTNUyqfqvCXioLe5Na5jFsL78ra/wuBU4iuEgd4w==}
-
-  commondir@1.0.1:
-    resolution: {integrity: sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==}
-
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
-  concordance@5.0.4:
-    resolution: {integrity: sha512-OAcsnTEYu1ARJqWVGwf4zh4JDfHZEaSNlNccFmt8YjB2l/n19/PF2viLINHc57vO4FKIAFl2FWASIGZZWZ2Kxw==}
-    engines: {node: '>=10.18.0 <11 || >=12.14.0 <13 || >=14'}
-
-  consola@3.4.2:
-    resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
-    engines: {node: ^14.18.0 || >=16.10.0}
-
-  convert-source-map@1.9.0:
-    resolution: {integrity: sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==}
-
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
-
-  convert-to-spaces@2.0.1:
-    resolution: {integrity: sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
@@ -934,16 +752,8 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
-  currently-unhandled@0.4.1:
-    resolution: {integrity: sha512-/fITjgjGU50vjQ4FH6eUoYu+iUoUKIXws2hL15JJpIR+BbTxaXQsMuuyjtNh2WqsSBS5nsaZHFsFecyw5CCAng==}
-    engines: {node: '>=0.10.0'}
-
   dataloader@1.4.0:
     resolution: {integrity: sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==}
-
-  date-time@3.1.0:
-    resolution: {integrity: sha512-uqCUKXE5q1PNBXjPqvwhwJf9SwMoAHBgWJ6DcrnS5o+W2JOiIILl0JEdVD8SGujrNS02GGxgwAg2PN2zONgtjg==}
-    engines: {node: '>=6'}
 
   debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
@@ -962,17 +772,9 @@ packages:
       supports-color:
         optional: true
 
-  decamelize@1.2.0:
-    resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
-    engines: {node: '>=0.10.0'}
-
   deepmerge@4.3.1:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
-
-  default-require-extensions@3.0.1:
-    resolution: {integrity: sha512-eXTJmRbm2TIt9MgWTsOH1wEuhew6XGZcMeGKCtLedIg/NCsg1iBePXkceTdK4Fii7pzmN9tGsZhKzZ4h7O/fxw==}
-    engines: {node: '>=8'}
 
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
@@ -1017,13 +819,6 @@ packages:
   electron-to-chromium@1.5.328:
     resolution: {integrity: sha512-QNQ5l45DzYytThO21403XN3FvK0hOkWDG8viNf6jqS42msJ8I4tGDSpBCgvDRRPnkffafiwAym2X2eHeGD2V0w==}
 
-  emittery@1.2.1:
-    resolution: {integrity: sha512-sFz64DCRjirhwHLxofFqxYQm6DCp6o0Ix7jwKQvuCHPn4GMRZNuBZyLPu9Ccmk/QSCAMZt6FOUqA8JZCQvA9fw==}
-    engines: {node: '>=14.16'}
-
-  emoji-regex@10.6.0:
-    resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
-
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
@@ -1057,19 +852,12 @@ packages:
   es-module-lexer@2.0.0:
     resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
 
-  es6-error@4.1.1:
-    resolution: {integrity: sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==}
-
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
 
   escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
-
-  escape-string-regexp@2.0.0:
-    resolution: {integrity: sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==}
-    engines: {node: '>=8'}
 
   escape-string-regexp@5.0.0:
     resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
@@ -1083,15 +871,8 @@ packages:
     engines: {node: '>=4'}
     hasBin: true
 
-  estree-walker@2.0.2:
-    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
-
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
-
-  esutils@2.0.3:
-    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
-    engines: {node: '>=0.10.0'}
 
   etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
@@ -1115,9 +896,6 @@ packages:
   extendable-error@0.1.7:
     resolution: {integrity: sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==}
 
-  fast-diff@1.3.0:
-    resolution: {integrity: sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==}
-
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
     engines: {node: '>=8.6.0'}
@@ -1134,13 +912,6 @@ packages:
       picomatch:
         optional: true
 
-  figures@6.1.0:
-    resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
-    engines: {node: '>=18'}
-
-  file-uri-to-path@1.0.0:
-    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
-
   filesize@10.1.6:
     resolution: {integrity: sha512-sJslQKU2uM33qH5nqewAwVB2QgR6w1aMNsYUp3aN5rMRyXEwJGmZvaWzeJFNTOXWlHQyBFCWrdj3fV/fsTOX8w==}
     engines: {node: '>= 10.4.0'}
@@ -1153,14 +924,6 @@ packages:
     resolution: {integrity: sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==}
     engines: {node: '>= 0.8'}
 
-  find-cache-dir@3.3.2:
-    resolution: {integrity: sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==}
-    engines: {node: '>=8'}
-
-  find-up-simple@1.0.1:
-    resolution: {integrity: sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ==}
-    engines: {node: '>=18'}
-
   find-up@4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
     engines: {node: '>=8'}
@@ -1168,20 +931,9 @@ packages:
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
-  foreground-child@2.0.0:
-    resolution: {integrity: sha512-dCIq9FpEcyQyXKCkyzmlPTFNgrCzPudOe+mhvJU5zAtlBnGVy2yKxtfsxK2tQBThwq225jcvBjpw1Gr40uzZCA==}
-    engines: {node: '>=8.0.0'}
-
-  foreground-child@3.3.1:
-    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
-    engines: {node: '>=14'}
-
   fresh@2.0.0:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
     engines: {node: '>= 0.8'}
-
-  fromentries@1.3.2:
-    resolution: {integrity: sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg==}
 
   fs-extra@7.0.1:
     resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
@@ -1204,29 +956,13 @@ packages:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
 
-  get-east-asian-width@1.5.0:
-    resolution: {integrity: sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==}
-    engines: {node: '>=18'}
-
-  get-package-type@0.1.0:
-    resolution: {integrity: sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==}
-    engines: {node: '>=8.0.0'}
-
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
 
-  glob@13.0.6:
-    resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
-    engines: {node: 18 || 20 || >=22}
-
   globby@11.1.0:
     resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
     engines: {node: '>=10'}
-
-  globby@16.1.1:
-    resolution: {integrity: sha512-dW7vl+yiAJSp6aCekaVnVJxurRv7DCOLyXqEG3RYMYUg7AuJ2jCqPkZTA8ooqC2vtnkaMcV5WfFBMuEnTu1OQg==}
-    engines: {node: '>=20'}
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
@@ -1241,10 +977,6 @@ packages:
 
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
-    engines: {node: '>=8'}
-
-  hasha@5.2.2:
-    resolution: {integrity: sha512-Hrp5vIK/xr5SkeN2onO32H0MgNZ0f17HRNH39WfL0SYUNOTZ5Lz1TJ8Pajo/87dYGEFlLMm7mIc/k/s6Bvz9HQ==}
     engines: {node: '>=8'}
 
   headers-polyfill@4.0.3:
@@ -1264,10 +996,6 @@ packages:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
 
-  https-proxy-agent@7.0.6:
-    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
-    engines: {node: '>= 14'}
-
   human-id@4.1.3:
     resolution: {integrity: sha512-tsYlhAYpjCKa//8rXZ9DqKEawhPoSytweBC2eNvcaDK+57RZLHGqNs3PZTQO6yekLFSuvA6AlnAfrw1uBvtb+Q==}
     hasBin: true
@@ -1276,36 +1004,12 @@ packages:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
 
-  ignore-by-default@2.1.0:
-    resolution: {integrity: sha512-yiWd4GVmJp0Q6ghmM2B/V3oZGRmjrKLXvHR3TE1nfoXsmoggllfZUQe74EN0fJdPFZu2NIvNdrMMLm3OsV7Ohw==}
-    engines: {node: '>=10 <11 || >=12 <13 || >=14'}
-
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
 
-  ignore@7.0.5:
-    resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
-    engines: {node: '>= 4'}
-
-  imurmurhash@0.1.4:
-    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
-    engines: {node: '>=0.8.19'}
-
-  indent-string@4.0.0:
-    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
-    engines: {node: '>=8'}
-
-  indent-string@5.0.0:
-    resolution: {integrity: sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==}
-    engines: {node: '>=12'}
-
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
-
-  irregular-plurals@4.2.0:
-    resolution: {integrity: sha512-bW9UXHL7bnUcNtTo+9ccSngbxc+V40H32IgvdVin0Xs8gbo+AVYD5g/72ce/54Kjfhq66vcZr8H8TKEvsifeOw==}
-    engines: {node: '>=18.20'}
 
   is-alphabetical@2.0.1:
     resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
@@ -1332,10 +1036,6 @@ packages:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
 
-  is-fullwidth-code-point@5.1.0:
-    resolution: {integrity: sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==}
-    engines: {node: '>=18'}
-
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
@@ -1350,31 +1050,9 @@ packages:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
 
-  is-path-inside@4.0.0:
-    resolution: {integrity: sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==}
-    engines: {node: '>=12'}
-
-  is-plain-object@5.0.0:
-    resolution: {integrity: sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==}
-    engines: {node: '>=0.10.0'}
-
-  is-promise@4.0.0:
-    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
-
-  is-stream@2.0.1:
-    resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
-    engines: {node: '>=8'}
-
   is-subdir@1.2.0:
     resolution: {integrity: sha512-2AT6j+gXe/1ueqbW6fLZJiIw3F8iXGJtt0yDrZaBhAZEG1raiTxKWU+IPqMCzQAXOUCKdA4UDMgacKH25XG2Cw==}
     engines: {node: '>=4'}
-
-  is-typedarray@1.0.0:
-    resolution: {integrity: sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==}
-
-  is-unicode-supported@2.1.0:
-    resolution: {integrity: sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==}
-    engines: {node: '>=18'}
 
   is-windows@1.0.2:
     resolution: {integrity: sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==}
@@ -1391,33 +1069,13 @@ packages:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
     engines: {node: '>=8'}
 
-  istanbul-lib-hook@3.0.0:
-    resolution: {integrity: sha512-Pt/uge1Q9s+5VAZ+pCo16TYMWPBIl+oaNIjgLQxcX0itS6ueeaA+pEfThZpH8WxhFgCiEb8sAJY6MdUKgiIWaQ==}
-    engines: {node: '>=8'}
-
-  istanbul-lib-instrument@6.0.3:
-    resolution: {integrity: sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==}
-    engines: {node: '>=10'}
-
-  istanbul-lib-processinfo@3.0.0:
-    resolution: {integrity: sha512-P7nLXRRlo7Sqinty6lNa7+4o9jBUYGpqtejqCOZKfgXlRoxY/QArflcB86YO500Ahj4pDJEG34JjMRbQgePLnQ==}
-    engines: {node: 20 || >=22}
-
   istanbul-lib-report@3.0.1:
     resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
-    engines: {node: '>=10'}
-
-  istanbul-lib-source-maps@4.0.1:
-    resolution: {integrity: sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==}
     engines: {node: '>=10'}
 
   istanbul-reports@3.2.0:
     resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
     engines: {node: '>=8'}
-
-  js-string-escape@1.0.1:
-    resolution: {integrity: sha512-Smw4xcfIQ5LVjAOuJCvN/zIodzA/BBSsluuoSykP+lUvScIi4U6RJLfwHet5cxFnCswUjISV8oAXaqaJDY3chg==}
-    engines: {node: '>= 0.8'}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -1539,26 +1197,12 @@ packages:
   lite-youtube-embed@0.3.4:
     resolution: {integrity: sha512-aXgxpwK7AIW58GEbRzA8EYaY4LWvF3FKak6B9OtSJmuNyLhX2ouD4cMTxz/yR5HFInhknaYd2jLWOTRTvT8oAw==}
 
-  load-json-file@7.0.1:
-    resolution: {integrity: sha512-Gnxj3ev3mB5TkVBGad0JM6dmLiQL+o0t23JPBZ9sd+yvSLk05mFoqKBw5N8gbbkU4TNXyqCgIrl/VM17OgUIgQ==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
   locate-path@5.0.0:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
     engines: {node: '>=8'}
 
-  lodash.flattendeep@4.4.0:
-    resolution: {integrity: sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ==}
-
   lodash.startcase@4.4.0:
     resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
-
-  lodash@4.17.23:
-    resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
-
-  lru-cache@11.2.7:
-    resolution: {integrity: sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==}
-    engines: {node: 20 || >=22}
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
@@ -1573,10 +1217,6 @@ packages:
   magicast@0.5.2:
     resolution: {integrity: sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==}
 
-  make-dir@3.1.0:
-    resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==}
-    engines: {node: '>=8'}
-
   make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
@@ -1585,20 +1225,8 @@ packages:
     resolution: {integrity: sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==}
     hasBin: true
 
-  matcher@6.0.0:
-    resolution: {integrity: sha512-TzDerdcNtI79w7Av4GT57bLdElPA/VAkjqdMZv8yhuc8geU2z0ljW9anXbX/55aHEMTpYypZb1lxsA/46r9oOQ==}
-    engines: {node: '>=20'}
-
-  md5-hex@3.0.1:
-    resolution: {integrity: sha512-BUiRtTtV39LIJwinWBjqVsU9xhdnz7/i889V859IBFpuqGAj6LuOvHv5XLbgZ2R7ptJoJaEcxkv88/h25T7Ciw==}
-    engines: {node: '>=8'}
-
   mdurl@2.0.0:
     resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
-
-  memoize@10.2.0:
-    resolution: {integrity: sha512-DeC6b7QBrZsRs3Y02A6A7lQyzFbsQbqgjI6UW0GigGWV+u1s25TycMr0XHZE4cJce7rY/vyw2ctMQqfDkIhUEA==}
-    engines: {node: '>=18'}
 
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
@@ -1621,14 +1249,6 @@ packages:
     engines: {node: '>=10.0.0'}
     hasBin: true
 
-  mimic-function@5.0.1:
-    resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
-    engines: {node: '>=18'}
-
-  minimatch@10.2.4:
-    resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
-    engines: {node: 18 || 20 || >=22}
-
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
 
@@ -1638,10 +1258,6 @@ packages:
   minipass@7.1.3:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
-
-  minizlib@3.1.0:
-    resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
-    engines: {node: '>= 18'}
 
   moo@0.5.2:
     resolution: {integrity: sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q==}
@@ -1687,28 +1303,11 @@ packages:
       encoding:
         optional: true
 
-  node-gyp-build@4.8.4:
-    resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
-    hasBin: true
-
-  node-preload@0.2.1:
-    resolution: {integrity: sha512-RM5oyBy45cLEoHqCeh+MNuFAxO0vTFBLskvQbOKnEE7YTTSN4tbN8QWDIPQ6L+WvKsB/qLEGpYe2ZZ9d4W9OIQ==}
-    engines: {node: '>=8'}
-
   node-releases@2.0.36:
     resolution: {integrity: sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==}
 
   node-retrieve-globals@6.0.1:
     resolution: {integrity: sha512-j0DeFuZ/Wg3VlklfbxUgZF/mdHMTEiEipBb3q0SpMMbHaV3AVfoUQF8UGxh1s/yjqO0TgRZd4Pi/x2yRqoQ4Eg==}
-
-  nofilter@3.1.0:
-    resolution: {integrity: sha512-l2NNj07e9afPnhAhvgVrCD/oy2Ai1yfLpuo3EpiO1jFTsB4sFz6oIfAfSZyQzVpkZQ9xS8ZS5g1jCBgq4Hwo0g==}
-    engines: {node: '>=12.19'}
-
-  nopt@8.1.0:
-    resolution: {integrity: sha512-ieGu42u/Qsa4TFktmaKEwM6MQH0pOWnaB3htzh0JRtx84+Mebc0cbZYN5bC+6WTZ4+77xrL9Pn5m7CV6VIkV7A==}
-    engines: {node: ^18.17.0 || >=20.5.0}
-    hasBin: true
 
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
@@ -1723,11 +1322,6 @@ packages:
     peerDependenciesMeta:
       chokidar:
         optional: true
-
-  nyc@18.0.0:
-    resolution: {integrity: sha512-G5UyHinFkB1BxqGTrmZdB6uIYH0+v7ZnVssuflUDi+J+RhKWyAhRT1RCehBSI6jLFLuUUgFDyLt49mUtdO1XeQ==}
-    engines: {node: 20 || >=22}
-    hasBin: true
 
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
@@ -1762,14 +1356,6 @@ packages:
     resolution: {integrity: sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==}
     engines: {node: '>=6'}
 
-  p-map@3.0.0:
-    resolution: {integrity: sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==}
-    engines: {node: '>=8'}
-
-  p-map@7.0.4:
-    resolution: {integrity: sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==}
-    engines: {node: '>=18'}
-
   p-queue@6.6.2:
     resolution: {integrity: sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==}
     engines: {node: '>=8'}
@@ -1782,23 +1368,8 @@ packages:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
 
-  package-config@5.0.0:
-    resolution: {integrity: sha512-GYTTew2slBcYdvRHqjhwaaydVMvn/qrGC323+nKclYioNSLTDUM/lGgtGTgyHVtYcozb+XkE8CNhwcraOmZ9Mg==}
-    engines: {node: '>=18'}
-
-  package-hash@4.0.0:
-    resolution: {integrity: sha512-whdkPIooSu/bASggZ96BWVvZTRMOFxnyUG5PnTSGKoJE2gd5mbVNmR2Nj20QFzxYYgAXpoqC+AiXzl+UMRh7zQ==}
-    engines: {node: '>=8'}
-
-  package-json-from-dist@1.0.1:
-    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
-
   package-manager-detector@0.2.11:
     resolution: {integrity: sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ==}
-
-  parse-ms@4.0.0:
-    resolution: {integrity: sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==}
-    engines: {node: '>=18'}
 
   parse-srcset@1.0.2:
     resolution: {integrity: sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q==}
@@ -1814,10 +1385,6 @@ packages:
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
-
-  path-scurry@2.0.2:
-    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
-    engines: {node: 18 || 20 || >=22}
 
   path-to-regexp@6.3.0:
     resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
@@ -1844,16 +1411,8 @@ packages:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
     engines: {node: '>=6'}
 
-  pkg-dir@4.2.0:
-    resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
-    engines: {node: '>=8'}
-
   please-upgrade-node@3.2.0:
     resolution: {integrity: sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==}
-
-  plur@6.0.0:
-    resolution: {integrity: sha512-Y9wXQivjRX0REtwpA9+n0bYYypWESn3cWtW2vazymw711qn+AQXxzZjRqhANYGBLIMC1UzVdpwe/1hHQwHfwng==}
-    engines: {node: '>=20'}
 
   postcss@8.5.8:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
@@ -1881,14 +1440,6 @@ packages:
     resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
     engines: {node: '>=10.13.0'}
     hasBin: true
-
-  pretty-ms@9.3.0:
-    resolution: {integrity: sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==}
-    engines: {node: '>=18'}
-
-  process-on-spawn@1.1.0:
-    resolution: {integrity: sha512-JOnOPQ/8TZgjs1JIH/m9ni7FfimjNa/PRx7y/Wb5qdItsnhO0jE4AT7fC0HjC28DUQWDr50dwSYZLdRMlqDq3Q==}
-    engines: {node: '>=8'}
 
   prr@1.0.1:
     resolution: {integrity: sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==}
@@ -1921,20 +1472,9 @@ packages:
   regex@6.1.0:
     resolution: {integrity: sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==}
 
-  release-zalgo@1.0.0:
-    resolution: {integrity: sha512-gUAyHVHPPC5wdqX/LG4LWtRYtgjxyX78oanFNTMMyFEfOqdC54s3eE82imuWKbOeqYht2CrNf64Qb8vgmmtZGA==}
-    engines: {node: '>=4'}
-
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
-
-  require-main-filename@2.0.0:
-    resolution: {integrity: sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==}
-
-  resolve-cwd@3.0.0:
-    resolution: {integrity: sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==}
-    engines: {node: '>=8'}
 
   resolve-from@5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
@@ -1946,11 +1486,6 @@ packages:
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
-
-  rimraf@6.1.3:
-    resolution: {integrity: sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA==}
-    engines: {node: 20 || >=22}
-    hasBin: true
 
   rolldown@1.0.0-rc.9:
     resolution: {integrity: sha512-9EbgWge7ZH+yqb4d2EnELAntgPTWbfL8ajiTW+SyhJEC4qhBbkCKbqFV4Ge4zmu5ziQuVbWxb/XwLZ+RIO7E8Q==}
@@ -1983,13 +1518,6 @@ packages:
     resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
     engines: {node: '>= 18'}
 
-  serialize-error@7.0.1:
-    resolution: {integrity: sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==}
-    engines: {node: '>=10'}
-
-  set-blocking@2.0.0:
-    resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
-
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
@@ -2004,9 +1532,6 @@ packages:
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
-  signal-exit@3.0.7:
-    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
-
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
@@ -2015,14 +1540,6 @@ packages:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
 
-  slash@5.1.0:
-    resolution: {integrity: sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==}
-    engines: {node: '>=14.16'}
-
-  slice-ansi@8.0.0:
-    resolution: {integrity: sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==}
-    engines: {node: '>=20'}
-
   slugify@1.6.8:
     resolution: {integrity: sha512-HVk9X1E0gz3mSpoi60h/saazLKXKaZThMLU3u/aNwoYn8/xQyX2MGxL0ui2eaokkD7tF+Zo+cKTHUbe1mmmGzA==}
     engines: {node: '>=8.0.0'}
@@ -2030,14 +1547,6 @@ packages:
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
-
-  source-map@0.6.1:
-    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
-    engines: {node: '>=0.10.0'}
-
-  spawn-wrap@3.0.0:
-    resolution: {integrity: sha512-z+s5vv4KzFPJVddGab0xX2n7kQPGMdNUX5l9T8EJqsXdKTWpcxmAqWHpsgHEXoC1taGBCc7b79bi62M5kdbrxQ==}
-    engines: {node: '>=8'}
 
   spawndamnit@3.0.1:
     resolution: {integrity: sha512-MmnduQUuHCoFckZoWnXsTg7JaiLBJrKFj9UI2MbRPGaJeVpsLcVBu6P/IGZovziM/YBsellCmsprgNA+w0CzVg==}
@@ -2048,10 +1557,6 @@ packages:
   ssri@11.0.0:
     resolution: {integrity: sha512-aZpUoMN/Jj2MqA4vMCeiKGnc/8SuSyHbGSBdgFbZxP8OJGF/lFkIuElzPxsN0q8TQQ+prw3P4EDfB3TBHHgfXw==}
     engines: {node: ^16.14.0 || >=18.0.0}
-
-  stack-utils@2.0.6:
-    resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
-    engines: {node: '>=10'}
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
@@ -2074,21 +1579,9 @@ packages:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
 
-  string-width@7.2.0:
-    resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
-    engines: {node: '>=18'}
-
-  string-width@8.2.0:
-    resolution: {integrity: sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==}
-    engines: {node: '>=20'}
-
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
-
-  strip-ansi@7.2.0:
-    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
-    engines: {node: '>=12'}
 
   strip-bom-string@1.0.0:
     resolution: {integrity: sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==}
@@ -2098,14 +1591,6 @@ packages:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
 
-  strip-bom@4.0.0:
-    resolution: {integrity: sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==}
-    engines: {node: '>=8'}
-
-  supertap@3.0.1:
-    resolution: {integrity: sha512-u1ZpIBCawJnO+0QePsEiOknOfCRq0yERxiAchT0i4li0WHNUJbf0evXXSXOcCAR4M8iMDoajXYmstm/qO81Isw==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
@@ -2114,25 +1599,9 @@ packages:
     resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
     engines: {node: '>=20'}
 
-  tar@7.5.11:
-    resolution: {integrity: sha512-ChjMH33/KetonMTAtpYdgUFr0tbz69Fp2v7zWxQfYZX4g5ZN2nOBXm1R2xyA+lMIKrLKIoKAwFj93jE/avX9cQ==}
-    engines: {node: '>=18'}
-
-  temp-dir@3.0.0:
-    resolution: {integrity: sha512-nHc6S/bwIilKHNRgK/3jlhDoIHcp45YgyiwcAk46Tr0LfEqGBVpmiAyuiuxeVE44m3mXnEeVhaipLOEWmH+Njw==}
-    engines: {node: '>=14.16'}
-
   term-size@2.2.1:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
     engines: {node: '>=8'}
-
-  test-exclude@8.0.0:
-    resolution: {integrity: sha512-ZOffsNrXYggvU1mDGHk54I96r26P8SyMjO5slMKSc7+IWmtB/MQKnEC2fP51imB3/pT6YK5cT5E8f+Dd9KdyOQ==}
-    engines: {node: 20 || >=22}
-
-  time-zone@1.0.0:
-    resolution: {integrity: sha512-TIsDdtKo6+XrPtiTm1ssmMngN1sAhyKnTO2kunQWqNPWIVvCm15Wmw4SWInwTVgJ5u/Tr04+8Ei9TNcw4x4ONA==}
-    engines: {node: '>=4'}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -2174,27 +1643,12 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
-  type-fest@0.13.1:
-    resolution: {integrity: sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==}
-    engines: {node: '>=10'}
-
-  type-fest@0.8.1:
-    resolution: {integrity: sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==}
-    engines: {node: '>=8'}
-
   type-fest@5.5.0:
     resolution: {integrity: sha512-PlBfpQwiUvGViBNX84Yxwjsdhd1TUlXr6zjX7eoirtCPIr08NAmxwa+fcYBTeRQxHo9YC9wwF3m9i700sHma8g==}
     engines: {node: '>=20'}
 
-  typedarray-to-buffer@3.1.5:
-    resolution: {integrity: sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==}
-
   uc.micro@2.1.0:
     resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
-
-  unicorn-magic@0.4.0:
-    resolution: {integrity: sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw==}
-    engines: {node: '>=20'}
 
   universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
@@ -2215,10 +1669,6 @@ packages:
 
   urlpattern-polyfill@10.1.0:
     resolution: {integrity: sha512-IGjKp/o0NL3Bso1PymYURCJxMPNAf/ILOpendP9f5B6e1rTJgdgiOvgfoT8VxCAdY+Wisb9uhGaJJf3yZ2V9nw==}
-
-  uuid@8.3.2:
-    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
-    hasBin: true
 
   vite@8.0.0:
     resolution: {integrity: sha512-fPGaRNj9Zytaf8LEiBhY7Z6ijnFKdzU/+mL8EFBaKr7Vw1/FWcTBAMW0wLPJAGMPX38ZPVCVgLceWiEqeoqL2Q==}
@@ -2301,15 +1751,8 @@ packages:
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
 
-  well-known-symbols@2.0.0:
-    resolution: {integrity: sha512-ZMjC3ho+KXo0BfJb7JgtQ5IBuvnShdlACNkKkdsqBmYw3bPAaJfPeYUo6tLUaT5tG/Gkh7xkpBhKRQ9e7pyg9Q==}
-    engines: {node: '>=6'}
-
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
-
-  which-module@2.0.1:
-    resolution: {integrity: sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -2329,17 +1772,6 @@ packages:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
 
-  wrap-ansi@9.0.2:
-    resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
-    engines: {node: '>=18'}
-
-  write-file-atomic@3.0.3:
-    resolution: {integrity: sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==}
-
-  write-file-atomic@7.0.1:
-    resolution: {integrity: sha512-OTIk8iR8/aCRWBqvxrzxR0hgxWpnYBblY1S5hDWBQfk/VFmJwzmJgQFN3WsoUKHISv2eAwe+PpbUzyL1CKTLXg==}
-    engines: {node: ^20.17.0 || >=22.9.0}
-
   ws@8.19.0:
     resolution: {integrity: sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==}
     engines: {node: '>=10.0.0'}
@@ -2352,9 +1784,6 @@ packages:
       utf-8-validate:
         optional: true
 
-  y18n@4.0.3:
-    resolution: {integrity: sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==}
-
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
@@ -2362,33 +1791,13 @@ packages:
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
-  yallist@5.0.0:
-    resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
-    engines: {node: '>=18'}
-
-  yargs-parser@18.1.3:
-    resolution: {integrity: sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==}
-    engines: {node: '>=6'}
-
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
 
-  yargs-parser@22.0.0:
-    resolution: {integrity: sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==}
-    engines: {node: ^20.19.0 || ^22.12.0 || >=23}
-
-  yargs@15.4.1:
-    resolution: {integrity: sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==}
-    engines: {node: '>=8'}
-
   yargs@17.7.2:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
-
-  yargs@18.0.0:
-    resolution: {integrity: sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==}
-    engines: {node: ^20.19.0 || ^22.12.0 || >=23}
 
   yoctocolors-cjs@2.1.3:
     resolution: {integrity: sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==}
@@ -2798,18 +2207,6 @@ snapshots:
 
   '@inquirer/type@3.0.10': {}
 
-  '@isaacs/fs-minipass@4.0.1':
-    dependencies:
-      minipass: 7.1.3
-
-  '@istanbuljs/load-nyc-config@1.1.0':
-    dependencies:
-      camelcase: 5.3.1
-      find-up: 4.1.0
-      get-package-type: 0.1.0
-      js-yaml: 3.14.2
-      resolve-from: 5.0.0
-
   '@istanbuljs/schema@0.1.3': {}
 
   '@jridgewell/gen-mapping@0.3.13':
@@ -2846,19 +2243,6 @@ snapshots:
       fs-extra: 8.1.0
       globby: 11.1.0
       read-yaml-file: 1.1.0
-
-  '@mapbox/node-pre-gyp@2.0.3':
-    dependencies:
-      consola: 3.4.2
-      detect-libc: 2.1.2
-      https-proxy-agent: 7.0.6
-      node-fetch: 2.7.0
-      nopt: 8.1.0
-      semver: 7.7.4
-      tar: 7.5.11
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
 
   '@mswjs/interceptors@0.41.3':
     dependencies:
@@ -2955,14 +2339,6 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.0-rc.9': {}
 
-  '@rollup/pluginutils@5.3.0':
-    dependencies:
-      '@types/estree': 1.0.8
-      estree-walker: 2.0.2
-      picomatch: 4.0.4
-
-  '@sindresorhus/merge-streams@4.0.0': {}
-
   '@sindresorhus/slugify@2.2.1':
     dependencies:
       '@sindresorhus/transliterate': 1.6.0
@@ -2998,25 +2374,6 @@ snapshots:
   '@types/node@12.20.55': {}
 
   '@types/statuses@2.0.6': {}
-
-  '@vercel/nft@1.3.2':
-    dependencies:
-      '@mapbox/node-pre-gyp': 2.0.3
-      '@rollup/pluginutils': 5.3.0
-      acorn: 8.16.0
-      acorn-import-attributes: 1.9.5(acorn@8.16.0)
-      async-sema: 3.1.1
-      bindings: 1.5.0
-      estree-walker: 2.0.2
-      glob: 13.0.6
-      graceful-fs: 4.2.11
-      node-gyp-build: 4.8.4
-      picomatch: 4.0.4
-      resolve-from: 5.0.0
-    transitivePeerDependencies:
-      - encoding
-      - rollup
-      - supports-color
 
   '@vitest/coverage-istanbul@4.1.2(vitest@4.1.2(msw@2.12.14)(vite@8.0.0(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)))':
     dependencies:
@@ -3078,47 +2435,24 @@ snapshots:
 
   a-sync-waterfall@1.0.1: {}
 
-  abbrev@3.0.1: {}
-
-  acorn-import-attributes@1.9.5(acorn@8.16.0):
-    dependencies:
-      acorn: 8.16.0
-
   acorn-walk@8.3.5:
     dependencies:
       acorn: 8.16.0
 
   acorn@8.16.0: {}
 
-  agent-base@7.1.4: {}
-
-  aggregate-error@3.1.0:
-    dependencies:
-      clean-stack: 2.2.0
-      indent-string: 4.0.0
-
   ansi-colors@4.1.3: {}
 
   ansi-regex@5.0.1: {}
-
-  ansi-regex@6.2.2: {}
 
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
 
-  ansi-styles@6.2.3: {}
-
   anymatch@3.1.3:
     dependencies:
       normalize-path: 3.0.0
       picomatch: 2.3.2
-
-  append-transform@2.0.0:
-    dependencies:
-      default-require-extensions: 3.0.1
-
-  archy@1.0.0: {}
 
   argparse@1.0.10:
     dependencies:
@@ -3126,69 +2460,13 @@ snapshots:
 
   argparse@2.0.1: {}
 
-  array-find-index@1.0.2: {}
-
   array-union@2.1.0: {}
-
-  arrgv@1.0.2: {}
-
-  arrify@3.0.0: {}
 
   asap@2.0.6: {}
 
   assertion-error@2.0.1: {}
 
-  async-sema@3.1.1: {}
-
-  ava@7.0.0:
-    dependencies:
-      '@vercel/nft': 1.3.2
-      acorn: 8.16.0
-      acorn-walk: 8.3.5
-      ansi-styles: 6.2.3
-      arrgv: 1.0.2
-      arrify: 3.0.0
-      callsites: 4.2.0
-      cbor: 10.0.11
-      chalk: 5.6.2
-      chunkd: 2.0.1
-      ci-info: 4.4.0
-      ci-parallel-vars: 1.0.1
-      cli-truncate: 5.2.0
-      code-excerpt: 4.0.0
-      common-path-prefix: 3.0.0
-      concordance: 5.0.4
-      currently-unhandled: 0.4.1
-      debug: 4.4.3
-      emittery: 1.2.1
-      figures: 6.1.0
-      globby: 16.1.1
-      ignore-by-default: 2.1.0
-      indent-string: 5.0.0
-      is-plain-object: 5.0.0
-      is-promise: 4.0.0
-      matcher: 6.0.0
-      memoize: 10.2.0
-      ms: 2.1.3
-      p-map: 7.0.4
-      package-config: 5.0.0
-      picomatch: 4.0.4
-      plur: 6.0.0
-      pretty-ms: 9.3.0
-      resolve-cwd: 3.0.0
-      stack-utils: 2.0.6
-      supertap: 3.0.1
-      temp-dir: 3.0.0
-      write-file-atomic: 7.0.1
-      yargs: 18.0.0
-    transitivePeerDependencies:
-      - encoding
-      - rollup
-      - supports-color
-
   balanced-match@1.0.2: {}
-
-  balanced-match@4.0.4: {}
 
   baseline-browser-mapping@2.10.12: {}
 
@@ -3211,20 +2489,10 @@ snapshots:
 
   binary-extensions@2.3.0: {}
 
-  bindings@1.5.0:
-    dependencies:
-      file-uri-to-path: 1.0.0
-
-  blueimp-md5@2.19.0: {}
-
   brace-expansion@1.1.13:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
-
-  brace-expansion@5.0.5:
-    dependencies:
-      balanced-match: 4.0.4
 
   braces@3.0.3:
     dependencies:
@@ -3238,26 +2506,9 @@ snapshots:
       node-releases: 2.0.36
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
 
-  caching-transform@4.0.0:
-    dependencies:
-      hasha: 5.2.2
-      make-dir: 3.1.0
-      package-hash: 4.0.0
-      write-file-atomic: 3.0.3
-
-  callsites@4.2.0: {}
-
-  camelcase@5.3.1: {}
-
   caniuse-lite@1.0.30001781: {}
 
-  cbor@10.0.11:
-    dependencies:
-      nofilter: 3.1.0
-
   chai@6.2.2: {}
-
-  chalk@5.6.2: {}
 
   chardet@2.1.1: {}
 
@@ -3273,44 +2524,13 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  chownr@3.0.0: {}
-
-  chunkd@2.0.1: {}
-
-  ci-info@4.4.0: {}
-
-  ci-parallel-vars@1.0.1: {}
-
-  clean-stack@2.2.0: {}
-
-  cli-truncate@5.2.0:
-    dependencies:
-      slice-ansi: 8.0.0
-      string-width: 8.2.0
-
   cli-width@4.1.0: {}
-
-  cliui@6.0.0:
-    dependencies:
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-      wrap-ansi: 6.2.0
 
   cliui@8.0.1:
     dependencies:
       string-width: 4.2.3
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
-
-  cliui@9.0.1:
-    dependencies:
-      string-width: 7.2.0
-      strip-ansi: 7.2.0
-      wrap-ansi: 9.0.2
-
-  code-excerpt@4.0.0:
-    dependencies:
-      convert-to-spaces: 2.0.1
 
   color-convert@2.0.1:
     dependencies:
@@ -3322,30 +2542,9 @@ snapshots:
 
   commander@5.1.0: {}
 
-  common-path-prefix@3.0.0: {}
-
-  commondir@1.0.1: {}
-
   concat-map@0.0.1: {}
 
-  concordance@5.0.4:
-    dependencies:
-      date-time: 3.1.0
-      esutils: 2.0.3
-      fast-diff: 1.3.0
-      js-string-escape: 1.0.1
-      lodash: 4.17.23
-      md5-hex: 3.0.1
-      semver: 7.7.4
-      well-known-symbols: 2.0.0
-
-  consola@3.4.2: {}
-
-  convert-source-map@1.9.0: {}
-
   convert-source-map@2.0.0: {}
-
-  convert-to-spaces@2.0.1: {}
 
   cookie@1.1.1: {}
 
@@ -3355,15 +2554,7 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
-  currently-unhandled@0.4.1:
-    dependencies:
-      array-find-index: 1.0.2
-
   dataloader@1.4.0: {}
-
-  date-time@3.1.0:
-    dependencies:
-      time-zone: 1.0.0
 
   debug@2.6.9:
     dependencies:
@@ -3373,13 +2564,7 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
-  decamelize@1.2.0: {}
-
   deepmerge@4.3.1: {}
-
-  default-require-extensions@3.0.1:
-    dependencies:
-      strip-bom: 4.0.0
 
   depd@2.0.0: {}
 
@@ -3417,10 +2602,6 @@ snapshots:
 
   electron-to-chromium@1.5.328: {}
 
-  emittery@1.2.1: {}
-
-  emoji-regex@10.6.0: {}
-
   emoji-regex@8.0.0: {}
 
   encodeurl@2.0.0: {}
@@ -3444,13 +2625,9 @@ snapshots:
 
   es-module-lexer@2.0.0: {}
 
-  es6-error@4.1.1: {}
-
   escalade@3.2.0: {}
 
   escape-html@1.0.3: {}
-
-  escape-string-regexp@2.0.0: {}
 
   escape-string-regexp@5.0.0: {}
 
@@ -3460,13 +2637,9 @@ snapshots:
 
   esprima@4.0.1: {}
 
-  estree-walker@2.0.2: {}
-
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.8
-
-  esutils@2.0.3: {}
 
   etag@1.8.1: {}
 
@@ -3481,8 +2654,6 @@ snapshots:
       is-extendable: 0.1.1
 
   extendable-error@0.1.7: {}
-
-  fast-diff@1.3.0: {}
 
   fast-glob@3.3.3:
     dependencies:
@@ -3499,12 +2670,6 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
-
-  figures@6.1.0:
-    dependencies:
-      is-unicode-supported: 2.1.0
-
-  file-uri-to-path@1.0.0: {}
 
   filesize@10.1.6: {}
 
@@ -3524,14 +2689,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  find-cache-dir@3.3.2:
-    dependencies:
-      commondir: 1.0.1
-      make-dir: 3.1.0
-      pkg-dir: 4.2.0
-
-  find-up-simple@1.0.1: {}
-
   find-up@4.1.0:
     dependencies:
       locate-path: 5.0.0
@@ -3539,19 +2696,7 @@ snapshots:
 
   flatted@3.4.2: {}
 
-  foreground-child@2.0.0:
-    dependencies:
-      cross-spawn: 7.0.6
-      signal-exit: 3.0.7
-
-  foreground-child@3.3.1:
-    dependencies:
-      cross-spawn: 7.0.6
-      signal-exit: 4.1.0
-
   fresh@2.0.0: {}
-
-  fromentries@1.3.2: {}
 
   fs-extra@7.0.1:
     dependencies:
@@ -3572,19 +2717,9 @@ snapshots:
 
   get-caller-file@2.0.5: {}
 
-  get-east-asian-width@1.5.0: {}
-
-  get-package-type@0.1.0: {}
-
   glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
-
-  glob@13.0.6:
-    dependencies:
-      minimatch: 10.2.4
-      minipass: 7.1.3
-      path-scurry: 2.0.2
 
   globby@11.1.0:
     dependencies:
@@ -3594,15 +2729,6 @@ snapshots:
       ignore: 5.3.2
       merge2: 1.4.1
       slash: 3.0.0
-
-  globby@16.1.1:
-    dependencies:
-      '@sindresorhus/merge-streams': 4.0.0
-      fast-glob: 3.3.3
-      ignore: 7.0.5
-      is-path-inside: 4.0.0
-      slash: 5.1.0
-      unicorn-magic: 0.4.0
 
   graceful-fs@4.2.11: {}
 
@@ -3616,11 +2742,6 @@ snapshots:
       strip-bom-string: 1.0.0
 
   has-flag@4.0.0: {}
-
-  hasha@5.2.2:
-    dependencies:
-      is-stream: 2.0.1
-      type-fest: 0.8.1
 
   headers-polyfill@4.0.3: {}
 
@@ -3643,34 +2764,15 @@ snapshots:
       statuses: 2.0.2
       toidentifier: 1.0.1
 
-  https-proxy-agent@7.0.6:
-    dependencies:
-      agent-base: 7.1.4
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
-
   human-id@4.1.3: {}
 
   iconv-lite@0.7.2:
     dependencies:
       safer-buffer: 2.1.2
 
-  ignore-by-default@2.1.0: {}
-
   ignore@5.3.2: {}
 
-  ignore@7.0.5: {}
-
-  imurmurhash@0.1.4: {}
-
-  indent-string@4.0.0: {}
-
-  indent-string@5.0.0: {}
-
   inherits@2.0.4: {}
-
-  irregular-plurals@4.2.0: {}
 
   is-alphabetical@2.0.1: {}
 
@@ -3691,10 +2793,6 @@ snapshots:
 
   is-fullwidth-code-point@3.0.0: {}
 
-  is-fullwidth-code-point@5.1.0:
-    dependencies:
-      get-east-asian-width: 1.5.0
-
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
@@ -3705,21 +2803,9 @@ snapshots:
 
   is-number@7.0.0: {}
 
-  is-path-inside@4.0.0: {}
-
-  is-plain-object@5.0.0: {}
-
-  is-promise@4.0.0: {}
-
-  is-stream@2.0.1: {}
-
   is-subdir@1.2.0:
     dependencies:
       better-path-resolve: 1.0.0
-
-  is-typedarray@1.0.0: {}
-
-  is-unicode-supported@2.1.0: {}
 
   is-windows@1.0.2: {}
 
@@ -3729,49 +2815,16 @@ snapshots:
 
   istanbul-lib-coverage@3.2.2: {}
 
-  istanbul-lib-hook@3.0.0:
-    dependencies:
-      append-transform: 2.0.0
-
-  istanbul-lib-instrument@6.0.3:
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/parser': 7.29.2
-      '@istanbuljs/schema': 0.1.3
-      istanbul-lib-coverage: 3.2.2
-      semver: 7.7.4
-    transitivePeerDependencies:
-      - supports-color
-
-  istanbul-lib-processinfo@3.0.0:
-    dependencies:
-      archy: 1.0.0
-      cross-spawn: 7.0.6
-      istanbul-lib-coverage: 3.2.2
-      p-map: 3.0.0
-      rimraf: 6.1.3
-      uuid: 8.3.2
-
   istanbul-lib-report@3.0.1:
     dependencies:
       istanbul-lib-coverage: 3.2.2
       make-dir: 4.0.0
       supports-color: 7.2.0
 
-  istanbul-lib-source-maps@4.0.1:
-    dependencies:
-      debug: 4.4.3
-      istanbul-lib-coverage: 3.2.2
-      source-map: 0.6.1
-    transitivePeerDependencies:
-      - supports-color
-
   istanbul-reports@3.2.0:
     dependencies:
       html-escaper: 2.0.2
       istanbul-lib-report: 3.0.1
-
-  js-string-escape@1.0.1: {}
 
   js-tokens@4.0.0: {}
 
@@ -3859,19 +2912,11 @@ snapshots:
 
   lite-youtube-embed@0.3.4: {}
 
-  load-json-file@7.0.1: {}
-
   locate-path@5.0.0:
     dependencies:
       p-locate: 4.1.0
 
-  lodash.flattendeep@4.4.0: {}
-
   lodash.startcase@4.4.0: {}
-
-  lodash@4.17.23: {}
-
-  lru-cache@11.2.7: {}
 
   lru-cache@5.1.1:
     dependencies:
@@ -3889,10 +2934,6 @@ snapshots:
       '@babel/types': 7.29.0
       source-map-js: 1.2.1
 
-  make-dir@3.1.0:
-    dependencies:
-      semver: 6.3.1
-
   make-dir@4.0.0:
     dependencies:
       semver: 7.7.4
@@ -3906,19 +2947,7 @@ snapshots:
       punycode.js: 2.3.1
       uc.micro: 2.1.0
 
-  matcher@6.0.0:
-    dependencies:
-      escape-string-regexp: 5.0.0
-
-  md5-hex@3.0.1:
-    dependencies:
-      blueimp-md5: 2.19.0
-
   mdurl@2.0.0: {}
-
-  memoize@10.2.0:
-    dependencies:
-      mimic-function: 5.0.1
 
   merge2@1.4.1: {}
 
@@ -3935,12 +2964,6 @@ snapshots:
 
   mime@3.0.0: {}
 
-  mimic-function@5.0.1: {}
-
-  minimatch@10.2.4:
-    dependencies:
-      brace-expansion: 5.0.5
-
   minimatch@3.1.5:
     dependencies:
       brace-expansion: 1.1.13
@@ -3948,10 +2971,6 @@ snapshots:
   minimist@1.2.8: {}
 
   minipass@7.1.3: {}
-
-  minizlib@3.1.0:
-    dependencies:
-      minipass: 7.1.3
 
   moo@0.5.2: {}
 
@@ -3994,12 +3013,6 @@ snapshots:
     dependencies:
       whatwg-url: 5.0.0
 
-  node-gyp-build@4.8.4: {}
-
-  node-preload@0.2.1:
-    dependencies:
-      process-on-spawn: 1.1.0
-
   node-releases@2.0.36: {}
 
   node-retrieve-globals@6.0.1:
@@ -4007,12 +3020,6 @@ snapshots:
       acorn: 8.16.0
       acorn-walk: 8.3.5
       esm-import-transformer: 3.0.5
-
-  nofilter@3.1.0: {}
-
-  nopt@8.1.0:
-    dependencies:
-      abbrev: 3.0.1
 
   normalize-path@3.0.0: {}
 
@@ -4023,38 +3030,6 @@ snapshots:
       commander: 5.1.0
     optionalDependencies:
       chokidar: 3.6.0
-
-  nyc@18.0.0:
-    dependencies:
-      '@istanbuljs/load-nyc-config': 1.1.0
-      '@istanbuljs/schema': 0.1.3
-      caching-transform: 4.0.0
-      convert-source-map: 1.9.0
-      decamelize: 1.2.0
-      find-cache-dir: 3.3.2
-      find-up: 4.1.0
-      foreground-child: 3.3.1
-      get-package-type: 0.1.0
-      glob: 13.0.6
-      istanbul-lib-coverage: 3.2.2
-      istanbul-lib-hook: 3.0.0
-      istanbul-lib-instrument: 6.0.3
-      istanbul-lib-processinfo: 3.0.0
-      istanbul-lib-report: 3.0.1
-      istanbul-lib-source-maps: 4.0.1
-      istanbul-reports: 3.2.0
-      make-dir: 3.1.0
-      node-preload: 0.2.1
-      p-map: 3.0.0
-      process-on-spawn: 1.1.0
-      resolve-from: 5.0.0
-      rimraf: 6.1.3
-      signal-exit: 3.0.7
-      spawn-wrap: 3.0.0
-      test-exclude: 8.0.0
-      yargs: 15.4.1
-    transitivePeerDependencies:
-      - supports-color
 
   obug@2.1.1: {}
 
@@ -4082,12 +3057,6 @@ snapshots:
 
   p-map@2.1.0: {}
 
-  p-map@3.0.0:
-    dependencies:
-      aggregate-error: 3.1.0
-
-  p-map@7.0.4: {}
-
   p-queue@6.6.2:
     dependencies:
       eventemitter3: 4.0.7
@@ -4099,25 +3068,9 @@ snapshots:
 
   p-try@2.2.0: {}
 
-  package-config@5.0.0:
-    dependencies:
-      find-up-simple: 1.0.1
-      load-json-file: 7.0.1
-
-  package-hash@4.0.0:
-    dependencies:
-      graceful-fs: 4.2.11
-      hasha: 5.2.2
-      lodash.flattendeep: 4.4.0
-      release-zalgo: 1.0.0
-
-  package-json-from-dist@1.0.1: {}
-
   package-manager-detector@0.2.11:
     dependencies:
       quansync: 0.2.11
-
-  parse-ms@4.0.0: {}
 
   parse-srcset@1.0.2: {}
 
@@ -4126,11 +3079,6 @@ snapshots:
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
-
-  path-scurry@2.0.2:
-    dependencies:
-      lru-cache: 11.2.7
-      minipass: 7.1.3
 
   path-to-regexp@6.3.0: {}
 
@@ -4146,17 +3094,9 @@ snapshots:
 
   pify@4.0.1: {}
 
-  pkg-dir@4.2.0:
-    dependencies:
-      find-up: 4.1.0
-
   please-upgrade-node@3.2.0:
     dependencies:
       semver-compare: 1.0.0
-
-  plur@6.0.0:
-    dependencies:
-      irregular-plurals: 4.2.0
 
   postcss@8.5.8:
     dependencies:
@@ -4182,14 +3122,6 @@ snapshots:
       posthtml-render: 3.0.0
 
   prettier@2.8.8: {}
-
-  pretty-ms@9.3.0:
-    dependencies:
-      parse-ms: 4.0.0
-
-  process-on-spawn@1.1.0:
-    dependencies:
-      fromentries: 1.3.2
 
   prr@1.0.1: {}
 
@@ -4218,28 +3150,13 @@ snapshots:
     dependencies:
       regex-utilities: 2.3.0
 
-  release-zalgo@1.0.0:
-    dependencies:
-      es6-error: 4.1.1
-
   require-directory@2.1.1: {}
-
-  require-main-filename@2.0.0: {}
-
-  resolve-cwd@3.0.0:
-    dependencies:
-      resolve-from: 5.0.0
 
   resolve-from@5.0.0: {}
 
   rettime@0.10.1: {}
 
   reusify@1.1.0: {}
-
-  rimraf@6.1.3:
-    dependencies:
-      glob: 13.0.6
-      package-json-from-dist: 1.0.1
 
   rolldown@1.0.0-rc.9(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1):
     dependencies:
@@ -4298,12 +3215,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  serialize-error@7.0.1:
-    dependencies:
-      type-fest: 0.13.1
-
-  set-blocking@2.0.0: {}
-
   setprototypeof@1.2.0: {}
 
   shebang-command@2.0.0:
@@ -4314,34 +3225,13 @@ snapshots:
 
   siginfo@2.0.0: {}
 
-  signal-exit@3.0.7: {}
-
   signal-exit@4.1.0: {}
 
   slash@3.0.0: {}
 
-  slash@5.1.0: {}
-
-  slice-ansi@8.0.0:
-    dependencies:
-      ansi-styles: 6.2.3
-      is-fullwidth-code-point: 5.1.0
-
   slugify@1.6.8: {}
 
   source-map-js@1.2.1: {}
-
-  source-map@0.6.1: {}
-
-  spawn-wrap@3.0.0:
-    dependencies:
-      cross-spawn: 7.0.6
-      foreground-child: 2.0.0
-      is-windows: 1.0.2
-      make-dir: 3.1.0
-      rimraf: 6.1.3
-      signal-exit: 3.0.7
-      which: 2.0.2
 
   spawndamnit@3.0.1:
     dependencies:
@@ -4353,10 +3243,6 @@ snapshots:
   ssri@11.0.0:
     dependencies:
       minipass: 7.1.3
-
-  stack-utils@2.0.6:
-    dependencies:
-      escape-string-regexp: 2.0.0
 
   stackback@0.0.2: {}
 
@@ -4374,37 +3260,13 @@ snapshots:
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
 
-  string-width@7.2.0:
-    dependencies:
-      emoji-regex: 10.6.0
-      get-east-asian-width: 1.5.0
-      strip-ansi: 7.2.0
-
-  string-width@8.2.0:
-    dependencies:
-      get-east-asian-width: 1.5.0
-      strip-ansi: 7.2.0
-
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
 
-  strip-ansi@7.2.0:
-    dependencies:
-      ansi-regex: 6.2.2
-
   strip-bom-string@1.0.0: {}
 
   strip-bom@3.0.0: {}
-
-  strip-bom@4.0.0: {}
-
-  supertap@3.0.1:
-    dependencies:
-      indent-string: 5.0.0
-      js-yaml: 3.14.2
-      serialize-error: 7.0.1
-      strip-ansi: 7.2.0
 
   supports-color@7.2.0:
     dependencies:
@@ -4412,25 +3274,7 @@ snapshots:
 
   tagged-tag@1.0.0: {}
 
-  tar@7.5.11:
-    dependencies:
-      '@isaacs/fs-minipass': 4.0.1
-      chownr: 3.0.0
-      minipass: 7.1.3
-      minizlib: 3.1.0
-      yallist: 5.0.0
-
-  temp-dir@3.0.0: {}
-
   term-size@2.2.1: {}
-
-  test-exclude@8.0.0:
-    dependencies:
-      '@istanbuljs/schema': 0.1.3
-      glob: 13.0.6
-      minimatch: 10.2.4
-
-  time-zone@1.0.0: {}
 
   tinybench@2.9.0: {}
 
@@ -4464,21 +3308,11 @@ snapshots:
   tslib@2.8.1:
     optional: true
 
-  type-fest@0.13.1: {}
-
-  type-fest@0.8.1: {}
-
   type-fest@5.5.0:
     dependencies:
       tagged-tag: 1.0.0
 
-  typedarray-to-buffer@3.1.5:
-    dependencies:
-      is-typedarray: 1.0.0
-
   uc.micro@2.1.0: {}
-
-  unicorn-magic@0.4.0: {}
 
   universalify@0.1.2: {}
 
@@ -4493,8 +3327,6 @@ snapshots:
       picocolors: 1.1.1
 
   urlpattern-polyfill@10.1.0: {}
-
-  uuid@8.3.2: {}
 
   vite@8.0.0(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1):
     dependencies:
@@ -4537,14 +3369,10 @@ snapshots:
 
   webidl-conversions@3.0.1: {}
 
-  well-known-symbols@2.0.0: {}
-
   whatwg-url@5.0.0:
     dependencies:
       tr46: 0.0.3
       webidl-conversions: 3.0.1
-
-  which-module@2.0.1: {}
 
   which@2.0.2:
     dependencies:
@@ -4567,55 +3395,13 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
 
-  wrap-ansi@9.0.2:
-    dependencies:
-      ansi-styles: 6.2.3
-      string-width: 7.2.0
-      strip-ansi: 7.2.0
-
-  write-file-atomic@3.0.3:
-    dependencies:
-      imurmurhash: 0.1.4
-      is-typedarray: 1.0.0
-      signal-exit: 3.0.7
-      typedarray-to-buffer: 3.1.5
-
-  write-file-atomic@7.0.1:
-    dependencies:
-      signal-exit: 4.1.0
-
   ws@8.19.0: {}
-
-  y18n@4.0.3: {}
 
   y18n@5.0.8: {}
 
   yallist@3.1.1: {}
 
-  yallist@5.0.0: {}
-
-  yargs-parser@18.1.3:
-    dependencies:
-      camelcase: 5.3.1
-      decamelize: 1.2.0
-
   yargs-parser@21.1.1: {}
-
-  yargs-parser@22.0.0: {}
-
-  yargs@15.4.1:
-    dependencies:
-      cliui: 6.0.0
-      decamelize: 1.2.0
-      find-up: 4.1.0
-      get-caller-file: 2.0.5
-      require-directory: 2.1.1
-      require-main-filename: 2.0.0
-      set-blocking: 2.0.0
-      string-width: 4.2.3
-      which-module: 2.0.1
-      y18n: 4.0.3
-      yargs-parser: 18.1.3
 
   yargs@17.7.2:
     dependencies:
@@ -4626,14 +3412,5 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
-
-  yargs@18.0.0:
-    dependencies:
-      cliui: 9.0.1
-      escalade: 3.2.0
-      get-caller-file: 2.0.5
-      string-width: 7.2.0
-      y18n: 5.0.8
-      yargs-parser: 22.0.0
 
   yoctocolors-cjs@2.1.3: {}


### PR DESCRIPTION
This is a large PR but it's doing something pretty straightforward, which is removing the AVA test runner and replacing it with the equivalent built-in Node.js utilities. There are no changes to the public API, and the tests themselves are unchanged, aside from the syntax updates.

Some older packages were using AVA, while newer ones use Vitest; I think the built-in Node.js tooling is now mature enough, and using it cuts down on dependencies.

I did an initial refactor by hand, and then had Claude (Haiku 4.5) use that as a pattern to do the syntax updates. There's a commit for each package, which makes validating the changes easier.

