### PR TITLE
Update pnpm/action-setup for Node.js v20 compatibility

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,12 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v6
       - name: Install pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@v6
+        # Standalone allows pnpm to be used with otherwise incompatible Node.js versions
+        # Required to support Node v20
+        # https://github.com/pnpm/action-setup#standalone
+        with:
+          standalone: true
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
@@ -39,7 +44,9 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v6
       - name: Install pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@v6
+        with:
+          standalone: true
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:


### PR DESCRIPTION
`pnpm/action-setup@6` was flunking CI (see #414) because it dropped support for Node 20, which we still need to support (it looks like Eleventy v4 will continue supporting Node v20 despite being EOL). The `standalone` option enables pnpm for older Node.js versions.